### PR TITLE
HPA data manager: RNA consensus + IHC + single-cell sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ cd.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
 - **Cancer-testis antigens** — `CTA_gene_names`/`CTA_gene_ids`, `CTA_evidence`,
   `synthesize_restriction` (HPA-only tissue-restriction; MS evidence stays in the
   target-selection layer).
+- **HPA normal tissue** — `hpa_rna_consensus`, `hpa_normal_tissue` (IHC),
+  `hpa_single_cell`, and per-gene lookups (`gene_tissue_ntpm`,
+  `gene_protein_tissues`, `gene_cell_type_ntpm`) over HPA v23, fetched on demand
+  (`cancerdata sources fetch`).
 - **Plots** (`pip install cancerdata[plots]`) — `cancerdata.plots.apd1_vs_tmb`,
   `apd1_orr_bars`, `incidence_vs_mortality`.
 

--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -67,6 +67,14 @@ from .expression import (
     representative_cohort_samples,
     within_sample_top_fraction,
 )
+from .hpa import (
+    gene_cell_type_ntpm,
+    gene_protein_tissues,
+    gene_tissue_ntpm,
+    hpa_normal_tissue,
+    hpa_rna_consensus,
+    hpa_single_cell,
+)
 from .incidence import (
     burden_category,
     cancer_burden,
@@ -127,6 +135,13 @@ __all__ = [
     "family_display_name",
     "format_cancer_code_label",
     "fusion_status",
+    "gene_cell_type_ntpm",
+    "gene_protein_tissues",
+    "gene_tissue_ntpm",
+    "hpa_normal_tissue",
+    # HPA normal-tissue reference data
+    "hpa_rna_consensus",
+    "hpa_single_cell",
     "is_mixture_cohort",
     "known_cohort_ids",
     "mixture_cohort_codes",

--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -23,7 +23,7 @@ import argparse
 import json
 import sys
 
-from . import apd1, cancer_types, cta, data_bundle, incidence, tmb
+from . import apd1, cancer_types, cta, data_bundle, incidence, reference_data, tmb
 from .version import __version__
 
 
@@ -162,6 +162,44 @@ def _cmd_plot(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_sources(args: argparse.Namespace) -> int:
+    if args.action == "list" or args.action == "status":
+        rows = reference_data.status()
+        print(f"{'Source':<20} {'Cached':<8} {'Version':<10} {'Size':>9}  Description")
+        print("-" * 92)
+        for r in rows:
+            cached = "yes" if r["cached"] else "no"
+            ver = r["cached_version"] or f"({r['default_version']})"
+            print(
+                f"{r['name']:<20} {cached:<8} {ver:<10} {_fmt_bytes(r['bytes']):>9}  {r['description']}"
+            )
+        print(f"\nCache directory: {reference_data.cache_dir()}")
+        return 0
+    if args.action == "fetch":
+        names = [args.name] if args.name else list(reference_data.REFERENCE_SOURCES)
+        failures = []
+        for name in names:
+            try:
+                path = reference_data.download(name, force=args.force)
+            except reference_data.ReferenceDataError as e:
+                print(f"Error: {name}: {e}", file=sys.stderr)
+                failures.append(name)
+                continue
+            print(f"Ready: {name} -> {path}")
+        return 1 if failures else 0
+    if args.action == "path":
+        if not args.name:
+            print("Error: 'sources path' requires a source name", file=sys.stderr)
+            return 1
+        try:
+            print(reference_data.ensure(args.name))
+        except reference_data.ReferenceDataError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        return 0
+    return 1
+
+
 def _cmd_burden(args: argparse.Namespace) -> int:
     try:
         if args.category is None:
@@ -262,6 +300,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Which share to report (default: us_incidence_pct)",
     )
     p_burden.set_defaults(func=_cmd_burden)
+
+    p_sources = sub.add_parser(
+        "sources", help="Manage HPA normal-tissue reference sources (RNA / IHC / single-cell)"
+    )
+    p_sources.add_argument(
+        "action",
+        choices=["list", "status", "fetch", "path"],
+        help="list/status (show cache state), fetch (download), path (print local path)",
+    )
+    p_sources.add_argument("name", nargs="?", default=None, help="Source name (omit to fetch all)")
+    p_sources.add_argument("--force", action="store_true", help="Re-download even if cached")
+    p_sources.set_defaults(func=_cmd_sources)
 
     return parser
 

--- a/cancerdata/hpa.py
+++ b/cancerdata/hpa.py
@@ -1,0 +1,84 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loaders over the Human Protein Atlas normal-tissue reference data.
+
+These fetch (once, cached) and parse the HPA tables registered in
+:mod:`cancerdata.reference_data`:
+
+- ``hpa_rna_consensus`` — per-tissue RNA nTPM (``Gene``, ``Gene name``,
+  ``Tissue``, ``nTPM``).
+- ``hpa_normal_tissue`` — IHC protein detection (``Gene``, ``Gene name``,
+  ``Tissue``, ``Cell type``, ``Level``, ``Reliability``).
+- ``hpa_single_cell`` — single-cell-type RNA nTPM (``Gene``, ``Gene name``,
+  ``Cell type``, ``nTPM``).
+
+This is the normal-tissue expression evidence behind the cancer-testis-antigen
+tissue-restriction definition and protein-level / single-cell comparisons.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import pandas as pd
+
+from . import reference_data
+
+
+@lru_cache(maxsize=1)
+def hpa_rna_consensus() -> pd.DataFrame:
+    """HPA RNA consensus per-tissue nTPM (downloads HPA v23 on first use)."""
+    return pd.read_csv(reference_data.ensure("hpa_rna_consensus"), sep="\t")
+
+
+@lru_cache(maxsize=1)
+def hpa_normal_tissue() -> pd.DataFrame:
+    """HPA IHC protein detection per tissue/cell type (downloads on first use)."""
+    return pd.read_csv(reference_data.ensure("hpa_normal_tissue"), sep="\t")
+
+
+@lru_cache(maxsize=1)
+def hpa_single_cell() -> pd.DataFrame:
+    """HPA single-cell-type RNA nTPM (downloads on first use)."""
+    return pd.read_csv(reference_data.ensure("hpa_single_cell"), sep="\t")
+
+
+def _strip_version(gene_id: str) -> str:
+    return str(gene_id).split(".")[0]
+
+
+def gene_tissue_ntpm(gene_id: str) -> dict[str, float]:
+    """``{tissue (lowercased): nTPM}`` of normal RNA expression for one gene
+    (unversioned Ensembl ID)."""
+    gid = _strip_version(gene_id)
+    df = hpa_rna_consensus()
+    sub = df[df["Gene"].astype(str).map(_strip_version) == gid]
+    return {str(t).strip().lower(): float(v) for t, v in zip(sub["Tissue"], sub["nTPM"])}
+
+
+def gene_cell_type_ntpm(gene_id: str) -> dict[str, float]:
+    """``{cell_type (lowercased): nTPM}`` of single-cell RNA for one gene."""
+    gid = _strip_version(gene_id)
+    df = hpa_single_cell()
+    sub = df[df["Gene"].astype(str).map(_strip_version) == gid]
+    return {str(t).strip().lower(): float(v) for t, v in zip(sub["Cell type"], sub["nTPM"])}
+
+
+def gene_protein_tissues(gene_id: str, *, levels=("Low", "Medium", "High")) -> set[str]:
+    """Tissues (lowercased) where the gene has detected IHC protein at one of
+    ``levels`` (default Low/Medium/High)."""
+    gid = _strip_version(gene_id)
+    df = hpa_normal_tissue()
+    sub = df[df["Gene"].astype(str).map(_strip_version) == gid]
+    sub = sub[sub["Level"].astype(str).isin(levels)]
+    return {str(t).strip().lower() for t in sub["Tissue"]}

--- a/cancerdata/reference_data.py
+++ b/cancerdata/reference_data.py
@@ -1,0 +1,220 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Versioned reference-data sources fetched on demand (Human Protein Atlas).
+
+These are per-file downloads (each a ``.zip`` that extracts to one ``.tsv``),
+distinct from the heavy per-cohort expression bundle (:mod:`cancerdata.data_bundle`,
+a single tarball). They back the CTA tissue-restriction definition and the
+protein-level / single-cell normal-tissue comparisons.
+
+Pinned to HPA ``v23`` — the most recent release whose mirror serves RNA consensus
+AND IHC ``normal_tissue`` as a matched pair (newer mirrors drop ``normal_tissue``).
+
+Cache layout (one subdir per source+version):
+
+    <cache>/sources/<name>/<version>/<filename>
+
+The cache root is ``~/.cache/cancerdata/sources`` (override with
+``CANCERDATA_DATA_DIR``). A ``manifest.json`` records URL / size / sha256 /
+download time for provenance.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import shutil
+import sys
+import urllib.request
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: Default HPA release (matched RNA + IHC pair).
+DEFAULT_HPA_VERSION = "v23"
+
+#: Registry of reference sources. ``urls`` maps a version label to a download
+#: URL; ``.zip`` URLs are transparently extracted to ``filename``.
+REFERENCE_SOURCES: dict[str, dict] = {
+    "hpa_rna_consensus": {
+        "description": "HPA RNA consensus tissue nTPM (per-tissue normal expression)",
+        "filename": "rna_tissue_consensus.tsv",
+        "urls": {
+            "v23": "https://v23.proteinatlas.org/download/rna_tissue_consensus.tsv.zip",
+            "latest": "https://www.proteinatlas.org/download/tsv/rna_tissue_consensus.tsv.zip",
+        },
+    },
+    "hpa_normal_tissue": {
+        "description": "HPA IHC protein expression (normal_tissue, per tissue/cell type)",
+        "filename": "normal_tissue.tsv",
+        "urls": {
+            "v23": "https://v23.proteinatlas.org/download/normal_tissue.tsv.zip",
+        },
+    },
+    "hpa_single_cell": {
+        "description": "HPA single-cell type RNA nTPM (per cell-type normal expression)",
+        "filename": "rna_single_cell_type.tsv",
+        "urls": {
+            "v23": "https://v23.proteinatlas.org/download/rna_single_cell_type.tsv.zip",
+            "latest": "https://www.proteinatlas.org/download/tsv/rna_single_cell_type.tsv.zip",
+        },
+    },
+}
+
+#: Env var overriding the reference-data cache root.
+CACHE_DIR_ENV_KEY = "CANCERDATA_DATA_DIR"
+
+
+class ReferenceDataError(RuntimeError):
+    """Raised for unknown sources/versions or download failures."""
+
+
+def cache_dir() -> Path:
+    """Reference-data cache directory (``<root>/sources``), created on demand."""
+    override = os.environ.get(CACHE_DIR_ENV_KEY)
+    base = Path(override).expanduser() if override else Path.home() / ".cache" / "cancerdata"
+    sources = base / "sources"
+    sources.mkdir(parents=True, exist_ok=True)
+    return sources
+
+
+def _source(name: str) -> dict:
+    try:
+        return REFERENCE_SOURCES[name]
+    except KeyError:
+        avail = ", ".join(sorted(REFERENCE_SOURCES))
+        raise ReferenceDataError(f"unknown reference source {name!r}; available: {avail}") from None
+
+
+def resolve_version(name: str, version: str | None = None) -> str:
+    """Concrete version for *name* (defaults to the pinned HPA release)."""
+    spec = _source(name)
+    if version is None:
+        version = DEFAULT_HPA_VERSION
+    if version not in spec["urls"]:
+        avail = ", ".join(sorted(spec["urls"]))
+        raise ReferenceDataError(f"{name!r} has no version {version!r}; available: {avail}")
+    return version
+
+
+def local_path(name: str, version: str | None = None) -> Path:
+    """Expected cache path for *name*/*version* (may not exist yet)."""
+    version = resolve_version(name, version)
+    spec = _source(name)
+    return cache_dir() / name / version / spec["filename"]
+
+
+def is_cached(name: str, version: str | None = None) -> bool:
+    return local_path(name, version).exists()
+
+
+def _manifest_path() -> Path:
+    return cache_dir() / "manifest.json"
+
+
+def _read_manifest() -> dict:
+    path = _manifest_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _write_manifest(manifest: dict) -> None:
+    # provenance manifest is best-effort
+    with contextlib.suppress(OSError):
+        _manifest_path().write_text(json.dumps(manifest, indent=2, sort_keys=True))
+
+
+def download(name: str, version: str | None = None, *, force: bool = False) -> Path:
+    """Download *name*/*version* into the cache (extracting the ``.zip``) and
+    record it in the manifest. A cached copy is reused unless ``force=True``."""
+    version = resolve_version(name, version)
+    spec = _source(name)
+    dest = local_path(name, version)
+    url = spec["urls"][version]
+
+    if dest.exists() and not force:
+        return dest
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp_zip = dest.parent / (spec["filename"] + ".zip.part")
+    try:
+        sys.stderr.write(f"cancerdata: downloading {name} ({url})\n")
+        sys.stderr.flush()
+        with urllib.request.urlopen(url) as resp, tmp_zip.open("wb") as h:
+            shutil.copyfileobj(resp, h, length=1024 * 1024)
+        with zipfile.ZipFile(tmp_zip) as zf:
+            member = _zip_member(zf, spec["filename"])
+            with zf.open(member) as src, dest.open("wb") as out:
+                shutil.copyfileobj(src, out, length=1024 * 1024)
+    except Exception as e:  # network / zip / IO — surface uniformly
+        dest.unlink(missing_ok=True)
+        raise ReferenceDataError(f"failed to download {name} ({url}): {e}") from e
+    finally:
+        tmp_zip.unlink(missing_ok=True)
+
+    manifest = _read_manifest()
+    manifest[name] = {
+        "version": version,
+        "url": url,
+        "path": str(dest),
+        "bytes": dest.stat().st_size,
+        "sha256": hashlib.sha256(dest.read_bytes()).hexdigest(),
+        "downloaded_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    _write_manifest(manifest)
+    return dest
+
+
+def _zip_member(zf: zipfile.ZipFile, preferred: str) -> str:
+    """Pick the .tsv member to extract (preferred name, else the first .tsv)."""
+    names = zf.namelist()
+    if preferred in names:
+        return preferred
+    tsvs = [n for n in names if n.endswith(".tsv")]
+    if not tsvs:
+        raise ReferenceDataError(f"no .tsv found in archive (members: {names})")
+    return tsvs[0]
+
+
+def ensure(name: str, version: str | None = None) -> Path:
+    """Return a local path to *name*/*version*, downloading if absent."""
+    path = local_path(name, version)
+    return path if path.exists() else download(name, version)
+
+
+def status() -> list[dict]:
+    """One row per source: cached?, version, size, description."""
+    manifest = _read_manifest()
+    rows = []
+    for name, spec in REFERENCE_SOURCES.items():
+        path = local_path(name)
+        record = manifest.get(name) or {}
+        rows.append(
+            {
+                "name": name,
+                "cached": path.exists(),
+                "default_version": DEFAULT_HPA_VERSION,
+                "available_versions": sorted(spec["urls"]),
+                "cached_version": record.get("version"),
+                "bytes": path.stat().st_size if path.exists() else 0,
+                "path": str(path),
+                "description": spec["description"],
+            }
+        )
+    return rows

--- a/tests/test_hpa.py
+++ b/tests/test_hpa.py
@@ -1,0 +1,92 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import pytest
+
+from cancerdata import hpa
+
+
+def _seed(cache_root, name, version, filename, text):
+    path = cache_root / "sources" / name / version / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+@pytest.fixture
+def hpa_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    # clear lru_caches so each test sees its own fixture
+    for fn in (hpa.hpa_rna_consensus, hpa.hpa_normal_tissue, hpa.hpa_single_cell):
+        fn.cache_clear()
+    _seed(
+        tmp_path,
+        "hpa_rna_consensus",
+        "v23",
+        "rna_tissue_consensus.tsv",
+        "Gene\tGene name\tTissue\tnTPM\n"
+        "ENSG00000001\tG1\ttestis\t120.0\n"
+        "ENSG00000001\tG1\tliver\t0.2\n"
+        "ENSG00000002\tG2\tliver\t50.0\n",
+    )
+    _seed(
+        tmp_path,
+        "hpa_normal_tissue",
+        "v23",
+        "normal_tissue.tsv",
+        "Gene\tGene name\tTissue\tCell type\tLevel\tReliability\n"
+        "ENSG00000001\tG1\ttestis\tgerm cells\tHigh\tEnhanced\n"
+        "ENSG00000001\tG1\tliver\thepatocytes\tNot detected\tEnhanced\n",
+    )
+    _seed(
+        tmp_path,
+        "hpa_single_cell",
+        "v23",
+        "rna_single_cell_type.tsv",
+        "Gene\tGene name\tCell type\tnTPM\n"
+        "ENSG00000001\tG1\tspermatocytes\t300.0\n"
+        "ENSG00000001\tG1\thepatocytes\t0.0\n",
+    )
+    yield tmp_path
+    for fn in (hpa.hpa_rna_consensus, hpa.hpa_normal_tissue, hpa.hpa_single_cell):
+        fn.cache_clear()
+
+
+def test_rna_consensus_loads(hpa_cache):
+    df = hpa.hpa_rna_consensus()
+    assert set(df.columns) == {"Gene", "Gene name", "Tissue", "nTPM"}
+    assert len(df) == 3
+
+
+def test_gene_tissue_ntpm(hpa_cache):
+    expr = hpa.gene_tissue_ntpm("ENSG00000001.5")  # versioned id tolerated
+    assert expr == {"testis": 120.0, "liver": 0.2}
+
+
+def test_gene_cell_type_ntpm(hpa_cache):
+    sc = hpa.gene_cell_type_ntpm("ENSG00000001")
+    assert sc["spermatocytes"] == 300.0
+
+
+def test_gene_protein_tissues_detected_only(hpa_cache):
+    # "Not detected" liver row is excluded; testis High is kept.
+    assert hpa.gene_protein_tissues("ENSG00000001") == {"testis"}
+
+
+def test_cli_sources_list(hpa_cache, capsys):
+    from cancerdata import cli
+
+    assert cli.main(["sources", "list"]) == 0
+    out = capsys.readouterr().out
+    assert "hpa_rna_consensus" in out and "hpa_single_cell" in out
+
+
+def test_cli_sources_path_uses_cache(hpa_cache, capsys):
+    from cancerdata import cli
+
+    # already seeded -> ensure() returns the path without a network fetch
+    assert cli.main(["sources", "path", "hpa_rna_consensus"]) == 0
+    assert "rna_tissue_consensus.tsv" in capsys.readouterr().out

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -1,0 +1,49 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import pytest
+
+from cancerdata import reference_data
+
+
+def test_cache_dir_honors_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    assert reference_data.cache_dir() == tmp_path / "sources"
+    assert reference_data.cache_dir().exists()
+
+
+def test_resolve_version_default_and_errors():
+    assert reference_data.resolve_version("hpa_rna_consensus") == "v23"
+    assert reference_data.resolve_version("hpa_rna_consensus", "latest") == "latest"
+    with pytest.raises(reference_data.ReferenceDataError):
+        reference_data.resolve_version("hpa_normal_tissue", "v99")
+    with pytest.raises(reference_data.ReferenceDataError):
+        reference_data.resolve_version("not_a_source")
+
+
+def test_local_path_and_is_cached(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    p = reference_data.local_path("hpa_rna_consensus")
+    assert p == tmp_path / "sources" / "hpa_rna_consensus" / "v23" / "rna_tissue_consensus.tsv"
+    assert not reference_data.is_cached("hpa_rna_consensus")
+    p.parent.mkdir(parents=True)
+    p.write_text("Gene\tTissue\tnTPM\n")
+    assert reference_data.is_cached("hpa_rna_consensus")
+
+
+def test_status_shape(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    rows = reference_data.status()
+    names = {r["name"] for r in rows}
+    assert names == {"hpa_rna_consensus", "hpa_normal_tissue", "hpa_single_cell"}
+    assert all(r["cached"] is False for r in rows)  # nothing downloaded
+
+
+def test_single_cell_registered():
+    # The single-cell nTPM source is part of the registry.
+    spec = reference_data.REFERENCE_SOURCES["hpa_single_cell"]
+    assert spec["filename"] == "rna_single_cell_type.tsv"
+    assert "v23" in spec["urls"]


### PR DESCRIPTION
Adds the **on-demand HPA normal-tissue reference layer** — the data manager the project needs for the cancer-testis-antigen definition and protein-level / single-cell comparisons. First PR after v1.0.0.

## What's added
- **`reference_data.py`** — versioned source registry pinned to HPA **v23**:
  - `hpa_rna_consensus` (per-tissue RNA nTPM), `hpa_normal_tissue` (IHC protein), `hpa_single_cell` (per-cell-type RNA nTPM)
  - `urllib`+`zipfile` fetch (no new dependency), per-source cache under `~/.cache/cancerdata/sources` (`CANCERDATA_DATA_DIR` override), provenance `manifest.json` (url/size/sha256/time).
- **`hpa.py`** — cached loaders + per-gene lookups: `gene_tissue_ntpm`, `gene_cell_type_ntpm`, `gene_protein_tissues`.
- **CLI** — `cancerdata sources list | status | fetch [name] | path <name>`: the data-manager surface for these sources.

## Verification
- **Live HPA v23 fetch validated**: `hpa_rna_consensus` downloads (1,000,036 rows) and parses; MAGEA4 reads testis 21.5 nTPM / placenta 4.7 / everything somatic < 1 — the textbook CTA restriction pattern.
- **Hermetic tests** (11 new) seed a synthetic cache — no network in CI. 87 tests total, ruff clean.
- Still imports neither tsarina nor pirlygenes.

## Next
Use these sources to **regenerate the CTA table from HPA** (replace the v1.0.0 seed; recompute `restriction`/`restriction_confidence` from live HPA), and to build the protein/single-cell comparison plots.