### PR TITLE
Phase C: within-sample top-fraction signal (build script + accessor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ cd.cohort_aggregate_members("SARC")       # pan-sarcoma grand union
 
 # Per-cohort expression percentiles (downloads the data bundle on first use):
 cd.available_percentile_cohorts()         # 118 cohorts with per-sample data
-cd.cohort_gene_percentiles("PRAD")        # per-gene p0…p100 vector for the cohort
+cd.cohort_gene_percentiles("PRAD")        # per-gene p0…p100 vector (within-cohort)
+cd.within_sample_top_fraction("PRAD")     # per-gene frac of samples where it's
+                                          # top-5% expressed (within-sample)
 ```
 
 ### Domains

--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -48,8 +48,10 @@ from .cancer_types import (
 from .expression import (
     available_percentile_cohorts,
     available_representative_cohorts,
+    available_within_sample_cohorts,
     cohort_gene_percentiles,
     representative_cohort_samples,
+    within_sample_top_fraction,
 )
 from .incidence import (
     burden_category,
@@ -67,6 +69,7 @@ __all__ = [
     "__version__",
     "available_percentile_cohorts",
     "available_representative_cohorts",
+    "available_within_sample_cohorts",
     "burden_category",
     # incidence / mortality
     "cancer_burden",
@@ -103,4 +106,5 @@ __all__ = [
     "sarcoma_lineage_codes",
     "tissue_of_origin",
     "viral_status",
+    "within_sample_top_fraction",
 ]

--- a/cancerdata/_build.py
+++ b/cancerdata/_build.py
@@ -1,0 +1,79 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure build-time transforms for precomputed expression artifacts.
+
+Kept dependency-light (pandas/numpy only) and separate from the read accessors so
+the heavy artifact builders in ``scripts/`` can be unit-tested without any data
+bundle. The maintainer runs the ``scripts/generate_*`` wrappers; this module is
+the testable core.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+_ID_COLS = ("Ensembl_Gene_ID", "Symbol")
+
+#: threshold (within-sample percentile rank) -> output column name.
+#: 0.95 = "in the top 5% of expressed genes in that sample".
+WITHIN_SAMPLE_THRESHOLDS = {
+    0.99: "frac_samples_top1pct",
+    0.95: "frac_samples_top5pct",
+    0.90: "frac_samples_top10pct",
+}
+
+
+def sample_columns(df: pd.DataFrame) -> list[str]:
+    """Per-sample value columns (everything that isn't a gene-id column)."""
+    return [c for c in df.columns if c not in _ID_COLS]
+
+
+def within_sample_top_fractions(
+    df: pd.DataFrame,
+    sample_cols: Iterable[str] | None = None,
+    *,
+    thresholds: Iterable[float] = tuple(WITHIN_SAMPLE_THRESHOLDS),
+) -> pd.DataFrame:
+    """Per-gene fraction of a cohort's samples in which the gene is highly
+    expressed *within that sample* (signal a).
+
+    For each sample (column), genes are ranked across the whole gene axis into a
+    within-sample percentile (``rank(pct=True)``). A gene clears threshold ``t``
+    in a sample when its within-sample percentile ≥ ``t``. The per-gene output is
+    the fraction of the cohort's samples where it clears ``t`` — i.e. "in what
+    fraction of these tumors is this gene among the top ``(1-t)`` of expressed
+    genes."
+
+    Returns one row per gene with ``Ensembl_Gene_ID``, ``Symbol``,
+    ``frac_samples_top{1,5,10}pct`` (per threshold), and ``n_samples``.
+    """
+    cols = list(sample_cols) if sample_cols is not None else sample_columns(df)
+    if not cols:
+        raise ValueError("no per-sample columns to rank")
+
+    # Rank genes WITHIN each sample (axis=0 = down the gene rows, per column).
+    ranks = df[cols].rank(axis=0, pct=True)
+
+    out = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": df["Ensembl_Gene_ID"].astype(str).to_numpy(),
+            "Symbol": df["Symbol"].astype(str).to_numpy(),
+        }
+    )
+    for t in thresholds:
+        pct = round((1.0 - t) * 100)
+        out[f"frac_samples_top{pct}pct"] = (ranks >= t).mean(axis=1).to_numpy()
+    out["n_samples"] = len(cols)
+    return out

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -40,18 +40,24 @@ from .load_dataset import _BUNDLED_DATA_DIR
 
 _REPRESENTATIVES_DIR = "cancer-reference-expression-representatives"
 _PERCENTILES_DIR = "cancer-reference-expression-percentiles"
+_WITHIN_SAMPLE_DIR = "cancer-reference-expression-within-sample-top5"
 
 
-def _bundle_subdir(name: str) -> Path:
+def _bundle_subdir(name: str, *, auto_fetch: bool = True) -> Path:
     """Locate a bundle shard directory: an in-repo checkout (``cancerdata/data/…``)
-    wins, else the downloaded bundle cache; the bundle is fetched if absent."""
+    wins, else the downloaded bundle cache; the bundle is fetched if absent.
+
+    ``auto_fetch=False`` skips the (potentially 340 MB) download — used for
+    artifacts not yet shipped in any released bundle, where a fetch couldn't
+    provide them anyway; the returned path simply won't exist."""
     in_repo = Path(_BUNDLED_DATA_DIR) / name
     if in_repo.exists():
         return in_repo
     cached = data_bundle.find(name)
     if cached is not None:
         return cached
-    data_bundle.ensure_local()
+    if auto_fetch:
+        data_bundle.ensure_local()
     return data_bundle.cache_dir() / name
 
 
@@ -215,3 +221,51 @@ def cohort_gene_percentiles(cancer_type, *, as_tpm: bool = True) -> pd.DataFrame
     if as_tpm:
         df[bp_cols] = np.expm1(df[bp_cols])
     return df
+
+
+# ---------- within-sample percentile prevalence (signal a) ----------
+
+#: within-sample percentile-rank threshold -> output column in the artifact.
+_WITHIN_SAMPLE_THRESHOLD_COLS = {
+    0.99: "frac_samples_top1pct",
+    0.95: "frac_samples_top5pct",
+    0.90: "frac_samples_top10pct",
+}
+
+
+def _within_sample_root() -> Path:
+    # Not (yet) part of a released bundle, so never trigger a 340 MB fetch.
+    return _bundle_subdir(_WITHIN_SAMPLE_DIR, auto_fetch=False)
+
+
+def available_within_sample_cohorts() -> list[str]:
+    """Cohort codes that ship a within-sample top-fraction shard (sorted)."""
+    return _available_shard_codes(_within_sample_root())
+
+
+def within_sample_top_fraction(cancer_type, *, threshold: float = 0.95) -> pd.DataFrame:
+    """Per-gene fraction of a cohort's samples in which the gene is highly
+    expressed *within that sample* — the "top ~5% expressed gene in this tumor"
+    prevalence (signal a, the producer side of the within-sample signal).
+
+    Returns one row per gene (``Ensembl_Gene_ID`` + ``Symbol``) with the
+    ``frac_samples_top{1,5,10}pct`` column for the requested ``threshold``
+    (0.99 / 0.95 / 0.90) plus ``n_samples``. Raises if the cohort has no
+    within-sample shard — that table is built offline from per-sample matrices
+    (see ``scripts/generate_within_sample_top5.py``) and shipped in the bundle.
+    """
+    col = _WITHIN_SAMPLE_THRESHOLD_COLS.get(threshold)
+    if col is None:
+        raise ValueError(f"threshold must be one of {sorted(_WITHIN_SAMPLE_THRESHOLD_COLS)}")
+    code = resolve_cancer_type(cancer_type)
+    shard = _within_sample_root() / f"{code}.parquet"
+    if not shard.exists():
+        raise ValueError(
+            f"no within-sample top-fraction vector for {code!r} — only cohorts "
+            f"with per-sample data ship one; see available_within_sample_cohorts()."
+        )
+    df = pd.read_parquet(shard)
+    keep = ["Ensembl_Gene_ID", "Symbol", col]
+    if "n_samples" in df.columns:
+        keep.append("n_samples")
+    return df[keep]

--- a/scripts/generate_within_sample_top5.py
+++ b/scripts/generate_within_sample_top5.py
@@ -1,0 +1,112 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build the per-gene × cohort *within-sample* top-fraction artifact (signal a).
+
+For each cohort with a per-sample expression matrix, compute — per gene — the
+fraction of that cohort's samples in which the gene ranks in the top 1/5/10% of
+expressed genes *within that sample*. Unlike ``cohort-reference-expression-
+percentiles`` (within-cohort, across samples), this is the within-sample,
+across-genes axis: "in what fraction of these tumors is this gene a top-expressed
+gene". It is NOT derivable from the percentile artifact and must be precomputed
+from the full per-sample matrices, which are never shipped.
+
+Input
+-----
+A directory of per-cohort parquet files, one per cohort code
+(``<INPUT>/<CODE>.parquet``), each with ``Ensembl_Gene_ID`` + ``Symbol`` columns
+and one column per sample (clean TPM, technical genes already handled upstream
+— or pass ``--drop-genes`` with a newline-delimited list of Ensembl IDs to drop
+so the top-fraction bar isn't dominated by mito/rRNA, mirroring the clean_tpm_v4
+basis the percentile artifact uses).
+
+Output
+------
+``cancerdata/data/cancer-reference-expression-within-sample-top5/<CODE>.parquet``
+with ``Ensembl_Gene_ID, Symbol, frac_samples_top1pct, frac_samples_top5pct,
+frac_samples_top10pct, n_samples``.
+
+Run:
+    python scripts/generate_within_sample_top5.py --input <per-sample-dir>
+
+After building, add ``cancer-reference-expression-within-sample-top5`` to
+``data_bundle.DOWNLOADABLE_PATHS``, rebuild + upload the data tarball, and bump
+``DATA_VERSION`` (never bump it before the tarball is uploaded — a 404 hangs
+fetch).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cancerdata._build import sample_columns, within_sample_top_fractions
+
+OUT_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "cancerdata"
+    / "data"
+    / "cancer-reference-expression-within-sample-top5"
+)
+
+
+def _load_drop_genes(path: Path | None) -> set[str]:
+    if path is None:
+        return set()
+    return {line.strip() for line in path.read_text().splitlines() if line.strip()}
+
+
+def build(input_dir: Path, *, drop_genes: set[str], out_dir: Path = OUT_DIR) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shards = sorted(input_dir.glob("*.parquet"))
+    if not shards:
+        raise SystemExit(f"no per-sample parquet files under {input_dir}")
+    n = 0
+    for shard in shards:
+        code = shard.stem
+        df = pd.read_parquet(shard)
+        if drop_genes:
+            df = df[~df["Ensembl_Gene_ID"].astype(str).isin(drop_genes)].reset_index(drop=True)
+        cols = sample_columns(df)
+        if not cols:
+            print(f"  {code}: no sample columns, skipped", flush=True)
+            continue
+        out = within_sample_top_fractions(df, cols)
+        out.to_parquet(out_dir / f"{code}.parquet", index=False, compression="zstd")
+        n += 1
+        print(f"  {code}: {len(out)} genes (n={len(cols)})", flush=True)
+    total_mb = sum(f.stat().st_size for f in out_dir.glob("*.parquet")) / 1e6
+    print(f"\ndone: {n} cohorts, {total_mb:.1f} MB -> {out_dir}", flush=True)
+
+
+def main(argv=None) -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--input", required=True, type=Path, help="Dir of per-cohort per-sample parquet files"
+    )
+    p.add_argument(
+        "--drop-genes",
+        type=Path,
+        default=None,
+        help="Optional newline-delimited Ensembl IDs of technical genes to drop",
+    )
+    args = p.parse_args(argv)
+    build(args.input, drop_genes=_load_drop_genes(args.drop_genes))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_within_sample.py
+++ b/tests/test_within_sample.py
@@ -1,0 +1,92 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from cancerdata import _build, expression
+
+
+def _matrix(genes, samples, values):
+    """genes × samples DataFrame with id columns."""
+    df = pd.DataFrame(values, columns=samples)
+    df.insert(0, "Symbol", [f"G{i}" for i in range(len(genes))])
+    df.insert(0, "Ensembl_Gene_ID", genes)
+    return df
+
+
+def test_within_sample_top_fractions_core():
+    # 4 genes, 2 samples. In both samples gene 3 (value 100) is the top gene.
+    genes = ["ENSG1", "ENSG2", "ENSG3", "ENSG4"]
+    vals = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [100.0, 100.0]])
+    df = _matrix(genes, ["s1", "s2"], vals)
+    out = _build.within_sample_top_fractions(df, thresholds=[0.95])
+    # gene 4 ranks top (pct=1.0 >= 0.95) in both samples -> 1.0
+    assert out.loc[out["Ensembl_Gene_ID"] == "ENSG4", "frac_samples_top5pct"].iloc[0] == 1.0
+    # gene 1 is lowest -> 0.0
+    assert out.loc[out["Ensembl_Gene_ID"] == "ENSG1", "frac_samples_top5pct"].iloc[0] == 0.0
+    assert out["n_samples"].iloc[0] == 2
+
+
+def test_within_sample_top_fractions_partial_prevalence():
+    # gene is top in 1 of 2 samples -> 0.5
+    genes = ["A", "B"]
+    # sample s1: B is top; sample s2: A is top
+    vals = np.array([[1.0, 100.0], [100.0, 1.0]])
+    df = _matrix(genes, ["s1", "s2"], vals)
+    out = _build.within_sample_top_fractions(df, thresholds=[0.95])
+    assert out["frac_samples_top5pct"].tolist() == [0.5, 0.5]
+
+
+def test_within_sample_top_fractions_requires_samples():
+    df = pd.DataFrame({"Ensembl_Gene_ID": ["A"], "Symbol": ["G0"]})
+    with pytest.raises(ValueError, match="no per-sample columns"):
+        _build.within_sample_top_fractions(df)
+
+
+@pytest.fixture
+def within_sample_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    shard_dir = tmp_path / "cancer-reference-expression-within-sample-top5"
+    shard_dir.mkdir(parents=True)
+    pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG1", "ENSG2"],
+            "Symbol": ["G1", "G2"],
+            "frac_samples_top1pct": [0.1, 0.9],
+            "frac_samples_top5pct": [0.3, 0.95],
+            "frac_samples_top10pct": [0.5, 1.0],
+            "n_samples": [40, 40],
+        }
+    ).to_parquet(shard_dir / "PRAD.parquet", index=False)
+    return tmp_path
+
+
+def test_available_within_sample_cohorts(within_sample_cache):
+    assert expression.available_within_sample_cohorts() == ["PRAD"]
+
+
+def test_within_sample_top_fraction_default_threshold(within_sample_cache):
+    df = expression.within_sample_top_fraction("PRAD")  # default 0.95 -> top5pct
+    assert "frac_samples_top5pct" in df.columns
+    assert df.loc[df["Symbol"] == "G2", "frac_samples_top5pct"].iloc[0] == 0.95
+
+
+def test_within_sample_top_fraction_alt_threshold(within_sample_cache):
+    df = expression.within_sample_top_fraction("prostate", threshold=0.90)
+    assert "frac_samples_top10pct" in df.columns
+
+
+def test_within_sample_bad_threshold(within_sample_cache):
+    with pytest.raises(ValueError, match="threshold must be one of"):
+        expression.within_sample_top_fraction("PRAD", threshold=0.5)
+
+
+def test_within_sample_missing_cohort_no_fetch(within_sample_cache):
+    # BRCA has no shard; must raise cleanly WITHOUT triggering a bundle download.
+    with pytest.raises(ValueError, match="no within-sample"):
+        expression.within_sample_top_fraction("BRCA")


### PR DESCRIPTION
**Stacked on #1 (Phase B)** — base is `phase-b-expression-bundle`; will retarget to `main` once Phase B merges.

Adds **signal (a)** — the within-sample, across-genes percentile prevalence ("top ~5% expressed gene in this tumor"). Orthogonal to Phase B's within-cohort `cohort_gene_percentiles`, and **not derivable** from it — must be precomputed from the full per-sample matrices (never shipped).

## What's added
- **`cancerdata/_build.py`** — pure, dependency-light core `within_sample_top_fractions`: rank genes *within each sample* (`rank(axis=0, pct=True)`), then per gene the mean of `(rank >= threshold)` across samples. Unit-tested.
- **`scripts/generate_within_sample_top5.py`** — maintainer build wrapper: per-cohort per-sample parquets in, optional `--drop-genes` technical mask, writes `cancer-reference-expression-within-sample-top5/<CODE>.parquet`.
- **`expression.py`** — `within_sample_top_fraction(cancer_type, threshold=0.95)` + `available_within_sample_cohorts()`, **no auto-fetch** for the not-yet-shipped artifact.

## Deliberate scope call
Did **not** add the artifact to `DOWNLOADABLE_PATHS` or bump `DATA_VERSION` — that breaks `fetch`/`is_local` until the table is actually built from per-sample data and uploaded in a new bundle (a maintainer step, documented in the script header). The read accessor works the moment the parquets are present locally.

## Verification
55 tests, ruff clean. Core transform + accessor tested on synthetic data (incl. no-fetch-on-missing). Build script smoke-tested end-to-end → correct prevalences. Imports neither tsarina nor pirlygenes.