### PR TITLE
CTA expression heatmap plot (per-gene) (#15)

### DIFF
--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -182,9 +182,15 @@ def _cmd_plot(args: argparse.Namespace) -> int:
         "apd1-vs-tmb": plots.apd1_vs_tmb,
         "apd1-orr-bars": plots.apd1_orr_bars,
         "incidence-vs-mortality": plots.incidence_vs_mortality,
+        "cta-expression-heatmap": plots.cta_expression_heatmap,
     }
     try:
-        kwargs = {"region": args.region} if args.which == "incidence-vs-mortality" else {}
+        if args.which == "incidence-vs-mortality":
+            kwargs = {"region": args.region}
+        elif args.which == "cta-expression-heatmap":
+            kwargs = {"stat": args.stat}
+        else:
+            kwargs = {}
         fns[args.which](save=args.out, **kwargs)
     except (ValueError, ModuleNotFoundError) as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -357,12 +363,23 @@ def _build_parser() -> argparse.ArgumentParser:
     p_plot = sub.add_parser("plot", help="Render a cancer-type reference plot to a PNG")
     p_plot.add_argument(
         "which",
-        choices=["apd1-vs-tmb", "apd1-orr-bars", "incidence-vs-mortality"],
+        choices=[
+            "apd1-vs-tmb",
+            "apd1-orr-bars",
+            "incidence-vs-mortality",
+            "cta-expression-heatmap",
+        ],
         help="Which plot to render",
     )
     p_plot.add_argument("--out", required=True, help="Output PNG path")
     p_plot.add_argument(
         "--region", default="us", choices=["us", "world"], help="Region for incidence-vs-mortality"
+    )
+    p_plot.add_argument(
+        "--stat",
+        default="median",
+        choices=["q1", "median", "q3"],
+        help="Statistic for cta-expression-heatmap",
     )
     p_plot.set_defaults(func=_cmd_plot)
 

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -26,10 +26,15 @@ from __future__ import annotations
 
 from .apd1 import cancer_apd1_response
 from .cancer_types import cancer_type_registry, format_cancer_code_label
+from .cta import CTA_gene_id_to_name, CTA_gene_ids
+from .expression import available_percentile_cohorts, cohort_gene_percentiles
 from .incidence import cancer_burden
 from .tmb import cancer_tmb
 
 _PLT = None
+
+#: stat name -> the percentile breakpoint column in the shipped percentile vector.
+_STAT_PERCENTILE_COL = {"q1": "p25", "median": "p50", "q3": "p75"}
 
 
 def _plt():
@@ -157,5 +162,109 @@ def incidence_vs_mortality(*, region="us", save=None):
     ax.set_ylabel(f"{region.upper()} share of cancer mortality (%)")
     ax.set_title(f"Incidence vs mortality by burden category ({region.upper()})")
     ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    return _save(fig, save)
