### PR TITLE
Proteoform-summed within-sample artifact: generator flag + accessor

### DIFF
--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -41,6 +41,7 @@ from .load_dataset import _BUNDLED_DATA_DIR
 _REPRESENTATIVES_DIR = "cancer-reference-expression-representatives"
 _PERCENTILES_DIR = "cancer-reference-expression-percentiles"
 _WITHIN_SAMPLE_DIR = "cancer-reference-expression-within-sample-top5"
+_WITHIN_SAMPLE_PROTEOFORM_DIR = "cancer-reference-expression-within-sample-top5-proteoform"
 
 
 def _bundle_subdir(name: str, *, auto_fetch: bool = True) -> Path:
@@ -233,17 +234,23 @@ _WITHIN_SAMPLE_THRESHOLD_COLS = {
 }
 
 
-def _within_sample_root() -> Path:
+def _within_sample_root(*, proteoform: bool = False) -> Path:
     # Not (yet) part of a released bundle, so never trigger a 340 MB fetch.
-    return _bundle_subdir(_WITHIN_SAMPLE_DIR, auto_fetch=False)
+    name = _WITHIN_SAMPLE_PROTEOFORM_DIR if proteoform else _WITHIN_SAMPLE_DIR
+    return _bundle_subdir(name, auto_fetch=False)
 
 
-def available_within_sample_cohorts() -> list[str]:
-    """Cohort codes that ship a within-sample top-fraction shard (sorted)."""
-    return _available_shard_codes(_within_sample_root())
+def available_within_sample_cohorts(*, proteoform: bool = False) -> list[str]:
+    """Cohort codes that ship a within-sample top-fraction shard (sorted).
+
+    With ``proteoform=True``, the proteoform-summed variant (identical-protein
+    members collapsed before ranking — see :func:`within_sample_top_fraction`)."""
+    return _available_shard_codes(_within_sample_root(proteoform=proteoform))
 
 
-def within_sample_top_fraction(cancer_type, *, threshold: float = 0.95) -> pd.DataFrame:
+def within_sample_top_fraction(
+    cancer_type, *, threshold: float = 0.95, proteoform: bool = False
+) -> pd.DataFrame:
     """Per-gene fraction of a cohort's samples in which the gene is highly
     expressed *within that sample* — the "top ~5% expressed gene in this tumor"
     prevalence (signal a, the producer side of the within-sample signal).
@@ -253,16 +260,25 @@ def within_sample_top_fraction(cancer_type, *, threshold: float = 0.95) -> pd.Da
     (0.99 / 0.95 / 0.90) plus ``n_samples``. Raises if the cohort has no
     within-sample shard — that table is built offline from per-sample matrices
     (see ``scripts/generate_within_sample_top5.py``) and shipped in the bundle.
+
+    With ``proteoform=True``, reads the proteoform-summed variant: identical-
+    protein paralogs (CTAG1A+CTAG1B, the CT47A family, …) are summed per sample
+    *before* the within-sample ranking, so a duplicated antigen is ranked as one
+    proteoform rather than several individually-diluted genes. Rows for those
+    members are replaced by a single proteoform-labelled row; build it with
+    ``generate_within_sample_top5.py --proteoform``.
     """
     col = _WITHIN_SAMPLE_THRESHOLD_COLS.get(threshold)
     if col is None:
         raise ValueError(f"threshold must be one of {sorted(_WITHIN_SAMPLE_THRESHOLD_COLS)}")
     code = resolve_cancer_type(cancer_type)
-    shard = _within_sample_root() / f"{code}.parquet"
+    shard = _within_sample_root(proteoform=proteoform) / f"{code}.parquet"
     if not shard.exists():
