### PR TITLE
aPD1 response data + cancer-type reference plots (tsarina-free)

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -17,6 +17,7 @@ Bottom-of-stack: depends only on pandas/numpy/pyarrow, never on the analysis
 or target-selection libraries that consume it.
 """
 
+from .apd1 import cancer_apd1_response, cancer_apd1_response_df
 from .cancer_types import (
     CANCER_TYPE_ALIASES,
     CANCER_TYPE_NAMES,
@@ -60,6 +61,9 @@ __all__ = [
     "CANCER_TYPE_NAMES",
     "__version__",
     "burden_category",
+    # anti-PD-1 response
+    "cancer_apd1_response",
+    "cancer_apd1_response_df",
     # incidence / mortality
     "cancer_burden",
     "cancer_burden_df",

--- a/cancerdata/apd1.py
+++ b/cancerdata/apd1.py
@@ -1,0 +1,59 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Anti-PD-1 monotherapy response (objective response rate) by cancer type."""
+
+from __future__ import annotations
+
+from .cancer_types import cancer_type_registry, resolve_cancer_type
+from .load_dataset import get_data
+
+
+def cancer_apd1_response_df():
+    """Return the curated ``cancer-apd1-response.csv`` reference: representative
+    objective response rate (ORR, %) to anti-PD-1 **monotherapy**
+    (pembrolizumab / nivolumab) per cancer-type code, with the drug, pivotal
+    trial, treatment setting, a published source PMID/DOI, and a confidence flag.
+
+    Intended as a per-cancer-type plotting axis (e.g. TMB vs aPD1 ORR, CTA burden
+    vs aPD1 ORR). Values are representative anchors, not exact reproducible
+    constants — they shift with data cutoff, line of therapy, and biomarker
+    selection (PD-L1 / MSI / MMR); the ``setting`` and ``notes`` columns record
+    that context."""
+    return get_data("cancer-apd1-response")
+
+
+def cancer_apd1_response(cancer_type=None, *, inherit=True):
+    """Anti-PD-1 monotherapy ORR (%) for one cancer type, or the whole
+    ``{code: orr_pct}`` map. ``cancer_type`` is resolved through
+    :func:`resolve_cancer_type`; with ``inherit`` (default) a code with no
+    curated row of its own inherits its nearest ancestor's value via the registry
+    ``parent_code`` chain. Returns ``None`` if neither the code nor any ancestor
+    has a value. Mirrors :func:`cancerdata.cancer_tmb`."""
+    df = cancer_apd1_response_df()
+    vals = df.dropna(subset=["apd1_orr_pct"])
+    mapping = dict(zip(vals["cancer_code"].astype(str), vals["apd1_orr_pct"].astype(float)))
+    if cancer_type is None:
+        return mapping
+    code = resolve_cancer_type(cancer_type)
+    if code in mapping or not inherit:
+        return mapping.get(code)
+    reg = cancer_type_registry().set_index("code")
+    cur, seen = code, set()
+    while cur and cur not in seen:
+        seen.add(cur)
+        if cur in mapping:
+            return mapping[cur]
+        if cur not in reg.index:
+            break
+        cur = str(reg.loc[cur].get("parent_code", "") or "").strip() or None
+    return None

--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -24,7 +24,7 @@ import argparse
 import json
 import sys
 
-from . import cancer_types, incidence, tmb
+from . import apd1, cancer_types, incidence, tmb
 from .cache import bundle_cache_dir
 from .version import __version__
 
@@ -66,6 +66,41 @@ def _cmd_tmb(args: argparse.Namespace) -> int:
         print(f"No TMB value for {args.code!r}", file=sys.stderr)
         return 1
     print(f"{value:g}")
