### PR TITLE
Host cancerdata's own data tarball with pirlygenes fallback (#14)

### DIFF
--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -74,6 +74,8 @@ def _cmd_status(args: argparse.Namespace) -> int:
     print(f"Data version: {snap['data_version']}")
     print(f"Cache dir:    {snap['cache_dir']}")
     print(f"Release URL:  {snap['release_url']}")
+    for fallback in snap.get("release_urls", [])[1:]:
+        print(f"  fallback:   {fallback}")
     print(f"All local:    {'yes' if snap['all_local'] else 'no'}")
     print("-" * 60)
     for name, item in snap["items"].items():

--- a/cancerdata/data_bundle.py
+++ b/cancerdata/data_bundle.py
@@ -19,16 +19,19 @@ GitHub Release.
 
 Cache layout (version-pinned so upgrades trigger a re-fetch):
 
-  ~/.cache/pirlygenes/bundled_data/v<DATA_VERSION>/
+  ~/.cache/cancerdata/bundled_data/v<DATA_VERSION>/
     cancer-reference-expression/...
     cancer-reference-expression-percentiles/...
     pan-cancer-expression.csv
     hpa-cell-type-expression.csv
 
-The historical ``~/.cache/pirlygenes`` root and ``PIRLYGENES_BUNDLED_DATA`` env
-var are preserved (this data used to be fetched by pirlygenes) so existing caches
-are reused as-is; ``CANCERDATA_BUNDLED_DATA`` takes precedence when set. The
-bundle is still hosted on the pirlygenes releases until its ownership migrates.
+cancerdata now owns the bundle: new downloads land under ``~/.cache/cancerdata``
+and prefer the ``pirl-unc/cancerdata`` release. To avoid a forced re-download
+during the migration, an already-populated legacy ``~/.cache/pirlygenes`` cache
+for the current version is reused as-is, and the fetch falls back to the
+``pirl-unc/pirlygenes`` release if cancerdata hasn't published this version's
+tarball yet. The ``PIRLYGENES_BUNDLED_DATA`` env var is still honored;
+``CANCERDATA_BUNDLED_DATA`` takes precedence when set.
 
 Public API:
   cache_dir()      → version-pinned cache Path
@@ -47,23 +50,41 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import urllib.error
 import urllib.request
 from pathlib import Path
 
 from .version import DATA_VERSION
 
-# The bundle is hosted on the pirlygenes releases for now (the data historically
-# lived there); ownership migrates to a cancerdata release in a later milestone.
-GITHUB_REPO = "pirl-unc/pirlygenes"
-TARBALL_FILENAME = f"pirlygenes-data-v{DATA_VERSION}.tar.gz"
-RELEASE_URL = (
-    f"https://github.com/{GITHUB_REPO}/releases/download/v{DATA_VERSION}/{TARBALL_FILENAME}"
-)
+
+def _release_url(repo: str, filename: str) -> str:
+    return f"https://github.com/{repo}/releases/download/v{DATA_VERSION}/{filename}"
+
+
+# cancerdata owns the bundle: its own release is tried first. The historical
+# pirlygenes release is kept as a fallback for one migration release so a version
+# whose cancerdata tarball isn't uploaded yet still fetches (a 404 from the
+# primary falls through to the fallback rather than hanging the user).
+GITHUB_REPO = "pirl-unc/cancerdata"
+TARBALL_FILENAME = f"cancerdata-data-v{DATA_VERSION}.tar.gz"
+RELEASE_URL = _release_url(GITHUB_REPO, TARBALL_FILENAME)
+
+FALLBACK_GITHUB_REPO = "pirl-unc/pirlygenes"
+FALLBACK_TARBALL_FILENAME = f"pirlygenes-data-v{DATA_VERSION}.tar.gz"
+FALLBACK_RELEASE_URL = _release_url(FALLBACK_GITHUB_REPO, FALLBACK_TARBALL_FILENAME)
+
+#: Release URLs tried in order until one downloads.
+RELEASE_URLS: tuple[str, ...] = (RELEASE_URL, FALLBACK_RELEASE_URL)
 
 #: Env var that overrides the cache (points at the version-pinned dir).
 CACHE_DIR_ENV_VAR = "CANCERDATA_BUNDLED_DATA"
 #: Back-compat env var honored when this package's own override is unset.
 LEGACY_CACHE_DIR_ENV_VAR = "PIRLYGENES_BUNDLED_DATA"