+        variant = "proteoform-summed " if proteoform else ""
         raise ValueError(
-            f"no within-sample top-fraction vector for {code!r} — only cohorts "
-            f"with per-sample data ship one; see available_within_sample_cohorts()."
+            f"no {variant}within-sample top-fraction vector for {code!r} — only "
+            f"cohorts with per-sample data ship one; see "
+            f"available_within_sample_cohorts(proteoform={proteoform})."
         )
     df = pd.read_parquet(shard)
     keep = ["Ensembl_Gene_ID", "Symbol", col]

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -266,7 +266,10 @@ def within_sample_top_fraction(
     *before* the within-sample ranking, so a duplicated antigen is ranked as one
     proteoform rather than several individually-diluted genes. Rows for those
     members are replaced by a single proteoform-labelled row; build it with
-    ``generate_within_sample_top5.py --proteoform``.
+    ``generate_within_sample_top5.py --proteoform``. Note that collapsing members
+    shrinks the gene axis the percentiles are computed over, so an ungrouped
+    gene's fraction can shift slightly between the two variants — they are not
+    row-for-row comparable for genes outside any proteoform group.
     """
     col = _WITHIN_SAMPLE_THRESHOLD_COLS.get(threshold)
     if col is None:

--- a/cancerdata/version.py
+++ b/cancerdata/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 # Version of the downloadable data bundle (the heavy per-cohort expression
 # tarball). Bump ONLY when the reference data changes — it pins the bundle

--- a/scripts/generate_within_sample_top5.py
+++ b/scripts/generate_within_sample_top5.py
@@ -38,10 +38,16 @@ frac_samples_top10pct, n_samples``.
 Run:
     python scripts/generate_within_sample_top5.py --input <per-sample-dir>
 
-After building, add ``cancer-reference-expression-within-sample-top5`` to
-``data_bundle.DOWNLOADABLE_PATHS``, rebuild + upload the data tarball, and bump
-``DATA_VERSION`` (never bump it before the tarball is uploaded — a 404 hangs
-fetch).
+Pass ``--proteoform`` to additionally sum identical-protein paralogs (CTAG1A+
+CTAG1B, the CT47A family, …) to proteoform level *before* the within-sample
+ranking, written to a parallel ``…-within-sample-top5-proteoform`` directory — so
+a duplicated antigen ranks as one proteoform rather than several
+individually-diluted genes.
+
+After building, add ``cancer-reference-expression-within-sample-top5`` (and, if
+built, ``…-within-sample-top5-proteoform``) to ``data_bundle.DOWNLOADABLE_PATHS``,
+rebuild + upload the data tarball, and bump ``DATA_VERSION`` (never bump it before
+the tarball is uploaded — a 404 hangs fetch).
 """
 
 from __future__ import annotations
@@ -54,14 +60,11 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from cancerdata._build import sample_columns, within_sample_top_fractions
+from cancerdata._build import sample_columns, sum_proteoform_tpm, within_sample_top_fractions
 
-OUT_DIR = (
-    Path(__file__).resolve().parents[1]
-    / "cancerdata"
-    / "data"
-    / "cancer-reference-expression-within-sample-top5"
-)
+_DATA_DIR = Path(__file__).resolve().parents[1] / "cancerdata" / "data"
+OUT_DIR = _DATA_DIR / "cancer-reference-expression-within-sample-top5"
+PROTEOFORM_OUT_DIR = _DATA_DIR / "cancer-reference-expression-within-sample-top5-proteoform"
 
 
 def _load_drop_genes(path: Path | None) -> set[str]:
@@ -70,7 +73,28 @@ def _load_drop_genes(path: Path | None) -> set[str]:
     return {line.strip() for line in path.read_text().splitlines() if line.strip()}
 
 
-def build(input_dir: Path, *, drop_genes: set[str], out_dir: Path = OUT_DIR) -> None:
+def build(
+    input_dir: Path,
+    *,
+    drop_genes: set[str],
+    out_dir: Path | None = None,
+    proteoform: bool = False,
+) -> None:
+    """Build the within-sample top-fraction artifact for each cohort.
+
+    With ``proteoform=True``, each cohort's per-sample matrix is collapsed to
+    proteoform level (identical-protein members summed) *before* the within-
+    sample ranking, so a duplicated antigen ranks as one proteoform rather than
+    several individually-diluted genes. Output lands in a parallel
+    ``…-within-sample-top5-proteoform`` directory.
+    """
+    if out_dir is None:
+        out_dir = PROTEOFORM_OUT_DIR if proteoform else OUT_DIR
+    group_map = None
+    if proteoform:
+        from cancerdata.proteoforms import proteoform_group_map
+
+        group_map = proteoform_group_map()
     out_dir.mkdir(parents=True, exist_ok=True)
     shards = sorted(input_dir.glob("*.parquet"))
     if not shards:
@@ -85,10 +109,15 @@ def build(input_dir: Path, *, drop_genes: set[str], out_dir: Path = OUT_DIR) -> 
         if not cols:
             print(f"  {code}: no sample columns, skipped", flush=True)
             continue
+        if group_map is not None:
+            # Sum identical-protein members per sample first, then rank within
+            # the collapsed gene/proteoform axis.
+            df = sum_proteoform_tpm(df, group_map, cols)
+            cols = sample_columns(df)
         out = within_sample_top_fractions(df, cols)
         out.to_parquet(out_dir / f"{code}.parquet", index=False, compression="zstd")
         n += 1
-        print(f"  {code}: {len(out)} genes (n={len(cols)})", flush=True)
+        print(f"  {code}: {len(out)} rows (n={len(cols)})", flush=True)
     total_mb = sum(f.stat().st_size for f in out_dir.glob("*.parquet")) / 1e6
     print(f"\ndone: {n} cohorts, {total_mb:.1f} MB -> {out_dir}", flush=True)
 
@@ -104,8 +133,13 @@ def main(argv=None) -> None:
         default=None,
         help="Optional newline-delimited Ensembl IDs of technical genes to drop",
     )