+
+
+def _cta_expression_matrix(stat, cohorts):
+    """cohorts × CTA-gene matrix of the requested ``stat`` TPM (NaN where a cohort
+    lacks a gene). Rows are cohort codes, columns are CTA symbols."""
+    import pandas as pd
+
+    col = _STAT_PERCENTILE_COL[stat]
+    id_to_name = CTA_gene_id_to_name()
+    cta_ids = set(CTA_gene_ids())
+    rows = {}
+    for code in cohorts:
+        df = cohort_gene_percentiles(code, as_tpm=True)
+        ids = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+        mask = ids.isin(cta_ids)
+        sub = df.loc[mask]
+        rows[code] = pd.Series(
+            sub[col].to_numpy(),
+            index=ids[mask].map(id_to_name),
+        )
+    matrix = pd.DataFrame(rows).T  # cohorts (rows) × CTA symbols (cols)
+    return matrix.loc[:, ~matrix.columns.duplicated()]
+
+
+def cta_expression_heatmap(
+    *,
+    stat="median",
+    cohorts=None,
+    n_cohorts=30,
+    n_ctas=30,
+    high_tpm=30.0,
+    proteoform=False,
+    save=None,
+):
+    """Heatmap of cancer-testis-antigen expression — rows are cohorts, columns are
+    CTAs, cells are the cohort's per-gene ``stat`` TPM (``"median"``/``"q1"``/``"q3"``
+    = p50/p25/p75 of the shipped percentile vector).
+
+    Rows are the ``n_cohorts`` cohorts with the highest single-CTA ``stat``; columns
+    are the ``n_ctas`` CTAs with the highest peak across cohorts, ordered by how many
+    cohorts express them above ``high_tpm`` (the actionable threshold) then by peak.
+    Colour is a log scale (dark = silent, hot = high) anchored in the clinically
+    meaningful 1–1000 TPM range.
+
+    ``cohorts`` restricts the cohort pool (default: every cohort with a percentile
+    vector). Needs the expression bundle present (percentile artifacts).
+
+    ``proteoform=True`` is not yet available: faithful paralog summation must happen
+    on per-sample matrices *before* the percentile summary (percentiles can't be
+    summed), which is the proteoform-summed percentile artifact tracked in #13.
+    """
+    import numpy as np
+    from matplotlib.colors import LogNorm
+
+    if stat not in _STAT_PERCENTILE_COL:
+        raise ValueError(f"stat must be one of {sorted(_STAT_PERCENTILE_COL)}")
+    if proteoform:
+        raise NotImplementedError(
+            "proteoform-summed CTA expression needs the proteoform-summed percentile "
+            "artifact (per-sample summation before summarizing — percentiles cannot be "
+            "summed); tracked in issue #13."
+        )
+    plt = _plt()
+    if cohorts is None:
+        cohorts = available_percentile_cohorts()
+    if not cohorts:
+        raise ValueError("no cohorts with a percentile vector — is the expression bundle present?")
+
+    matrix = _cta_expression_matrix(stat, cohorts)
+    # Columns: top CTAs by peak, ordered by breadth (#cohorts > high_tpm) then peak.
+    peak = matrix.max(axis=0, skipna=True)
+    breadth = (matrix > high_tpm).sum(axis=0)
+    top_ctas = (
+        peak.to_frame("peak")
+        .assign(breadth=breadth)
+        .sort_values(["breadth", "peak"], ascending=False)
+        .head(n_ctas)
+        .index
+    )
+    # Rows: cohorts with the highest single-CTA value, sorted descending.
+    row_score = matrix[top_ctas].max(axis=1, skipna=True)
+    top_cohorts = row_score.sort_values(ascending=False).head(n_cohorts).index
+    grid = matrix.loc[top_cohorts, top_ctas]
+
+    floor = 0.01
+    data = np.clip(grid.to_numpy(dtype=float), floor, None)
+    fig, ax = plt.subplots(figsize=(max(8, 0.42 * len(top_ctas)), max(6, 0.34 * len(top_cohorts))))
+    im = ax.imshow(
+        data,
+        aspect="auto",
+        cmap="magma",
+        norm=LogNorm(vmin=floor, vmax=max(1000.0, float(np.nanmax(data)))),
+    )
+    ax.set_xticks(range(len(top_ctas)))
+    ax.set_xticklabels(list(top_ctas), rotation=90, fontsize=6)
+    ax.set_yticks(range(len(top_cohorts)))
+    ax.set_yticklabels([format_cancer_code_label(c) for c in top_cohorts], fontsize=6)
+    ax.set_title(
+        f"CTA expression ({stat} TPM) — top {len(top_cohorts)} cohorts × {len(top_ctas)} CTAs"
+    )
+    cbar = fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01)
+    cbar.set_label(f"{stat} TPM (log)")
     fig.tight_layout()
     return _save(fig, save)

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -168,21 +168,35 @@ def incidence_vs_mortality(*, region="us", save=None):
 
 def _cta_expression_matrix(stat, cohorts):
     """cohorts × CTA-gene matrix of the requested ``stat`` TPM (NaN where a cohort
-    lacks a gene). Rows are cohort codes, columns are CTA symbols."""
+    lacks a gene). Rows are cohort codes, columns are CTA symbols. Cohorts without
+    a percentile vector (summary-only or unknown codes) are skipped with a warning
+    rather than aborting the whole plot."""
+    import warnings
+
     import pandas as pd
 
     col = _STAT_PERCENTILE_COL[stat]
     id_to_name = CTA_gene_id_to_name()
     cta_ids = set(CTA_gene_ids())
     rows = {}
+    skipped = []
     for code in cohorts:
-        df = cohort_gene_percentiles(code, as_tpm=True)
+        try:
+            df = cohort_gene_percentiles(code, as_tpm=True)
+        except ValueError:
+            skipped.append(str(code))
+            continue
         ids = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
         mask = ids.isin(cta_ids)
         sub = df.loc[mask]
         rows[code] = pd.Series(
             sub[col].to_numpy(),
             index=ids[mask].map(id_to_name),
+        )
+    if skipped:
+        warnings.warn(
+            f"skipped {len(skipped)} cohort(s) without a percentile vector: {', '.join(skipped)}",
+            stacklevel=2,
         )
     matrix = pd.DataFrame(rows).T  # cohorts (rows) × CTA symbols (cols)
     return matrix.loc[:, ~matrix.columns.duplicated()]
@@ -233,6 +247,11 @@ def cta_expression_heatmap(
         raise ValueError("no cohorts with a percentile vector — is the expression bundle present?")
 
     matrix = _cta_expression_matrix(stat, cohorts)
+    if matrix.empty or matrix.shape[1] == 0:
+        raise ValueError(
+            "no CTA expression data for the selected cohorts — none had a percentile "
+            "vector, or none expressed any CTA gene."
+        )
     # Columns: top CTAs by peak, ordered by breadth (#cohorts > high_tpm) then peak.
     peak = matrix.max(axis=0, skipna=True)
     breadth = (matrix > high_tpm).sum(axis=0)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -39,3 +39,35 @@ def test_cli_plot(tmp_path):
     out = tmp_path / "cli.png"
     assert cli.main(["plot", "apd1-vs-tmb", "--out", str(out)]) == 0
     assert out.exists()
+
+
+# ---- CTA expression heatmap (needs the expression bundle / percentile data) ----
+
+_HAS_PERCENTILES = bool(__import__("cancerdata").available_percentile_cohorts())
+_needs_bundle = pytest.mark.skipif(
+    not _HAS_PERCENTILES, reason="expression bundle (percentile artifacts) not present"
+)
+
+
+@_needs_bundle
+def test_cta_expression_heatmap_renders(tmp_path):
+    out = tmp_path / "cta.png"
+    cohorts = __import__("cancerdata").available_percentile_cohorts()[:6]
+    fig = plots.cta_expression_heatmap(cohorts=cohorts, n_cohorts=4, n_ctas=8, save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+    assert fig is not None
+
+
+def test_cta_expression_heatmap_bad_stat():
+    with pytest.raises(ValueError, match="stat must be one of"):
+        plots.cta_expression_heatmap(stat="mean", cohorts=["X"])
+
+
+def test_cta_expression_heatmap_proteoform_not_implemented():
+    with pytest.raises(NotImplementedError, match="#13"):
+        plots.cta_expression_heatmap(proteoform=True, cohorts=["X"])
+
+
+def test_cta_expression_heatmap_no_cohorts():
+    with pytest.raises(ValueError, match="no cohorts"):
+        plots.cta_expression_heatmap(cohorts=[])

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -71,3 +71,13 @@ def test_cta_expression_heatmap_proteoform_not_implemented():
 def test_cta_expression_heatmap_no_cohorts():
     with pytest.raises(ValueError, match="no cohorts"):
         plots.cta_expression_heatmap(cohorts=[])
+
+
+def test_cta_expression_heatmap_skips_unusable_cohorts():
+    # A code with no percentile vector is skipped with a warning, not a crash; with
+    # only unusable codes the matrix is empty -> clean ValueError.
+    with (
+        pytest.warns(UserWarning, match="without a percentile vector"),
+        pytest.raises(ValueError, match="no CTA expression data"),
+    ):
+        plots.cta_expression_heatmap(cohorts=["NOT_A_REAL_COHORT"])


### PR DESCRIPTION
## Summary
First plot of the plots phase (tracking #17). Adds `plots.cta_expression_heatmap` — the per-cancer-type CTA expression heatmap from issue #15.

## What it shows
Rows = cohorts, columns = CTAs, cells = the cohort's per-gene **stat TPM** (`median`/`q1`/`q3` = p50/p25/p75 of the shipped percentile vectors), over `CTA_gene_ids()`. Columns are the top CTAs by peak ordered by breadth above an actionable-TPM threshold; rows are the cohorts with the highest single-CTA value. Log colour scale (dark = silent, hot = high) anchored in the 1–1000 TPM clinical range. Wired into the CLI: `cancerdata plot cta-expression-heatmap --stat median --out h.png`. Behind the `[plots]` matplotlib extra.

Rendered sanity check (SKCM→PRAME/MAGEA-high, LUAD→XAGE1A/B-high) is biologically on the nose.

## Honest limitation — per-gene, not paralog-merged
cancerdata ships the **per-gene percentile summary**, and percentiles can't be validly summed. Faithful paralog merging (pirlygenes' `_merge_proteins`) sums **per-sample** TPM *before* summarizing — that's the proteoform-summed percentile artifact tracked in **#13**, blocked on per-sample matrices. So this ships the per-gene heatmap (XAGE1A/XAGE1B appear as separate columns today). `proteoform=True` raises `NotImplementedError` pointing at #13; the hook lights up once that artifact ships — no plot rewrite needed.

## Tests
`test_plots.py`: renders against the local percentile bundle (auto-skips if absent), plus stat / proteoform / empty-cohort guards. Full suite 135 pass (+4); ruff clean.

Addresses #15 (P1). P2 (addressable burden) and P3 (9mers) per the plan on #15. See #17.