+
+#: Default cache parents. New downloads go under the cancerdata root; an existing
+#: pirlygenes cache for the current version is reused to avoid a re-download.
+_DEFAULT_CACHE_PARENT = Path.home() / ".cache" / "cancerdata" / "bundled_data"
+_LEGACY_CACHE_PARENT = Path.home() / ".cache" / "pirlygenes" / "bundled_data"
 
 # Names that live in the downloadable tarball (relative to the cache root) and
 # are NOT bundled in the wheel. load_dataset checks here after the wheel data dir.
@@ -81,12 +102,23 @@ def _cache_override() -> str | None:
 
 
 def cache_root() -> Path:
-    """Parent of all version-pinned cache dirs (``v<version>/`` lives inside)."""
+    """Parent of all version-pinned cache dirs (``v<version>/`` lives inside).
+
+    Defaults to the cancerdata cache root, but if *this* version was already
+    downloaded under the legacy pirlygenes root (and not yet under the new one),
+    that legacy root is returned so the migration doesn't force a re-download.
+    """
     override = _cache_override()
     if override:
         # Override points at the version-pinned dir; its parent is the root.
         return Path(override).expanduser().parent
-    return Path.home() / ".cache" / "pirlygenes" / "bundled_data"
+    version_dir = f"v{DATA_VERSION}"
+    if (
+        not (_DEFAULT_CACHE_PARENT / version_dir).exists()
+        and (_LEGACY_CACHE_PARENT / version_dir).exists()
+    ):
+        return _LEGACY_CACHE_PARENT
+    return _DEFAULT_CACHE_PARENT
 
 
 def cache_dir() -> Path:
@@ -109,26 +141,13 @@ def find(relative_path: str) -> Path | None:
     return candidate if candidate.exists() else None
 
 
-def fetch(*, verbose: bool = True) -> Path:
-    """Download + extract the bundle for this version into the cache.
-
-    Always overwrites — safe to call to repair a corrupt cache. Returns the
-    cache directory.
-    """
-    root = cache_dir()
-    root.mkdir(parents=True, exist_ok=True)
-    if verbose:
-        sys.stderr.write(
-            f"cancerdata: downloading data bundle for v{DATA_VERSION} "
-            "(~350 MB, one-time)\n"
-            f"  from {RELEASE_URL}\n"
-            f"  to   {root}\n"
-        )
-        sys.stderr.flush()
+def _download_and_extract(url: str, root: Path, *, verbose: bool) -> None:
+    """Download a tarball from ``url`` and extract it into ``root``. Raises
+    ``urllib.error.URLError``/``HTTPError`` if the URL is unreachable (e.g. 404)."""
     with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
         tmp_path = Path(tmp.name)
     try:
-        with urllib.request.urlopen(RELEASE_URL) as resp, tmp_path.open("wb") as h:
+        with urllib.request.urlopen(url) as resp, tmp_path.open("wb") as h:
             shutil.copyfileobj(resp, h, length=1024 * 1024)
         if verbose:
             sys.stderr.write("cancerdata: extracting...\n")
@@ -141,10 +160,44 @@ def fetch(*, verbose: bool = True) -> Path:
                 tf.extractall(root)
     finally:
         tmp_path.unlink(missing_ok=True)