+    return 0
+
+
+def _cmd_apd1(args: argparse.Namespace) -> int:
+    if args.code is None:
+        for code, value in sorted(apd1.cancer_apd1_response().items()):
+            print(f"{code}\t{value:g}")
+        return 0
+    try:
+        value = apd1.cancer_apd1_response(args.code, inherit=not args.no_inherit)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    if value is None:
+        print(f"No anti-PD-1 ORR for {args.code!r}", file=sys.stderr)
+        return 1
+    print(f"{value:g}")
+    return 0
+
+
+def _cmd_plot(args: argparse.Namespace) -> int:
+    from . import plots
+
+    fns = {
+        "apd1-vs-tmb": plots.apd1_vs_tmb,
+        "apd1-orr-bars": plots.apd1_orr_bars,
+        "incidence-vs-mortality": plots.incidence_vs_mortality,
+    }
+    try:
+        kwargs = {"region": args.region} if args.which == "incidence-vs-mortality" else {}
+        fns[args.which](save=args.out, **kwargs)
+    except (ValueError, ModuleNotFoundError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Wrote {args.out}")
     return 0
 
 
@@ -111,6 +146,27 @@ def _build_parser() -> argparse.ArgumentParser:
     p_tmb.add_argument("code", nargs="?", default=None, help="Cancer code/alias (omit for all)")
     p_tmb.add_argument("--no-inherit", action="store_true", help="Do not inherit an ancestor's TMB")
     p_tmb.set_defaults(func=_cmd_tmb)
+
+    p_apd1 = sub.add_parser(
+        "apd1", help="Anti-PD-1 monotherapy ORR (%) for a code, or the full map"
+    )
+    p_apd1.add_argument("code", nargs="?", default=None, help="Cancer code/alias (omit for all)")
+    p_apd1.add_argument(
+        "--no-inherit", action="store_true", help="Do not inherit an ancestor's ORR"
+    )
+    p_apd1.set_defaults(func=_cmd_apd1)
+
+    p_plot = sub.add_parser("plot", help="Render a cancer-type reference plot to a PNG")
+    p_plot.add_argument(
+        "which",
+        choices=["apd1-vs-tmb", "apd1-orr-bars", "incidence-vs-mortality"],
+        help="Which plot to render",
+    )
+    p_plot.add_argument("--out", required=True, help="Output PNG path")
+    p_plot.add_argument(
+        "--region", default="us", choices=["us", "world"], help="Region for incidence-vs-mortality"
+    )
+    p_plot.set_defaults(func=_cmd_plot)
 
     p_burden = sub.add_parser(
         "burden", help="Incidence/mortality share for a burden category, or the full map"

--- a/cancerdata/data/cancer-apd1-response.csv
+++ b/cancerdata/data/cancer-apd1-response.csv
@@ -1,0 +1,28 @@
+cancer_code,apd1_orr_pct,drug,trial,setting,pmid_doi,confidence,notes
+SKCM,42,nivolumab,CheckMate-067,first-line advanced; nivo monotherapy arm,PMID:28889792,high,Nivo mono ~42-45% (CheckMate-067); pembro KEYNOTE-006 primary 33-37% / longer-FU ~42% (PMID:25891173); aPD1 monotherapy ~40-45% in melanoma
+LUAD,45,pembrolizumab,KEYNOTE-024,first-line; PD-L1 TPS>=50% selected,PMID:27718847,high,PD-L1>=50% selected; all-comers/low-PD-L1 ~18% (KEYNOTE-042 PMID:30955977)
+LUSC,45,pembrolizumab,KEYNOTE-024,first-line; PD-L1 TPS>=50% selected,PMID:27718847,medium,NSCLC pooled in KN-024; squamous subset similar to adeno
+LUAD_STK11,10,pembrolizumab,KEYNOTE-042 subgroup,STK11/KEAP1-mutant immune-cold subset,PMID:30955977,low,Approximate; STK11/KEAP1-mutant LUAD is immune-cold with markedly lower aPD1 benefit (reported mainly as PFS/OS HRs)
+HNSC,19,pembrolizumab,KEYNOTE-048,first-line R/M; CPS>=1; monotherapy arm,PMID:33052747,high,CPS>=20 ~23%; total population ~17%; HPV+/HPV- differential not cleanly established in KN-048
+KIRC,25,nivolumab,CheckMate-025,pretreated (post-VEGF TKI); all-comers,PMID:26406148,high,vs everolimus 5%
+BLCA,28.6,pembrolizumab,KEYNOTE-052,first-line cisplatin-ineligible; all-comers,PMID:32552471,high,Mature KEYNOTE-052 final ORR 28.6% (Vuky 2020); CPS>=10 ~47%; 2017 interim was 24%; CheckMate-275 pretreated ~20%
+COAD,5,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; only the ~13% MSI-H/dMMR respond (MSI-H ~45%; MSS ~0%)
+READ,5,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; MSI-H ~45% and MSS ~0%
+STAD,12,pembrolizumab,KEYNOTE-059,third-line; all-comers,PMID:29260193,medium,CPS>=1 ~16%; monotherapy indication later withdrawn
+LIHC,17,nivolumab,CheckMate-040,sorafenib-naive & -experienced,PMID:28434648,medium,Reported 15-20% across dose-escalation/expansion
+ESCA,18,nivolumab,ATTRACTION-3,pretreated; esophageal SCC,PMID:31582355,medium,nivo ~19%; KEYNOTE-181 ESCC subgroup ~17%
+CESC,15,pembrolizumab,KEYNOTE-158,pretreated; PD-L1+ (CPS>=1) selected,PMID:30943124,high,All responders were PD-L1+; all-comer ~12%
+HL,71,nivolumab,CheckMate-205,relapsed/refractory post-ASCT,PMID:29584546,high,Very high responder; KEYNOTE-087 pembro ~69%
+NEC_MERKEL,56,pembrolizumab,KEYNOTE-017,first-line advanced; all-comers,PMID:30726175,high,Very high responder; CR ~24%
+BRCA_Basal,5,pembrolizumab,KEYNOTE-086,pretreated metastatic TNBC; all-comers,PMID:30475950,medium,Cohort A (pretreated) ~5%; PD-L1+ untreated cohort B ~21%
+UCEC,8,pembrolizumab,KEYNOTE-158,all-comers (response is MMR-dependent),PMID:34990208,medium,dMMR/MSI-H ~50% vs pMMR ~6% (KN-158); all-comer is a weighted blend
+SCLC,13,nivolumab,CheckMate-032,pretreated; all-comers,PMID:27269732,medium,~10-19%; nivo mono ~10%; KEYNOTE-028 PD-L1-selected was higher (~33%) but not representative
+MESO,10,pembrolizumab,KEYNOTE-158,pretreated; all-comers,PMID:33125908,low,Reported ~8-20% across studies
+NPC,25,pembrolizumab,KEYNOTE-028,pretreated; PD-L1+ selected,PMID:28837405,medium,KN-028 NPC cohort ~26%
+PRAD,4,pembrolizumab,KEYNOTE-199,pretreated mCRPC,PMID:31774688,high,Near-zero anchor; ~5% PD-L1+ / ~3% PD-L1-
+PAAD,1,pembrolizumab,pooled/basket,pretreated; MSS,,low,Near-zero anchor (~0-3%); no single clean monotherapy trial; rare dMMR/MSI-H PDAC responds (~37%) but is a tiny subset
+GBM,8,nivolumab,CheckMate-143,recurrent; all-comers,PMID:32437507,high,Near-zero anchor; vs bevacizumab 23%
+COAD_MSI,45,pembrolizumab,KEYNOTE-177,first-line; MSI-H/dMMR,PMID:33264544,high,MSI-H/dMMR colon; immune-hot; the canonical aPD1-responsive subtype
+COAD_MSS,0,pembrolizumab,KEYNOTE-016/-028,MSS,PMID:26028255,high,Microsatellite-stable colon; immune-cold; ~0% response
+READ_MSI,45,pembrolizumab,KEYNOTE-177,first-line; MSI-H/dMMR,PMID:33264544,medium,MSI-H/dMMR rectal; small subset; same biology as COAD_MSI
+READ_MSS,0,pembrolizumab,KEYNOTE-016,MSS,PMID:26028255,high,Microsatellite-stable rectal; immune-cold

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -1,0 +1,155 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cancer-type-level reference plots built from cancerdata's own data.
+
+These need only cancerdata-owned data (TMB, anti-PD-1 ORR, incidence/mortality,
+the cancer-type registry for lineage colors) — no CTA or peptide data — so they
+have no dependency on the target-selection libraries.
+
+matplotlib is an optional extra (``pip install cancerdata[plots]``); it is
+imported lazily so the data layer stays importable without it. Every function
+returns the matplotlib ``Figure`` and optionally writes a PNG when ``save`` is
+given.
+"""
+
+from __future__ import annotations
+
+from .apd1 import cancer_apd1_response
+from .cancer_types import cancer_type_registry, format_cancer_code_label
+from .incidence import _BURDEN_METRICS, cancer_burden
+from .tmb import cancer_tmb
+
+
+def _plt():
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg", force=False)  # headless-safe default; honor a set backend
+        import matplotlib.pyplot as plt
+
+        return plt
+    except ModuleNotFoundError as e:  # pragma: no cover - exercised via extras
+        raise ModuleNotFoundError(
+            "cancerdata plotting requires matplotlib — install with `pip install cancerdata[plots]`"
+        ) from e
+
+
+def _family_by_code() -> dict[str, str]:
+    reg = cancer_type_registry()
+    return dict(zip(reg["code"].astype(str), reg["family"].astype(str)))
+
+
+def _family_colors(codes):
+    """Map each code to an RGBA color by registry family (stable tab20 palette)."""
+    plt = _plt()
+    fam_by_code = _family_by_code()
+    families = sorted({fam_by_code.get(c, "?") for c in codes})
+    cmap = plt.get_cmap("tab20")
+    fam_color = {f: cmap(i % 20) for i, f in enumerate(families)}
+    return {c: fam_color[fam_by_code.get(c, "?")] for c in codes}, fam_color
+
+
+def _save(fig, save):
+    if save is not None:
+        fig.savefig(save, dpi=150, bbox_inches="tight")
+    return fig
+
+
+def apd1_vs_tmb(*, save=None, annotate=True):
+    """Scatter of anti-PD-1 ORR (%) vs median TMB (log x), one point per cancer
+    type with a curated value for both, colored by lineage family. The classic
+    "more mutations -> more neoantigens -> better checkpoint response" view."""
+    plt = _plt()
+    tmb = cancer_tmb()
+    orr = cancer_apd1_response()
+    codes = sorted(set(tmb) & set(orr))
+    if not codes:
+        raise ValueError("no cancer types with both a TMB and an anti-PD-1 value")
+    colors, fam_color = _family_colors(codes)
+
+    fig, ax = plt.subplots(figsize=(11, 7))
+    for c in codes:
+        ax.scatter(
+            tmb[c], orr[c], color=colors[c], s=70, edgecolor="white", linewidth=0.6, zorder=3
+        )
+        if annotate:
+            ax.annotate(
+                format_cancer_code_label(c),
+                (tmb[c], orr[c]),
+                fontsize=6,
+                xytext=(3, 3),
+                textcoords="offset points",
+            )
+    ax.set_xscale("log")
+    ax.set_xlabel("Median tumor mutational burden (mut/Mb, log scale)")
+    ax.set_ylabel("Anti-PD-1 monotherapy ORR (%)")
+    ax.set_title(f"Anti-PD-1 response vs TMB ({len(codes)} cancer types)")
+    ax.grid(True, which="both", alpha=0.3)
+    handles = [
+        plt.Line2D([], [], marker="o", linestyle="", color=col, label=fam)
+        for fam, col in sorted(fam_color.items())
+    ]
+    ax.legend(handles=handles, fontsize=6, ncol=2, loc="upper left", framealpha=0.9)
+    fig.tight_layout()
+    return _save(fig, save)
+
+
+def apd1_orr_bars(*, save=None):
+    """Horizontal bar chart of anti-PD-1 ORR by cancer type, sorted ascending,
+    colored by lineage family."""
+    plt = _plt()
+    orr = cancer_apd1_response()
+    codes = sorted(orr, key=lambda c: orr[c])
+    colors, _fam_color = _family_colors(codes)
+
+    fig, ax = plt.subplots(figsize=(9, max(4, 0.3 * len(codes))))
+    ax.barh(
+        [format_cancer_code_label(c) for c in codes],
+        [orr[c] for c in codes],
+        color=[colors[c] for c in codes],
+    )
+    ax.set_xlabel("Anti-PD-1 monotherapy ORR (%)")
+    ax.set_title(f"Anti-PD-1 response by cancer type ({len(codes)} types)")
+    ax.grid(True, axis="x", alpha=0.3)
+    ax.tick_params(axis="y", labelsize=7)
+    fig.tight_layout()
+    return _save(fig, save)
+
+
+def incidence_vs_mortality(*, region="us", save=None):
+    """Scatter of mortality-share vs incidence-share (%) per burden category for
+    a region (``"us"`` or ``"world"``). The diagonal separates high-lethality
+    (pancreas, lung) from low-lethality (thyroid, prostate) categories."""
+    plt = _plt()
+    if region not in ("us", "world"):
+        raise ValueError("region must be 'us' or 'world'")
+    inc_metric, mort_metric = f"{region}_incidence_pct", f"{region}_mortality_pct"
+    assert inc_metric in _BURDEN_METRICS and mort_metric in _BURDEN_METRICS
+    inc = cancer_burden(metric=inc_metric)
+    mort = cancer_burden(metric=mort_metric)
+    cats = sorted(set(inc) & set(mort))
+
+    fig, ax = plt.subplots(figsize=(9, 8))
+    lim = max(max(inc.values(), default=1), max(mort.values(), default=1)) * 1.1
+    ax.plot([0, lim], [0, lim], color="0.7", linestyle="--", linewidth=1, zorder=1)
+    for cat in cats:
+        ax.scatter(inc[cat], mort[cat], s=60, color="tab:red", alpha=0.8, zorder=3)
+        ax.annotate(
+            cat, (inc[cat], mort[cat]), fontsize=6, xytext=(3, 3), textcoords="offset points"
+        )
+    ax.set_xlabel(f"{region.upper()} share of cancer incidence (%)")
+    ax.set_ylabel(f"{region.upper()} share of cancer mortality (%)")
+    ax.set_title(f"Incidence vs mortality by burden category ({region.upper()})")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    return _save(fig, save)

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -26,22 +26,29 @@ from __future__ import annotations
 
 from .apd1 import cancer_apd1_response
 from .cancer_types import cancer_type_registry, format_cancer_code_label
-from .incidence import _BURDEN_METRICS, cancer_burden
+from .incidence import cancer_burden
 from .tmb import cancer_tmb
+
+_PLT = None
 
 
 def _plt():
+    """Lazy, one-time matplotlib import (headless-safe Agg default; honors a
+    backend the caller already set)."""
+    global _PLT
+    if _PLT is not None:
+        return _PLT
     try:
         import matplotlib
 
-        matplotlib.use("Agg", force=False)  # headless-safe default; honor a set backend
+        matplotlib.use("Agg", force=False)
         import matplotlib.pyplot as plt
-
-        return plt
     except ModuleNotFoundError as e:  # pragma: no cover - exercised via extras
         raise ModuleNotFoundError(
             "cancerdata plotting requires matplotlib — install with `pip install cancerdata[plots]`"
         ) from e
+    _PLT = plt
+    return _PLT
 
 
 def _family_by_code() -> dict[str, str]:
@@ -134,7 +141,6 @@ def incidence_vs_mortality(*, region="us", save=None):
     if region not in ("us", "world"):
         raise ValueError("region must be 'us' or 'world'")
     inc_metric, mort_metric = f"{region}_incidence_pct", f"{region}_mortality_pct"
-    assert inc_metric in _BURDEN_METRICS and mort_metric in _BURDEN_METRICS
     inc = cancer_burden(metric=inc_metric)
     mort = cancer_burden(metric=mort_metric)
     cats = sorted(set(inc) & set(mort))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+plots = [
+    "matplotlib",
+]
 dev = [
     "pytest",
     "pytest-cov",
     "ruff",
+    "matplotlib",
 ]
 
 [project.scripts]

--- a/tests/test_apd1.py
+++ b/tests/test_apd1.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from cancerdata import apd1
+
+
+def test_apd1_map_nonempty_floats():
+    mapping = apd1.cancer_apd1_response()
+    assert mapping
+    assert all(isinstance(v, float) for v in mapping.values())
+
+
+def test_apd1_resolves_alias():
+    # melanoma (SKCM) is the canonical high-responder.
+    assert apd1.cancer_apd1_response("melanoma") == apd1.cancer_apd1_response("SKCM")
+    assert apd1.cancer_apd1_response("SKCM") > 0
+
+
+def test_apd1_inherits_from_parent():
+    mapping = apd1.cancer_apd1_response()
+    reg = apd1.cancer_type_registry()
+    reg = reg[reg["parent_code"].notna()]
+    found = False
+    for _, row in reg.iterrows():
+        code, parent = str(row["code"]), str(row["parent_code"])
+        if code not in mapping and parent in mapping:
+            assert apd1.cancer_apd1_response(code) == mapping[parent]
+            assert apd1.cancer_apd1_response(code, inherit=False) is None
+            found = True
+            break
+    assert found, "expected at least one subtype that inherits its parent's ORR"

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import pytest
+
+pytest.importorskip("matplotlib")
+
+from cancerdata import cli, plots
+
+
+def test_apd1_vs_tmb_renders(tmp_path):
+    out = tmp_path / "apd1_vs_tmb.png"
+    fig = plots.apd1_vs_tmb(save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+    assert fig is not None
+
+
+def test_apd1_orr_bars_renders(tmp_path):
+    out = tmp_path / "bars.png"
+    plots.apd1_orr_bars(save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_incidence_vs_mortality_renders(tmp_path):
+    out = tmp_path / "inc.png"
+    plots.incidence_vs_mortality(region="world", save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_incidence_bad_region():
+    with pytest.raises(ValueError, match="region must be"):
+        plots.incidence_vs_mortality(region="moon")
+
+
+def test_cli_plot(tmp_path):
+    out = tmp_path / "cli.png"
+    assert cli.main(["plot", "apd1-vs-tmb", "--out", str(out)]) == 0
+    assert out.exists()


### PR DESCRIPTION
**Stacked on #3 (data parity).** First step toward the goal of cancerdata generating pirlygenes' cancer-type plots — the subset that needs **only cancerdata-owned data** (no CTA/peptide data), so it's fully standalone.

## Added
- **`apd1.py`** — owns `cancer-apd1-response.csv` (anti-PD-1 monotherapy ORR per cancer type, 27 codes) + `cancer_apd1_response(_df)` with the same registry parent-chain inheritance as `cancer_tmb`. Tsarina-free. CLI: `cancerdata apd1 [CODE]`.
- **`plots.py`** — optional `[plots]` extra (matplotlib, lazy-imported so the data layer stays light). Three plots, each from cancerdata data alone:
  - `apd1_vs_tmb` — the classic "more mutations → better checkpoint response" scatter, colored by lineage
  - `apd1_orr_bars` — ORR by cancer type
  - `incidence_vs_mortality` — mortality vs incidence share by burden category (us/world)
  - CLI: `cancerdata plot <which> --out fig.png [--region us|world]`

## Verification
46 tests, ruff clean. Rendered all three PNGs from real data (screenshots shared with the maintainer).

## Not here (needs a decision)
The CTA-dependent plots — addressable burden, CTA-specific 9mers/type, CTA expression heatmaps — depend on **CTA membership**, curated in tsarina. Whether cancerdata should own CTA definitions (and therefore HPA tissue-expression data) is the next design question; flagged separately. No pirlygenes/tsarina edits in this PR.