### PR TITLE
Cross-cutting subtype groupings: MSI/POLE/HPV reverse queries (#27 O2)

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -21,6 +21,8 @@ from .apd1 import cancer_apd1_response, cancer_apd1_response_df
 from .cancer_types import (
     CANCER_TYPE_ALIASES,
     CANCER_TYPE_NAMES,
+    cancer_subtype_group,
+    cancer_subtype_groupings,
     cancer_type_families,
     cancer_type_info,
     cancer_type_registry,
@@ -134,6 +136,8 @@ __all__ = [
     "cancer_burden",
     "cancer_burden_df",
     "cancer_code_burden_map",
+    "cancer_subtype_group",
+    "cancer_subtype_groupings",
     # TMB
     "cancer_tmb",
     "cancer_tmb_df",

--- a/cancerdata/cancer_types.py
+++ b/cancerdata/cancer_types.py
@@ -526,6 +526,55 @@ def cancer_type_subtypes_of(parent_code):
     return df[df["parent_code"] == parent_code]["code"].tolist()
 
 
+def _parent_of_map():
+    """``{code: parent_code}`` from the registry (empty parents dropped)."""
+    df = cancer_type_registry()
+    out = {}
+    for code, parent in zip(df["code"], df["parent_code"]):
+        if isinstance(parent, str) and parent:
+            out[str(code)] = parent
+    return out
+
+
+def _walk_ancestors(code, parent_of):
+    """Codes on the ``parent_code`` chain above ``code`` (excluding itself)."""
+    seen, cur = [], code
+    while cur in parent_of:
+        cur = parent_of[cur]
+        if cur in seen:  # defensive: a cycle would otherwise loop forever
+            break
+        seen.append(cur)
+    return seen
+
+
+def cancer_subtype_groupings():
+    """Orthogonal cross-cutting subtype groupings (``cancer-subtype-groupings.csv``).
+
+    Axes such as microsatellite (MSI/MSS), hypermutation (POLE), viral_hpv, and
+    copy_number_mycn cut *across* the organ ``parent_code`` tree — a leaf belongs to
+    its organ parent **and** to a mechanism group. Returns the long-form
+    ``group_code, axis, member_code, basis`` table (defensive copy).
+    """
+    return get_data("cancer-subtype-groupings").copy()
+
+
+def cancer_subtype_group(group_code, *, under=None):
+    """Member registry codes of a cross-cutting group (e.g. ``"MSI"``, ``"MSS"``,
+    ``"POLE"``, ``"HPV_POS"``, ``"MYCN_AMP"``).
+
+    ``cancer_subtype_group("MSI")`` returns every MSI subtype across cancers;
+    ``cancer_subtype_group("POLE")`` the POLE-ultramutated subtypes. With ``under``,
+    restrict to members that are descendants of that hierarchy node —
+    ``cancer_subtype_group("MSI", under="CRC")`` -> the colorectal MSI cross-cut.
+    """
+    df = cancer_subtype_groupings()
+    members = df[df["group_code"] == group_code]["member_code"].tolist()
+    if under is not None:
+        parent_of = _parent_of_map()
+        members = [m for m in members if under in _walk_ancestors(m, parent_of)]
+    return members
+
+
 def mixture_cohort_codes():
     """Return parent codes flagged as mixture cohorts in the registry.
 

--- a/cancerdata/data/cancer-subtype-groupings.csv
+++ b/cancerdata/data/cancer-subtype-groupings.csv
@@ -1,0 +1,12 @@
+group_code,axis,member_code,basis
+MSI,microsatellite,COAD_MSI,MSI-H/dMMR colon
+MSI,microsatellite,READ_MSI,MSI-H/dMMR rectum
+MSI,microsatellite,UCEC_MSI,MSI-H/dMMR endometrial
+MSS,microsatellite,COAD_MSS,microsatellite-stable colon
+MSS,microsatellite,READ_MSS,microsatellite-stable rectum
+POLE,hypermutation,UCEC_POLE,POLE-ultramutated endometrial
+HPV_POS,viral_hpv,HNSC_HPVpos,HPV-driven head and neck
+HPV_POS,viral_hpv,CESC,HPV-driven cervical (entity is HPV-defining)
+HPV_NEG,viral_hpv,HNSC_HPVneg,HPV-negative head and neck
+MYCN_AMP,copy_number_mycn,NBL_MYCNamp,MYCN-amplified neuroblastoma
+MYCN_NONAMP,copy_number_mycn,NBL_MYCNnonamp,MYCN-non-amplified neuroblastoma

--- a/tests/test_subtype_groupings.py
+++ b/tests/test_subtype_groupings.py
@@ -1,0 +1,46 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Cross-cutting subtype groupings: MSI/POLE/HPV reverse queries (#27, O2)."""
+
+from cancerdata import (
+    cancer_subtype_group,
+    cancer_subtype_groupings,
+    cancer_type_registry,
+)
+
+
+def test_all_msi_types():
+    assert cancer_subtype_group("MSI") == ["COAD_MSI", "READ_MSI", "UCEC_MSI"]
+
+
+def test_all_pole_subtypes():
+    assert cancer_subtype_group("POLE") == ["UCEC_POLE"]
+
+
+def test_under_scopes_to_descendants():
+    # MSI across all cancers vs colorectal-only (descendants of CRC).
+    assert cancer_subtype_group("MSI", under="CRC") == ["COAD_MSI", "READ_MSI"]
+    assert cancer_subtype_group("MSI", under="UCEC") == ["UCEC_MSI"]
+
+
+def test_unknown_group_is_empty():
+    assert cancer_subtype_group("NOT_A_GROUP") == []
+
+
+def test_groupings_table_axes():
+    df = cancer_subtype_groupings()
+    assert set(df.columns) == {"group_code", "axis", "member_code", "basis"}
+    assert {"microsatellite", "hypermutation", "viral_hpv"} <= set(df["axis"])
+
+
+def test_every_member_is_a_registry_code():
+    # A grouping must never reference a cancer code that doesn't exist, or the
+    # reverse query would return phantom codes.
+    members = set(cancer_subtype_groupings()["member_code"])
+    codes = set(cancer_type_registry()["code"])
+    missing = sorted(members - codes)
+    assert not missing, f"subtype-grouping members not in the registry: {missing}"


### PR DESCRIPTION
## Summary
Second ontology step (#27). Adds the orthogonal cross-cutting subtype layer — the *"give me all the MSI cancer types / POLE subtypes"* reverse queries you asked for — that cuts across the organ `parent_code` tree.

## What changed
- Ports **`cancer-subtype-groupings.csv`** (11 rows): axes `microsatellite` (MSI/MSS), `hypermutation` (POLE), `viral_hpv` (HPV_POS/NEG), `copy_number_mycn` (MYCN_AMP/NONAMP).
- **`cancer_subtype_groupings()`** → the long-form table.
- **`cancer_subtype_group(group, *, under=None)`** → members of a group:
  - `cancer_subtype_group("MSI")` → `[COAD_MSI, READ_MSI, UCEC_MSI]`
  - `cancer_subtype_group("POLE")` → `[UCEC_POLE]`
  - `cancer_subtype_group("MSI", under="CRC")` → `[COAD_MSI, READ_MSI]` (colorectal cross-cut)
- `_walk_ancestors` / `_parent_of_map` helpers for the `under=` descendant filter (these get promoted to the public tree API in O3).

## Consistency guard
A test asserts **every grouping `member_code` is a real registry code** — so the reverse query can never return a phantom cohort. Passes because O1 (#28) added `UCEC_POLE`, `CRC`, etc.

## Tests
`test_subtype_groupings.py`: MSI/POLE queries, `under=` scoping, unknown-group→empty, axes, member→registry integrity. Full suite 147 pass (+6); ruff clean.

Addresses #27 (O2).