-    if verbose:
-        sys.stderr.write(f"cancerdata: data bundle ready at {root}\n")
-        sys.stderr.flush()
-    return root
+
+
+def fetch(*, verbose: bool = True) -> Path:
+    """Download + extract the bundle for this version into the cache.
+
+    Tries each URL in :data:`RELEASE_URLS` (cancerdata first, pirlygenes fallback)
+    until one succeeds, so a version not yet published on the cancerdata release
+    transparently falls back. Always overwrites — safe to call to repair a corrupt
+    cache. Returns the cache directory.
+    """
+    root = cache_dir()
+    root.mkdir(parents=True, exist_ok=True)
+    errors: list[str] = []
+    for url in RELEASE_URLS:
+        if verbose:
+            sys.stderr.write(
+                f"cancerdata: downloading data bundle for v{DATA_VERSION} "
+                "(~350 MB, one-time)\n"
+                f"  from {url}\n"
+                f"  to   {root}\n"
+            )
+            sys.stderr.flush()
+        try:
+            _download_and_extract(url, root, verbose=verbose)
+        except (urllib.error.URLError, urllib.error.HTTPError) as e:
+            errors.append(f"{url}: {e}")
+            if verbose:
+                sys.stderr.write(f"cancerdata: {url} unavailable ({e}); trying next source\n")
+                sys.stderr.flush()
+            continue
+        if verbose:
+            sys.stderr.write(f"cancerdata: data bundle ready at {root}\n")
+            sys.stderr.flush()
+        return root
+    raise RuntimeError(
+        "cancerdata: could not download the data bundle from any release source:\n  "
+        + "\n  ".join(errors)
+    )
 
 
 def ensure_local(*, auto_fetch: bool = True, verbose: bool = True) -> Path:
@@ -188,6 +241,7 @@ def status() -> dict:
         "data_version": DATA_VERSION,
         "cache_dir": str(root),
         "release_url": RELEASE_URL,
+        "release_urls": list(RELEASE_URLS),
         "items": items,
         "all_local": is_local(),
     }
@@ -273,8 +327,12 @@ def prune_cache(*, keep_current: bool = True, dry_run: bool = False) -> list[dic
 
 __all__ = [
     "DOWNLOADABLE_PATHS",
+    "FALLBACK_GITHUB_REPO",
+    "FALLBACK_RELEASE_URL",
+    "FALLBACK_TARBALL_FILENAME",
     "GITHUB_REPO",
     "RELEASE_URL",
+    "RELEASE_URLS",
     "TARBALL_FILENAME",
     "cache_dir",
     "cache_root",

--- a/cancerdata/data_bundle.py
+++ b/cancerdata/data_bundle.py
@@ -142,10 +142,17 @@ def find(relative_path: str) -> Path | None:
 
 
 def _download_and_extract(url: str, root: Path, *, verbose: bool) -> None:
-    """Download a tarball from ``url`` and extract it into ``root``. Raises
-    ``urllib.error.URLError``/``HTTPError`` if the URL is unreachable (e.g. 404)."""
+    """Download a tarball from ``url`` and extract it into ``root``.
+
+    Extraction goes into a staging dir first and is promoted into ``root`` only
+    after it completes, so a failed/corrupt download never leaves a half-populated
+    cache that a later run would read as valid. Raises ``urllib.error.URLError``
+    (unreachable, e.g. 404) or ``tarfile.TarError`` (corrupt/non-tar body) — the
+    caller falls back to the next source on either.
+    """
     with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
         tmp_path = Path(tmp.name)
+    staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=root))
     try:
         with urllib.request.urlopen(url) as resp, tmp_path.open("wb") as h:
             shutil.copyfileobj(resp, h, length=1024 * 1024)
@@ -155,11 +162,20 @@ def _download_and_extract(url: str, root: Path, *, verbose: bool) -> None:
         with tarfile.open(tmp_path) as tf:
             # filter=data is Python 3.12+; fall back to the older API.
             try:
-                tf.extractall(root, filter="data")
+                tf.extractall(staging, filter="data")
             except TypeError:
-                tf.extractall(root)
+                tf.extractall(staging)
+        # Promote staged entries into the cache, replacing any prior copy.
+        for entry in staging.iterdir():
+            dest = root / entry.name
+            if dest.is_dir():
+                shutil.rmtree(dest)
+            elif dest.exists():
+                dest.unlink()
+            shutil.move(str(entry), str(dest))
     finally:
         tmp_path.unlink(missing_ok=True)
+        shutil.rmtree(staging, ignore_errors=True)
 
 
 def fetch(*, verbose: bool = True) -> Path:
@@ -184,7 +200,9 @@ def fetch(*, verbose: bool = True) -> Path:
             sys.stderr.flush()
         try:
             _download_and_extract(url, root, verbose=verbose)
-        except (urllib.error.URLError, urllib.error.HTTPError) as e:
+        except (urllib.error.URLError, tarfile.TarError) as e:
+            # URLError covers HTTPError (404); TarError covers a corrupt body or
+            # an HTML error page served with 200 — fall back to the next source.
             errors.append(f"{url}: {e}")
             if verbose:
                 sys.stderr.write(f"cancerdata: {url} unavailable ({e}); trying next source\n")

--- a/scripts/build_data_tarball.sh
+++ b/scripts/build_data_tarball.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build the cancerdata expression-data tarball for upload to a GitHub Release.
+#
+# The wheel ships only the small curated tables; the heavy per-cohort expression
+# artifacts (data_bundle.DOWNLOADABLE_PATHS) are distributed as a version-pinned
+# tarball attached to the pirl-unc/cancerdata release. This script packages those
+# paths from a source directory that already contains them — e.g. a populated
+# cache dir (`cancerdata fetch` then `cancerdata status` for the path) or a
+# pirlygenes data checkout during the migration.
+#
+# Usage:
+#   scripts/build_data_tarball.sh <source-dir> [output-dir]
+#
+# Then: upload <output-dir>/cancerdata-data-v<DATA_VERSION>.tar.gz to the
+# `v<DATA_VERSION>` release on pirl-unc/cancerdata, and only THEN bump DATA_VERSION
+# (never before the upload — a 404 on the primary URL falls back to pirlygenes,
+# but a version with neither published hangs the fetch).
+set -euo pipefail
+
+SRC="${1:?usage: build_data_tarball.sh <source-dir> [output-dir]}"
+OUT_DIR="${2:-.}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+DATA_VERSION="$(python -c 'from cancerdata.version import DATA_VERSION; print(DATA_VERSION)')"
+read -r -a PATHS <<<"$(python -c 'from cancerdata.data_bundle import DOWNLOADABLE_PATHS; print(" ".join(DOWNLOADABLE_PATHS))')"
+OUT="${OUT_DIR%/}/cancerdata-data-v${DATA_VERSION}.tar.gz"
+
+missing=()
+for p in "${PATHS[@]}"; do
+    [[ -e "$SRC/$p" ]] || missing+=("$p")
+done
+if ((${#missing[@]})); then
+    echo "error: source dir '$SRC' is missing required bundle paths:" >&2
+    printf '  %s\n' "${missing[@]}" >&2
+    exit 1
+fi
+
+mkdir -p "${OUT_DIR%/}"
+echo "packaging ${#PATHS[@]} bundle paths from $SRC -> $OUT"
+tar -czf "$OUT" -C "$SRC" "${PATHS[@]}"
+SIZE="$(du -h "$OUT" | cut -f1)"
+echo "wrote $OUT ($SIZE)"
+echo
+echo "next: gh release upload v${DATA_VERSION} '$OUT' --repo pirl-unc/cancerdata"
+echo "      (create the v${DATA_VERSION} release first if it doesn't exist)"

--- a/scripts/build_data_tarball.sh
+++ b/scripts/build_data_tarball.sh
@@ -20,6 +20,15 @@ set -euo pipefail
 SRC="${1:?usage: build_data_tarball.sh <source-dir> [output-dir]}"
 OUT_DIR="${2:-.}"
 
+# Resolve user-supplied paths to absolute BEFORE cd'ing into the repo, so a
+# relative source/output dir stays relative to the caller's CWD.
+SRC="$(cd "$SRC" 2>/dev/null && pwd)" || {
+    echo "error: source dir '$1' not found" >&2
+    exit 1
+}
+mkdir -p "${OUT_DIR%/}"
+OUT_DIR="$(cd "${OUT_DIR%/}" && pwd)"
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
@@ -37,7 +46,6 @@ if ((${#missing[@]})); then
     exit 1
 fi
 
-mkdir -p "${OUT_DIR%/}"
 echo "packaging ${#PATHS[@]} bundle paths from $SRC -> $OUT"
 tar -czf "$OUT" -C "$SRC" "${PATHS[@]}"
 SIZE="$(du -h "$OUT" | cut -f1)"

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -4,7 +4,12 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import urllib.error
+
+import pytest
+
 from cancerdata import data_bundle
+from cancerdata.version import DATA_VERSION
 
 
 def test_is_downloadable_distinguishes_bundle_from_wheel():
@@ -50,3 +55,66 @@ def test_prune_keeps_current(monkeypatch, tmp_path):
     planned = data_bundle.prune_cache(dry_run=True)
     versions = {e["version"] for e in planned}
     assert versions == {"v1.0.0"}  # current (v2.0.0) is kept
+
+
+def test_release_urls_prefer_cancerdata_then_pirlygenes():
+    assert data_bundle.RELEASE_URLS == (
+        data_bundle.RELEASE_URL,
+        data_bundle.FALLBACK_RELEASE_URL,
+    )
+    assert "pirl-unc/cancerdata" in data_bundle.RELEASE_URL
+    assert "pirl-unc/pirlygenes" in data_bundle.FALLBACK_RELEASE_URL
+    assert f"v{DATA_VERSION}" in data_bundle.RELEASE_URL
+
+
+def test_fetch_falls_back_when_primary_404s(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / f"v{DATA_VERSION}"))
+    attempted = []
+
+    def fake_download(url, root, *, verbose):
+        attempted.append(url)
+        if url == data_bundle.RELEASE_URL:
+            raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+        # fallback "succeeds"
+
+    monkeypatch.setattr(data_bundle, "_download_and_extract", fake_download)
+    out = data_bundle.fetch(verbose=False)
+    assert out == data_bundle.cache_dir()
+    assert attempted == [data_bundle.RELEASE_URL, data_bundle.FALLBACK_RELEASE_URL]
+
+
+def test_fetch_raises_when_all_sources_fail(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / f"v{DATA_VERSION}"))
+
+    def always_404(url, root, *, verbose):
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(data_bundle, "_download_and_extract", always_404)
+    with pytest.raises(RuntimeError, match="could not download"):
+        data_bundle.fetch(verbose=False)
+
+
+def test_cache_root_reuses_legacy_pirlygenes_dir(monkeypatch, tmp_path):
+    # No env override; legacy cache already has THIS version, new root does not.
+    monkeypatch.delenv("CANCERDATA_BUNDLED_DATA", raising=False)
+    monkeypatch.delenv("PIRLYGENES_BUNDLED_DATA", raising=False)
+    new_root = tmp_path / "cancerdata" / "bundled_data"
+    legacy_root = tmp_path / "pirlygenes" / "bundled_data"
+    (legacy_root / f"v{DATA_VERSION}").mkdir(parents=True)
+    monkeypatch.setattr(data_bundle, "_DEFAULT_CACHE_PARENT", new_root)
+    monkeypatch.setattr(data_bundle, "_LEGACY_CACHE_PARENT", legacy_root)
+
+    assert data_bundle.cache_root() == legacy_root  # reuse, no forced re-download
+    # Once the new root has this version too, it wins.
+    (new_root / f"v{DATA_VERSION}").mkdir(parents=True)
+    assert data_bundle.cache_root() == new_root
+
+
+def test_cache_root_defaults_to_cancerdata_when_no_cache(monkeypatch, tmp_path):
+    monkeypatch.delenv("CANCERDATA_BUNDLED_DATA", raising=False)
+    monkeypatch.delenv("PIRLYGENES_BUNDLED_DATA", raising=False)
+    new_root = tmp_path / "cancerdata" / "bundled_data"
+    legacy_root = tmp_path / "pirlygenes" / "bundled_data"
+    monkeypatch.setattr(data_bundle, "_DEFAULT_CACHE_PARENT", new_root)
+    monkeypatch.setattr(data_bundle, "_LEGACY_CACHE_PARENT", legacy_root)
+    assert data_bundle.cache_root() == new_root

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -4,6 +4,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import tarfile
 import urllib.error
 
 import pytest
@@ -76,6 +77,23 @@ def test_fetch_falls_back_when_primary_404s(monkeypatch, tmp_path):
         if url == data_bundle.RELEASE_URL:
             raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
         # fallback "succeeds"
+
+    monkeypatch.setattr(data_bundle, "_download_and_extract", fake_download)
+    out = data_bundle.fetch(verbose=False)
+    assert out == data_bundle.cache_dir()
+    assert attempted == [data_bundle.RELEASE_URL, data_bundle.FALLBACK_RELEASE_URL]
+
+
+def test_fetch_falls_back_on_corrupt_primary_tarball(monkeypatch, tmp_path):
+    # A 200 response whose body isn't a valid tar (e.g. an HTML error page) must
+    # fall back to the next source, not propagate.
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / f"v{DATA_VERSION}"))
+    attempted = []
+
+    def fake_download(url, root, *, verbose):
+        attempted.append(url)
+        if url == data_bundle.RELEASE_URL:
+            raise tarfile.ReadError("not a gzip file")
 
     monkeypatch.setattr(data_bundle, "_download_and_extract", fake_download)
     out = data_bundle.fetch(verbose=False)


### PR DESCRIPTION
## Summary
Third data step of the consolidation (tracking #17). Makes `data_bundle` own the heavy expression tarball instead of inheriting pirlygenes releases — **without** a forced re-download or a broken fetch during migration.

## What changed
- **Release source**: primary is now `pirl-unc/cancerdata` (`cancerdata-data-v<DATA_VERSION>.tar.gz`); `pirl-unc/pirlygenes` is a one-release **fallback**. `fetch()` tries `RELEASE_URLS` in order — a 404 on the primary (tarball not uploaded yet) falls through to pirlygenes rather than hanging the user; raises only if **all** sources fail.
- **Cache root** moves to `~/.cache/cancerdata/bundled_data`, but an existing `~/.cache/pirlygenes` cache for the current version is **reused** (no re-download). Both env overrides unchanged.
- **`scripts/build_data_tarball.sh`**: packages `DOWNLOADABLE_PATHS` from a source dir into the versioned tarball, with a missing-path guard and an upload-command hint.
- `status()` + CLI now show the fallback URL.

## Why fetch still works today
DATA_VERSION is `5.22.6`; the cancerdata `v5.22.6` release doesn't exist yet, so the primary URL 404s and fetch transparently uses the existing pirlygenes tarball. Once the cancerdata tarball is uploaded for a version, it's preferred automatically.

## Scope / deferred (manual release step)
The actual **build → upload → DATA_VERSION bump** is a human release action (700 MB asset), intentionally not done here. This PR lands the machinery so the cutover is just "upload, then bump" — never bump before upload (the fallback covers the gap, but a version with neither published would hang).

## Tests
`test_data_bundle.py`: URL ordering, fetch fallback on 404, raise-when-all-fail, legacy-cache reuse, default-root. Build script smoke-tested (packages all 5 paths; errors on missing). Full suite 130 pass (+6); ruff clean; `bash -n` clean.

Addresses #14. See #17.