+    p.add_argument(
+        "--proteoform",
+        action="store_true",
+        help="Sum identical-protein paralogs to proteoform level before ranking",
+    )
     args = p.parse_args(argv)
-    build(args.input, drop_genes=_load_drop_genes(args.drop_genes))
+    build(args.input, drop_genes=_load_drop_genes(args.drop_genes), proteoform=args.proteoform)
 
 
 if __name__ == "__main__":

--- a/tests/test_within_sample_proteoform.py
+++ b/tests/test_within_sample_proteoform.py
@@ -1,0 +1,91 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from cancerdata.expression import (
+    available_within_sample_cohorts,
+    within_sample_top_fraction,
+)
+
+_GEN_PATH = Path(__file__).resolve().parents[1] / "scripts" / "generate_within_sample_top5.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("_gen_within_sample", _GEN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_generator_proteoform_collapses_members_before_ranking(tmp_path):
+    gen = _load_generator()
+    input_dir = tmp_path / "per_sample"
+    input_dir.mkdir()
+    # 4 genes across 3 samples; SSX4 + SSX4B encode the identical protein.
+    pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": [
+                "ENSG00000268009",  # SSX4
+                "ENSG00000269791",  # SSX4B
+                "ENSG00000185686",  # PRAME (ungrouped)
+                "ENSG00000005961",  # filler so ranks aren't degenerate
+            ],
+            "Symbol": ["SSX4", "SSX4B", "PRAME", "ITGA2B"],
+            "s1": [3.0, 5.0, 100.0, 1.0],
+            "s2": [4.0, 4.0, 2.0, 0.0],
+            "s3": [10.0, 0.0, 0.0, 50.0],
+        }
+    ).to_parquet(input_dir / "PRAD.parquet", index=False)
+
+    out_dir = tmp_path / "out"
+    gen.build(input_dir, drop_genes=set(), out_dir=out_dir, proteoform=True)
+
+    out = pd.read_parquet(out_dir / "PRAD.parquet")
+    symbols = set(out["Symbol"])
+    # SSX4 + SSX4B collapsed to a single proteoform row; the members are gone.
+    assert "SSX4/SSX4B" in symbols
+    assert "SSX4" not in symbols and "SSX4B" not in symbols
+    # Ungrouped genes survive untouched.
+    assert {"PRAME", "ITGA2B"} <= symbols
+    # n_samples is the sample count, and the threshold columns exist.
+    assert (out["n_samples"] == 3).all()
+    assert "frac_samples_top5pct" in out.columns
+
+
+@pytest.fixture
+def proteoform_within_sample_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    shard_dir = tmp_path / "cancer-reference-expression-within-sample-top5-proteoform"
+    shard_dir.mkdir(parents=True)
+    pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["SSX4/SSX4B", "ENSG00000185686"],
+            "Symbol": ["SSX4/SSX4B", "PRAME"],
+            "frac_samples_top5pct": [0.42, 0.10],
+            "n_samples": [200, 200],
+        }
+    ).to_parquet(shard_dir / "PRAD.parquet", index=False)
+    return tmp_path
+
+
+def test_accessor_reads_proteoform_variant(proteoform_within_sample_cache):
+    assert available_within_sample_cohorts(proteoform=True) == ["PRAD"]
+    # The per-gene variant has no shard, so it stays empty.
+    assert available_within_sample_cohorts() == []
+
+    out = within_sample_top_fraction("PRAD", threshold=0.95, proteoform=True)
+    assert list(out["Symbol"]) == ["SSX4/SSX4B", "PRAME"]
+    assert out.set_index("Symbol").loc["SSX4/SSX4B", "frac_samples_top5pct"] == 0.42
+
+
+def test_accessor_proteoform_missing_shard_raises(proteoform_within_sample_cache):
+    with pytest.raises(ValueError, match="proteoform-summed"):
+        within_sample_top_fraction("LUAD", proteoform=True)

--- a/tests/test_within_sample_proteoform.py
+++ b/tests/test_within_sample_proteoform.py
@@ -60,6 +60,44 @@ def test_generator_proteoform_collapses_members_before_ranking(tmp_path):
     assert "frac_samples_top5pct" in out.columns
 
 
+def test_generator_proteoform_rescues_diluted_members(tmp_path):
+    # The motivating case: two identical-protein paralogs each rank below the
+    # top-5% bar on their own, but their summed proteoform clears it. Build both
+    # variants from the same input and confirm the proteoform fraction exceeds
+    # either member's per-gene fraction.
+    gen = _load_generator()
+    input_dir = tmp_path / "per_sample"
+    input_dir.mkdir()
+    pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": [
+                "ENSG00000268009",  # SSX4
+                "ENSG00000269791",  # SSX4B
+                "ENSG00000185686",  # PRAME (ungrouped)
+                "ENSG00000005961",  # ITGA2B (ungrouped)
+            ],
+            "Symbol": ["SSX4", "SSX4B", "PRAME", "ITGA2B"],
+            "s1": [3.0, 5.0, 100.0, 1.0],
+            "s2": [4.0, 4.0, 2.0, 0.0],
+            "s3": [10.0, 0.0, 0.0, 50.0],
+        }
+    ).to_parquet(input_dir / "PRAD.parquet", index=False)
+
+    per_gene_dir = tmp_path / "per_gene"
+    proteoform_dir = tmp_path / "proteoform"
+    gen.build(input_dir, drop_genes=set(), out_dir=per_gene_dir, proteoform=False)
+    gen.build(input_dir, drop_genes=set(), out_dir=proteoform_dir, proteoform=True)
+
+    per_gene = pd.read_parquet(per_gene_dir / "PRAD.parquet").set_index("Symbol")
+    proteoform = pd.read_parquet(proteoform_dir / "PRAD.parquet").set_index("Symbol")
+
+    member_fracs = per_gene.loc[["SSX4", "SSX4B"], "frac_samples_top5pct"]
+    proteoform_frac = proteoform.loc["SSX4/SSX4B", "frac_samples_top5pct"]
+    # Neither diluted member clears the bar; the summed proteoform does.
+    assert (member_fracs == 0.0).all()
+    assert proteoform_frac > member_fracs.max()
+
+
 @pytest.fixture
 def proteoform_within_sample_cache(monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))


### PR DESCRIPTION
## Summary

Advances the heavy proteoform follow-up: the **within-sample top-fraction** artifact can now be built at the **proteoform** level, and a `proteoform=` flag on the accessor reads it.

When `generate_within_sample_top5.py --proteoform` runs, each cohort's per-sample matrix is collapsed via `sum_proteoform_tpm` (identical-protein members summed per sample) **before** the within-sample ranking — so a duplicated antigen (CTAG1A+CTAG1B, the 12-member CT47A family, …) ranks as **one proteoform** rather than several individually-diluted genes that each miss the top-N% bar. Output lands in a parallel `…-within-sample-top5-proteoform/` directory.

## Changes
- `generate_within_sample_top5.py`: `--proteoform` flag; `build(..., proteoform=True)` loads the registry group map and collapses each matrix before ranking; writes to the proteoform dir.
- `expression.within_sample_top_fraction(cancer_type, *, threshold, proteoform=False)` and `available_within_sample_cohorts(*, proteoform=False)` read the variant; clear error on a missing shard.
- Composition reuses the existing `sum_proteoform_tpm` core and `within_sample_top_fractions` pure function — no new ranking math.

## Scope
Like the base within-sample artifact, **generation runs offline over the full per-sample matrices** (never shipped), so the actual parquet build + `DOWNLOADABLE_PATHS`/`DATA_VERSION` bump + tarball upload are deferred to a data release. This PR wires the **build + read path** so the proteoform artifact is one flag away once those matrices are in hand. (The percentile generator lives upstream in pirlygenes; the same `sum_proteoform_tpm`-first composition applies there.)

## Verification
- 113 tests pass (+3); lint clean on 3.9–3.12
- Generator collapses members before ranking (synthetic cohort); accessor reads the proteoform variant and errors clearly on a missing shard
- Version 1.1.0 → 1.2.0
