### PR TITLE
Driver fusions per cancer type + reverse lookups (#27 O4)

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -81,6 +81,13 @@ from .expression_registry import (
     registry_dataframe,
     sources_for_cancer_code,
 )
+from .fusions import (
+    cancer_fusions,
+    cancer_fusions_df,
+    cancer_types_with_fusion,
+    fusion_partners,
+    protein_family,
+)
 from .hpa import (
     gene_cell_type_ntpm,
     gene_protein_tissues,
@@ -140,6 +147,8 @@ __all__ = [
     "cancer_burden",
     "cancer_burden_df",
     "cancer_code_burden_map",
+    "cancer_fusions",
+    "cancer_fusions_df",
     "cancer_subtype_group",
     "cancer_subtype_groupings",
     # TMB
@@ -156,6 +165,7 @@ __all__ = [
     "cancer_type_tree",
     "cancer_types_by_tissue",
     "cancer_types_in_family",
+    "cancer_types_with_fusion",
     "canonical_cancer_code",
     "cohort_aggregate_members",
     # cohort vocabulary
@@ -171,6 +181,7 @@ __all__ = [
     "expression_sources",
     "family_display_name",
     "format_cancer_code_label",
+    "fusion_partners",
     "fusion_status",
     "gene_cell_type_ntpm",
     "gene_protein_tissues",
@@ -183,6 +194,7 @@ __all__ = [
     "is_mixture_cohort",
     "known_cohort_ids",
     "mixture_cohort_codes",
+    "protein_family",
     "proteoform_for_gene",
     "proteoform_group_map",
     "proteoform_groups",

--- a/cancerdata/data/cancer-fusions.csv
+++ b/cancerdata/data/cancer-fusions.csv
@@ -1,0 +1,172 @@
+cancer_code,fusion_family,gene_5prime,gene_5prime_family,gene_3prime,gene_3prime_family,frequency,is_defining,pathognomonic,rnaseq_detectable,mechanism,confidence,pmid,notes
+SARC_EWS,EWSR1-ETS,EWSR1,FET,FLI1,ETS,~85%,true,true,yes,fusion_transcript,high,PMID:1522903,Ewing sarcoma; t(11;22)(q24;q12); most common partner
+SARC_EWS,EWSR1-ETS,EWSR1,FET,ERG,ETS,~10%,true,true,yes,fusion_transcript,high,PMID:8162068,t(21;22)(q22;q12); second most common ETS partner
+SARC_EWS,EWSR1-ETS,EWSR1,FET,ETV1,ETS,rare,true,true,yes,fusion_transcript,medium,PMID:7700648,rare ETS variant fusion
+SARC_EWS,EWSR1-ETS,EWSR1,FET,ETV4,ETS,rare,true,true,yes,fusion_transcript,medium,PMID:9182765,rare ETS variant fusion (also called E1AF)
+SARC_EWS,EWSR1-ETS,EWSR1,FET,FEV,ETS,rare,true,true,yes,fusion_transcript,medium,PMID:11050006,rare ETS variant fusion
+SARC_EWS,FUS-ETS,FUS,FET,ERG,ETS,rare,true,true,yes,fusion_transcript,medium,PMID:8392442,FET-family alternative (FUS instead of EWSR1)
+SARC_SYN,SS18-SSX,SS18,,SSX1,SSX,~65%,true,true,yes,fusion_transcript,high,PMID:7951326,synovial sarcoma; t(X;18)(p11;q11); SSX1 more common in biphasic
+SARC_SYN,SS18-SSX,SS18,,SSX2,SSX,~35%,true,true,yes,fusion_transcript,high,PMID:7951326,SSX2 tends monophasic
+SARC_SYN,SS18-SSX,SS18,,SSX4,SSX,rare,true,true,yes,fusion_transcript,medium,PMID:7951326,rare third partner
+SARC_DSRCT,EWSR1-WT1,EWSR1,FET,WT1,zinc-finger TF,~95%,true,true,yes,fusion_transcript,high,PMID:7954420,desmoplastic small round cell tumor; t(11;22)(p13;q12)
+SARC_ASPS,ASPSCR1-TFE3,ASPSCR1,,TFE3,MiT/TFE,~95%,true,false,surrogate,fusion_transcript,high,PMID:11526541,alveolar soft part sarcoma; der(17)t(X;17); ASPL=ASPSCR1; TFE3 IHC surrogate
+SARC_CCS,EWSR1-ATF1,EWSR1,FET,ATF1,bZIP(CREB/ATF),~90%,true,true,yes,fusion_transcript,high,PMID:8504306,clear cell sarcoma (melanoma of soft parts); t(12;22)(q13;q12)
+SARC_CCS,EWSR1-CREB1,EWSR1,FET,CREB1,bZIP(CREB/ATF),minority,true,false,yes,fusion_transcript,medium,PMID:17464315,variant; also seen in GI clear cell sarcoma-like / angiomatoid FH
+SARC_IFS,ETV6-NTRK3,ETV6,ETS,NTRK3,RTK,~90%,true,false,yes,fusion_transcript,high,PMID:9590769,infantile fibrosarcoma; t(12;15)(p13;q25); TRK-inhibitor responsive
+SARC_EHE,WWTR1-CAMTA1,WWTR1,Hippo coactivator,CAMTA1,,~90%,true,true,yes,fusion_transcript,high,PMID:21885844,epithelioid hemangioendothelioma; t(1;3); WWTR1=TAZ; CAMTA1 IHC surrogate
+SARC_EHE,YAP1-TFE3,YAP1,Hippo coactivator,TFE3,MiT/TFE,minority,true,false,surrogate,fusion_transcript,high,PMID:23737213,distinct EHE subset; TFE3 IHC surrogate; YAP1-TFE3 variant
+SARC_LGFMS,FUS-CREB3L2,FUS,FET,CREB3L2,bZIP(CREB/ATF),~90%,true,true,yes,fusion_transcript,high,PMID:15334060,low-grade fibromyxoid sarcoma; t(7;16)(q33;p11)
+SARC_LGFMS,FUS-CREB3L1,FUS,FET,CREB3L1,bZIP(CREB/ATF),minority,true,true,yes,fusion_transcript,medium,PMID:15920748,variant translocation t(11;16)
+SARC_LGFMS,EWSR1-CREB3L1,EWSR1,FET,CREB3L1,bZIP(CREB/ATF),rare,true,true,yes,fusion_transcript,medium,PMID:17345601,rare FET-family variant
+SARC_EMC,EWSR1-NR4A3,EWSR1,FET,NR4A3,nuclear receptor,~60%,true,true,yes,fusion_transcript,high,PMID:9537325,extraskeletal myxoid chondrosarcoma; t(9;22)(q22;q12); NR4A3=CHN/TEC/NOR1
+SARC_EMC,TAF15-NR4A3,TAF15,FET,NR4A3,nuclear receptor,~30%,true,true,yes,fusion_transcript,high,PMID:10398438,TAF15=TAF2N/RBP56; t(9;17)
+SARC_EMC,TCF12-NR4A3,TCF12,bHLH,NR4A3,nuclear receptor,rare,true,true,yes,fusion_transcript,medium,PMID:12112524,rare variant; t(9;15)
+SARC_SFT,NAB2-STAT6,NAB2,,STAT6,STAT,~95%,true,true,surrogate,fusion_transcript,high,PMID:23313952,solitary fibrous tumor; intrachromosomal 12q13 inversion; nuclear STAT6 IHC surrogate; intronic breakpoints can miss in RNA
+SARC_IMT,TPM3-ALK,TPM3,tropomyosin,ALK,RTK,common,true,true,surrogate,fusion_transcript,high,PMID:10934142,inflammatory myofibroblastic tumor; ALK IHC surrogate; ALK-inhibitor responsive
+SARC_IMT,TPM4-ALK,TPM4,tropomyosin,ALK,RTK,minority,true,true,surrogate,fusion_transcript,medium,PMID:10934142,IMT ALK partner
+SARC_IMT,EML4-ALK,EML4,,ALK,RTK,minority,true,false,surrogate,fusion_transcript,medium,PMID:16951148,IMT ALK partner
+SARC_IMT,RANBP2-ALK,RANBP2,,ALK,RTK,minority,true,true,surrogate,fusion_transcript,medium,PMID:16462738,epithelioid inflammatory myofibroblastic sarcoma; aggressive variant
+SARC_IMT,CARS1-ROS1,CARS1,,ROS1,RTK,minority,true,true,surrogate,fusion_transcript,medium,PMID:25028501,ROS1-rearranged IMT subset (CARS=CARS1)
+SARC_IMT,ETV6-NTRK3,ETV6,ETS,NTRK3,RTK,rare,true,false,yes,fusion_transcript,medium,PMID:25028501,NTRK-rearranged IMT subset
+SARC_IMT,TFG-ROS1,TFG,,ROS1,RTK,rare,true,true,surrogate,fusion_transcript,low,PMID:24875859,ROS1 partner reported in IMT
+SARC_DFSP,COL1A1-PDGFB,COL1A1,collagen,PDGFB,growth factor,~90%,true,true,surrogate,fusion_transcript,high,PMID:9192848,dermatofibrosarcoma protuberans; supernumerary ring chr from t(17;22); PDGFB overexpression; imatinib responsive
+SARC_MYXLPS,FUS-DDIT3,FUS,FET,DDIT3,bZIP(C/EBP),~90%,true,true,yes,fusion_transcript,high,PMID:8099842,myxoid/round cell liposarcoma; t(12;16)(q13;p11); DDIT3=CHOP
+SARC_MYXLPS,EWSR1-DDIT3,EWSR1,FET,DDIT3,bZIP(C/EBP),minority,true,true,yes,fusion_transcript,medium,PMID:8612988,variant t(12;22)
+SARC_PEC,SFPQ-TFE3,SFPQ,,TFE3,MiT/TFE,minority,false,false,surrogate,fusion_transcript,medium,PMID:25517172,PEComa TFE3-rearranged subset; SFPQ=PSF; TFE3 IHC surrogate; most PEComas are TSC1/2-driven not fusion
+SARC_PEC,DVL2-TFE3,DVL2,,TFE3,MiT/TFE,rare,false,false,surrogate,fusion_transcript,low,PMID:25651471,rare PEComa TFE3 partner
+SARC_RMS_ARMS,PAX3-FOXO1,PAX3,PAX,FOXO1,FOX,~70%,true,true,yes,fusion_transcript,high,PMID:8275086,alveolar rhabdomyosarcoma; t(2;13)(q35;q14); worse prognosis than PAX7
+SARC_RMS_ARMS,PAX7-FOXO1,PAX7,PAX,FOXO1,FOX,~20%,true,true,yes,fusion_transcript,medium,PMID:8275086,"t(1;13)(p36;q14); younger, better outcome; FOXO1=FKHR; PMID is the shared PAX-FKHR discovery paper"
+SARC_RMS_SSRMS,VGLL2-NCOA2,VGLL2,vestigial-like,NCOA2,NR coactivator,subset,true,true,yes,fusion_transcript,medium,PMID:30664692,infantile spindle cell/sclerosing RMS; congenital subset
+SARC_RMS_SSRMS,TEAD1-NCOA2,TEAD1,TEAD,NCOA2,NR coactivator,subset,true,true,yes,fusion_transcript,low,PMID:30664692,alternative infantile spindle cell RMS fusion
+SARC_RMS_SSRMS,(none),,,,,,false,false,no,other,high,,"older child/adult sclerosing-spindle RMS driven by MYOD1 L122R point mutation, not a fusion"
+SARC_CHON,HEY1-NCOA2,HEY1,bHLH,NCOA2,NR coactivator,~80%,true,true,yes,fusion_transcript,high,PMID:22387997,mesenchymal chondrosarcoma; ins(8;8) or t(8;8)
+SARC_CHON,IRF2BP2-CDX1,IRF2BP2,,CDX1,homeobox,rare,false,false,yes,fusion_transcript,low,PMID:23185413,rare mesenchymal chondrosarcoma variant
+SARC_CHON,(none),,,,,,false,false,no,other,high,,"conventional chondrosarcoma driven by IDH1/IDH2 mutation, not a fusion"
+SARC_ESS_LG,JAZF1-SUZ12,JAZF1,,SUZ12,PRC2/Polycomb,~50%,true,true,yes,fusion_transcript,high,PMID:11427703,low-grade endometrial stromal sarcoma; t(7;17); SUZ12=JJAZ1
+SARC_ESS_LG,JAZF1-PHF1,JAZF1,,PHF1,PRC2/Polycomb,minority,true,true,yes,fusion_transcript,medium,PMID:16331334,variant; PHF1 (6p21) recurrent partner
+SARC_ESS_LG,EPC1-PHF1,EPC1,PRC2/Polycomb,PHF1,PRC2/Polycomb,minority,true,true,yes,fusion_transcript,medium,PMID:16331334,PHF1-rearranged LG-ESS variant
+SARC_ESS_HG,YWHAE-NUTM2A,YWHAE,14-3-3,NUTM2A,NUT,common,true,true,yes,fusion_transcript,high,PMID:22456610,high-grade endometrial stromal sarcoma; t(10;17); NUTM2A/B=FAM22A/B; cyclin D1+
+SARC_ESS_HG,YWHAE-NUTM2B,YWHAE,14-3-3,NUTM2B,NUT,common,true,true,yes,fusion_transcript,high,PMID:22456610,paralogous 3' partner
+SARC_ESS_HG,ZC3H7B-BCOR,ZC3H7B,,BCOR,PRC2/Polycomb,subset,true,false,yes,fusion_transcript,medium,PMID:23344418,BCOR-rearranged HG-ESS subset; BCOR ITD-related morphology
+SARC_LMS,(none),,,,,,false,false,no,other,high,,"leiomyosarcoma: complex karyotype, TP53/RB1/PTEN loss; no recurrent fusion"
+SARC_UPS,(none),,,,,,false,false,no,other,high,,"undifferentiated pleomorphic sarcoma: complex genome, no defining fusion"
+SARC_MYXFIB,(none),,,,,,false,false,no,other,high,,"myxofibrosarcoma: complex karyotype, no recurrent fusion"
+SARC_DDLPS,(none),,,,,,false,false,no,other,high,,"dedifferentiated liposarcoma: 12q13-15 amplification (MDM2/CDK4), not a fusion"
+SARC_WDLPS,(none),,,,,,false,false,no,other,high,,"well-differentiated liposarcoma: MDM2/CDK4 amplification (ring/giant marker chr), not a fusion"
+SARC_PLEOLPS,(none),,,,,,false,false,no,other,high,,"pleomorphic liposarcoma: complex karyotype, TP53/RB1 loss; no defining fusion"
+SARC_GIST,(none),,,,,,false,false,no,other,high,,GIST: KIT or PDGFRA activating mutation (or SDH-deficient); not fusion-driven
+SARC_MPNST,(none),,,,,,false,false,no,other,high,,MPNST: NF1 loss + SUZ12/EED (PRC2) loss + CDKN2A; not fusion-driven
+SARC_EPITH,(none),,,,,,false,false,no,other,high,,"epithelioid sarcoma: SMARCB1/INI1 loss (deletion), not a fusion"
+SARC_KS,(none),,,,,,false,false,no,other,high,,"Kaposi sarcoma: HHV8/KSHV viral oncogenesis, not a chromosomal fusion"
+SARC_OS,(none),,,,,,false,false,no,other,high,,"osteosarcoma: complex/chaotic karyotype, chromothripsis, TP53/RB1; no recurrent fusion"
+SARC_RMS_ERMS,(none),,,,,,false,false,no,other,high,,"embryonal RMS: RAS-pathway mutations, 11p15 LOH; fusion-negative"
+SARC_CHOR,(none),,,,,,false,false,surrogate,other,high,,chordoma: TBXT(brachyury) duplication/overexpression drives; not a fusion (brachyury IHC)
+SARC_GCTB,(none),,,,,,false,false,surrogate,other,high,,giant cell tumor of bone: H3F3A (H3-3A) G34W point mutation; not a fusion
+LAML,RUNX1-RUNX1T1,RUNX1,CBF,RUNX1T1,CBF,common,true,true,yes,fusion_transcript,high,PMID:1907282,AML t(8;21)(q22;q22); core-binding factor; RUNX1T1=ETO/MTG8; favorable
+LAML,CBFB-MYH11,CBFB,CBF,MYH11,myosin,common,true,true,yes,fusion_transcript,high,PMID:8316832,AML inv(16)(p13q22)/t(16;16); CBF-AML; favorable
+LAML,KMT2A-MLLT3,KMT2A,KMT/HMTase,MLLT3,YEATS,subset,true,true,yes,fusion_transcript,high,PMID:1652368,AML t(9;11); KMT2A=MLL; MLLT3=AF9; promiscuous MLL partner
+LAML,KMT2A-MLLT10,KMT2A,KMT/HMTase,MLLT10,MLL partner,subset,true,false,yes,fusion_transcript,medium,PMID:8642287,t(10;11); MLLT10=AF10
+LAML,KMT2A-ELL,KMT2A,KMT/HMTase,ELL,,subset,true,true,yes,fusion_transcript,medium,PMID:8161785,t(11;19)(q23;p13.1)
+LAML,KMT2A-MLLT1,KMT2A,KMT/HMTase,MLLT1,YEATS,subset,true,true,yes,fusion_transcript,medium,PMID:1825142,t(11;19)(q23;p13.3); MLLT1=ENL
+LAML,DEK-NUP214,DEK,,NUP214,nucleoporin,rare,true,true,yes,fusion_transcript,high,PMID:1565502,t(6;9)(p23;q34); FLT3-ITD-associated; poor prognosis; NUP214=CAN
+LAML,NUP98-NSD1,NUP98,nucleoporin,NSD1,KMT/HMTase,rare,true,true,yes,fusion_transcript,medium,PMID:11493482,t(5;11); cryptic; pediatric AML; poor prognosis
+LAML,NUP98-KDM5A,NUP98,nucleoporin,KDM5A,,rare,true,true,yes,fusion_transcript,low,PMID:23531517,t(11;12); KDM5A=JARID1A; acute megakaryoblastic
+LAML,RBM15-MKL1,RBM15,,MKL1,MRTF,rare,true,true,yes,fusion_transcript,medium,PMID:11753601,"t(1;22); infant acute megakaryoblastic leukemia; MKL1=MRTFA, RBM15=OTT"
+LAML_APL,PML-RARA,PML,TRIM/PML,RARA,nuclear receptor,~95%,true,true,yes,fusion_transcript,high,PMID:1652369,acute promyelocytic leukemia; t(15;17)(q24;q21); ATRA/ATO responsive
+LAML_APL,ZBTB16-RARA,ZBTB16,BTB-ZF TF,RARA,nuclear receptor,rare,true,true,yes,fusion_transcript,high,PMID:8302850,t(11;17); ZBTB16=PLZF; ATRA-resistant variant
+LAML_APL,NPM1-RARA,NPM1,nucleophosmin,RARA,nuclear receptor,rare,true,true,yes,fusion_transcript,medium,PMID:8642286,t(5;17) variant APL
+CML,BCR-ABL1,BCR,,ABL1,non-RTK kinase,~100%,true,false,yes,fusion_transcript,high,PMID:6304885,chronic myeloid leukemia; t(9;22) Philadelphia; p210 (e13a2/e14a2); TKI responsive
+B_ALL,BCR-ABL1,BCR,,ABL1,non-RTK kinase,~25%,true,false,yes,fusion_transcript,high,PMID:2825356,Ph+ B-ALL; adults more often; p190 (e1a2) typical; TKI responsive
+B_ALL,ETV6-RUNX1,ETV6,ETS,RUNX1,CBF,~25%,true,true,yes,fusion_transcript,high,PMID:7896484,"childhood B-ALL; t(12;21)(p13;q22) cryptic; ETV6=TEL, RUNX1=AML1; favorable"
+B_ALL,TCF3-PBX1,TCF3,bHLH(E-protein),PBX1,homeobox(TALE),~5%,true,true,yes,fusion_transcript,high,PMID:2196176,t(1;19)(q23;p13); TCF3=E2A; pre-B
+B_ALL,KMT2A-AFF1,KMT2A,KMT/HMTase,AFF1,AF4/LAF4,subset,true,true,yes,fusion_transcript,high,PMID:1606615,t(4;11)(q21;q23); infant B-ALL; AFF1=AF4; poor prognosis
+B_ALL,DUX4-IGH,IGH,Ig locus,DUX4,homeobox,subset,true,true,surrogate,ig_enhancer_hijack,medium,PMID:27776115,DUX4-rearranged B-ALL; IGH enhancer drives DUX4; ERG deregulation; favorable; orientation per IGH-enhancer juxtaposition
+B_ALL,P2RY8-CRLF2,P2RY8,,CRLF2,cytokine receptor,subset,true,true,surrogate,promoter_swap,medium,PMID:19838194,Ph-like; PAR1 deletion places CRLF2 under P2RY8 promoter; CRLF2 overexpression
+B_ALL,IGH-CRLF2,IGH,Ig locus,CRLF2,cytokine receptor,subset,true,true,surrogate,ig_enhancer_hijack,medium,PMID:19838194,Ph-like; IGH enhancer drives CRLF2; JAK pathway activation
+T_ALL,STIL-TAL1,STIL,,TAL1,bHLH,subset,true,true,surrogate,promoter_swap,high,PMID:8350619,T-ALL; SIL-TAL1 microdeletion 1p32 places TAL1 under STIL promoter; TAL1 overexpression
+T_ALL,TLX1-TRD,TRD,TCR locus,TLX1,homeobox,subset,true,true,surrogate,enhancer_hijack,medium,PMID:1671808,t(10;14)/t(7;10); TCR enhancer drives TLX1 (HOX11) overexpression
+T_ALL,TLX3-BCL11B,BCL11B,,TLX3,homeobox,subset,true,true,surrogate,enhancer_hijack,medium,PMID:11607818,t(5;14)(q35;q32); TLX3=HOX11L2 overexpression via BCL11B enhancer
+T_ALL,NUP214-ABL1,NUP214,nucleoporin,ABL1,non-RTK kinase,subset,true,true,yes,fusion_transcript,medium,PMID:15361874,episomal amplification 9q34; TKI-sensitive T-ALL
+T_ALL,KMT2A-MLLT10,KMT2A,KMT/HMTase,MLLT10,MLL partner,subset,true,false,yes,fusion_transcript,medium,PMID:8642287,t(10;11); MLLT10=AF10; early T-cell precursor associated
+MCL,CCND1-IGH,IGH,Ig locus,CCND1,cyclin,~95%,true,false,surrogate,ig_enhancer_hijack,high,PMID:8049438,mantle cell lymphoma; t(11;14)(q13;q32); IGH enhancer drives cyclin D1; no chimeric transcript; cyclin D1 IHC surrogate; PMID unverified
+FL,BCL2-IGH,IGH,Ig locus,BCL2,BCL2/apoptosis,~85%,true,false,surrogate,ig_enhancer_hijack,high,PMID:3929080,follicular lymphoma; t(14;18)(q32;q21); IGH enhancer drives BCL2 anti-apoptotic overexpression
+BL,MYC-IGH,IGH,Ig locus,MYC,,~80%,true,false,surrogate,ig_enhancer_hijack,high,PMID:6262918,Burkitt lymphoma; t(8;14)(q24;q32); IGH enhancer drives MYC
+BL,MYC-IGK,IGK,Ig locus,MYC,,minority,true,true,surrogate,ig_enhancer_hijack,high,PMID:6939711,variant t(2;8); IGK light-chain enhancer drives MYC
+BL,MYC-IGL,IGL,Ig locus,MYC,,minority,true,true,surrogate,ig_enhancer_hijack,high,PMID:6939711,variant t(8;22); IGL light-chain enhancer drives MYC
+DLBC,BCL6-IGH,IGH,Ig locus,BCL6,BTB-ZF TF,subset,false,false,surrogate,ig_enhancer_hijack,medium,PMID:8284124,DLBCL; BCL6 (3q27) promiscuous rearrangements; many non-Ig partners; BCL6 overexpression
+DLBC,MYC-IGH,IGH,Ig locus,MYC,,subset,false,false,surrogate,ig_enhancer_hijack,medium,PMID:19204204,double-hit / HGBL with MYC + BCL2 (and/or BCL6) rearrangements; aggressive
+DLBC,BCL2-IGH,IGH,Ig locus,BCL2,BCL2/apoptosis,subset,false,false,surrogate,ig_enhancer_hijack,medium,PMID:19204204,double-hit partner lesion (GCB-DLBCL)
+MM,CCND1-IGH,IGH,Ig locus,CCND1,cyclin,~15-20%,true,false,surrogate,ig_enhancer_hijack,high,PMID:9596662,multiple myeloma; t(11;14); cyclin D1 overexpression; venetoclax-sensitive subset
+MM,NSD2-IGH,IGH,Ig locus,NSD2,KMT/HMTase,~15%,true,true,surrogate,ig_enhancer_hijack,high,PMID:9520447,t(4;14)(p16;q32); NSD2=WHSC1/MMSET + FGFR3 dysregulation; high-risk
+MM,FGFR3-IGH,IGH,Ig locus,FGFR3,RTK,~15%,true,true,surrogate,ig_enhancer_hijack,high,PMID:9520447,co-deregulated with NSD2 in t(4;14); FGFR3 overexpression
+MM,MAF-IGH,IGH,Ig locus,MAF,bZIP(MAF),~5%,true,true,surrogate,ig_enhancer_hijack,high,PMID:9989715,t(14;16)(q32;q23); c-MAF overexpression; high-risk
+MM,CCND3-IGH,IGH,Ig locus,CCND3,cyclin,rare,true,true,surrogate,ig_enhancer_hijack,medium,PMID:11290608,t(6;14)(p21;q32); cyclin D3 overexpression
+MM,MAFB-IGH,IGH,Ig locus,MAFB,bZIP(MAF),rare,true,true,surrogate,ig_enhancer_hijack,medium,PMID:11090077,t(14;20)(q32;q12); MAFB overexpression; high-risk
+CLL,(none),,,,,,false,false,no,other,high,,"CLL: del13q14, trisomy 12, del11q(ATM), del17p(TP53), IGHV mutation status; not fusion-driven"
+MDS,(none),,,,,,false,false,no,other,high,,"MDS: del5q/-7/del20q, SF3B1/TET2/ASXL1/TP53 mutations; not fusion-driven (rare exceptions)"
+MPN,(none),,,,,,false,false,no,other,high,,"MPN (PV/ET/PMF): JAK2 V617F, CALR, or MPL driver mutations; not fusion-driven"
+CTCL,(none),,,,,,false,false,no,other,high,,"cutaneous T-cell lymphoma (MF/Sezary): complex CNAs, no defining recurrent fusion"
+HCL,(none),,,,,,false,false,no,other,high,,hairy cell leukemia: BRAF V600E point mutation; not a fusion
+NUTM,BRD4-NUTM1,BRD4,BET,NUTM1,NUT,~70%,true,true,yes,fusion_transcript,high,PMID:12543779,NUT carcinoma; t(15;19); most common partner; BET-inhibitor target
+NUTM,BRD3-NUTM1,BRD3,BET,NUTM1,NUT,~15%,true,true,yes,fusion_transcript,high,PMID:19318580,second most common NUT carcinoma fusion
+NUTM,NSD3-NUTM1,NSD3,KMT/HMTase,NUTM1,NUT,~10%,true,true,yes,fusion_transcript,high,PMID:26057308,NSD3=WHSC1L1; NUT carcinoma variant
+NUTM,ZNF532-NUTM1,ZNF532,,NUTM1,NUT,rare,true,true,yes,fusion_transcript,medium,PMID:29162909,rare NUT carcinoma partner
+ADCC,MYB-NFIB,MYB,MYB,NFIB,NFI,~60%,true,true,yes,fusion_transcript,high,PMID:19841262,adenoid cystic carcinoma; t(6;9)(q22-23;p23-24)
+ADCC,MYBL1-NFIB,MYBL1,MYB,NFIB,NFI,subset,true,true,yes,fusion_transcript,high,PMID:26851182,MYBL1-NFIB alternative in MYB-negative ACC; same MYB-pathway activation
+ACINIC,HTN3-MSANTD3,HTN3,,MSANTD3,,subset,true,true,yes,fusion_transcript,medium,PMID:30664692,acinic cell carcinoma (salivary) recurrent fusion; t(4;11)
+ACINIC,(none),,,,,,false,false,surrogate,enhancer_hijack,medium,PMID:30664692,secretory acinic / mammary analogue overlap; many acinic cell carcinomas show NR4A3 enhancer hijack overexpression rather than a clean chimera
+THCA,CCDC6-RET,CCDC6,,RET,RTK,subset,false,false,yes,fusion_transcript,high,PMID:1690453,papillary thyroid carcinoma RET/PTC1; CCDC6=H4; RET-inhibitor target; radiation-associated
+THCA,NCOA4-RET,NCOA4,NR coactivator,RET,RTK,subset,false,false,yes,fusion_transcript,high,PMID:8183555,RET/PTC3; NCOA4=ELE1/ARA70; common in radiation-induced PTC
+THCA,PAX8-PPARG,PAX8,PAX,PPARG,nuclear receptor,subset,false,false,yes,fusion_transcript,high,PMID:10866930,follicular thyroid carcinoma (and follicular-variant PTC); t(2;3)(q13;p25)
+THCA,ETV6-NTRK3,ETV6,ETS,NTRK3,RTK,minority,false,false,yes,fusion_transcript,medium,PMID:24613932,NTRK-rearranged PTC; TRK-inhibitor target
+THCA,STRN-ALK,STRN,,ALK,RTK,rare,false,false,surrogate,fusion_transcript,medium,PMID:24613932,ALK-rearranged thyroid carcinoma subset
+THCA,(none),,,,,,false,false,no,other,high,,"most PTC driven by BRAF V600E point mutation, not a fusion; fusions enrich in young/radiation cases"
+LUAD,EML4-ALK,EML4,,ALK,RTK,~4-5%,false,false,yes,fusion_transcript,high,PMID:17625570,NSCLC; inv(2)(p21p23); ALK-TKI responsive; variant 1/3 common; intronic breakpoints
+LUAD,CD74-ROS1,CD74,,ROS1,RTK,~1-2%,false,false,yes,fusion_transcript,high,PMID:22327623,ROS1-rearranged NSCLC; crizotinib/entrectinib target
+LUAD,EZR-ROS1,EZR,,ROS1,RTK,minority,false,false,yes,fusion_transcript,medium,PMID:22327623,ROS1 partner in NSCLC
+LUAD,SLC34A2-ROS1,SLC34A2,SLC,ROS1,RTK,minority,false,false,yes,fusion_transcript,medium,PMID:17625570,ROS1 partner in NSCLC
+LUAD,KIF5B-RET,KIF5B,,RET,RTK,~1-2%,false,false,yes,fusion_transcript,high,PMID:22327623,RET-rearranged NSCLC; selpercatinib/pralsetinib target
+LUAD,CCDC6-RET,CCDC6,,RET,RTK,minority,false,false,yes,fusion_transcript,medium,PMID:22327623,RET partner in NSCLC
+LUAD,CD74-NRG1,CD74,,NRG1,growth factor,rare,false,false,yes,fusion_transcript,medium,PMID:24469108,NRG1-rearranged (often invasive mucinous adenocarcinoma); HER3 pathway; zenocutuzumab target
+LUAD,SLC3A2-NRG1,SLC3A2,SLC,NRG1,growth factor,rare,false,false,yes,fusion_transcript,low,PMID:34743207,NRG1 partner
+LUAD,NTRK,,,NTRK1,RTK,rare,false,false,yes,fusion_transcript,medium,PMID:24162815,"NTRK1/3-rearranged NSCLC (rare); multiple 5' partners (e.g. MPRIP, TPM3, SQSTM1); TRK-inhibitor target"
+PRAD,TMPRSS2-ERG,TMPRSS2,,ERG,ETS,~50%,false,false,surrogate,promoter_swap,high,PMID:16254181,prostate cancer; androgen-driven TMPRSS2 promoter drives ERG; intrachromosomal del 21q22; ERG IHC surrogate
+PRAD,SLC45A3-ERG,SLC45A3,SLC,ERG,ETS,minority,false,false,surrogate,promoter_swap,medium,PMID:19015641,androgen-regulated SLC45A3 (prostein) promoter drives ERG
+PRAD,TMPRSS2-ETV1,TMPRSS2,,ETV1,ETS,minority,false,false,surrogate,promoter_swap,medium,PMID:16254181,ETV1 alternative ETS partner; ETV1 has additional 5' partners
+PRAD,TMPRSS2-ETV4,TMPRSS2,,ETV4,ETS,rare,false,false,surrogate,promoter_swap,medium,PMID:16518403,rarer ETS fusion
+PRAD,TMPRSS2-ETV5,TMPRSS2,,ETV5,ETS,rare,false,false,surrogate,promoter_swap,low,PMID:17486278,rarest ETS fusion
+GBM,FGFR3-TACC3,FGFR3,RTK,TACC3,TACC,~3%,false,false,yes,fusion_transcript,high,PMID:22837387,glioblastoma; tandem dup 4p16; FGFR-inhibitor target; tandem-dup can be missed by some callers
+GBM,(none),,,,,,false,false,no,other,high,,"most GBM driven by EGFR amp/EGFRvIII, +7/-10, CDKN2A loss, TERT promoter; not a defining fusion"
+LGG,KIAA1549-BRAF,KIAA1549,,BRAF,,~70%,true,true,yes,fusion_transcript,high,PMID:18974108,pilocytic astrocytoma; tandem dup 7q34; MAPK activation; MEK-inhibitor sensitive
+LGG,FGFR3-TACC3,FGFR3,RTK,TACC3,TACC,subset,false,false,yes,fusion_transcript,medium,PMID:22837387,subset of diffuse gliomas; FGFR target
+LGG,(none),,,,,,false,false,no,other,high,,diffuse adult LGG driven by IDH1/2 mutation +/- 1p19q codeletion or ATRX/TP53; not fusion-defined
+CHOL,FGFR2-BICC1,FGFR2,RTK,BICC1,,subset,false,false,yes,fusion_transcript,high,PMID:23558953,intrahepatic cholangiocarcinoma; FGFR2 fusions (~10-15% iCCA); FGFR-inhibitor (pemigatinib) target; promiscuous 3' partners
+CHOL,FGFR2-AHCYL1,FGFR2,RTK,AHCYL1,,subset,false,false,yes,fusion_transcript,medium,PMID:24122810,recurrent FGFR2 3' partner in iCCA
+MTC,(none),,,,,,false,false,no,other,high,,medullary thyroid carcinoma: RET germline/somatic POINT mutations (M918T etc.) or RAS; NOT a fusion
+NEC_MERKEL,(none),,,,,,false,false,no,other,high,,Merkel cell carcinoma: MCPyV clonal integration (virus-positive) or UV-mutation (virus-negative); not a chromosomal fusion
+SCLC,(none),,,,,,false,false,no,other,high,,"small cell lung cancer: near-universal TP53 + RB1 loss, MYC family amp; no recurrent fusion"
+NET_PANCREAS,(none),,,,,,false,false,no,other,high,,"pancreatic neuroendocrine tumor: MEN1, DAXX/ATRX, mTOR-pathway mutations; not fusion-driven"
+NET_MIDGUT,(none),,,,,,false,false,no,other,high,,"midgut/small-bowel NET: CDKN1B mutation, chr18 LOH; not fusion-driven"
+LIHC,DNAJB1-PRKACA,DNAJB1,,PRKACA,non-RTK kinase,~100% of FLC,true,true,yes,fusion_transcript,high,PMID:24578576,"fibrolamellar HCC subtype; ~400kb deletion chr19 fuses DNAJB1 to PRKACA; defining for FLC (young, non-cirrhotic)"
+LIHC,(none),,,,,,false,false,no,other,high,,"conventional HCC: TERT promoter, CTNNB1, TP53; not fusion-driven"
+BRCA,ETV6-NTRK3,ETV6,ETS,NTRK3,RTK,~100% of secretory,true,false,yes,fusion_transcript,high,PMID:12244301,secretory carcinoma of breast (MASC analogue); t(12;15); rare subtype but defining; TRK-inhibitor target
+BRCA,(none),,,,,,false,false,no,other,high,,common breast cancer (luminal/HER2/basal): driven by ER/HER2/CN events; no defining fusion (secretory carcinoma excepted)
+SARC_RMS_ARMS,PAX-FOXO/alt,PAX3,PAX,NCOA1,NR coactivator,rare,true,true,yes,fusion_transcript,low,PMID:19953635,PAX3 alternative 3' partner (NCOA1); fusion-positive ARMS variant
+SARC_RMS_ARMS,PAX-FOXO/alt,PAX3,PAX,NCOA2,NR coactivator,rare,true,true,yes,fusion_transcript,low,PMID:19953635,PAX3 alternative 3' partner (NCOA2)
+SARC_RMS_ARMS,PAX-FOXO/alt,PAX3,PAX,FOXO4,FOX,rare,true,true,yes,fusion_transcript,low,,rare PAX3-FOXO4 (AFX) variant; still a PAX->FOX fusion
+SARC_RMS_SSRMS,FET-TFCP2,EWSR1,FET,TFCP2,CP2 TF,subset,true,true,yes,fusion_transcript,medium,PMID:30138265,"sclerosing/spindle-cell RMS, often intraosseous; FET-TFCP2"
+SARC_RMS_SSRMS,FET-TFCP2,FUS,FET,TFCP2,CP2 TF,minority,true,true,yes,fusion_transcript,low,PMID:38114270,FUS alternative to EWSR1 in spindle/sclerosing RMS
+SARC_RMS_SSRMS,NCOA2-fusion,SRF,MADS-box TF,NCOA2,NR coactivator,rare,true,true,yes,fusion_transcript,low,PMID:23463663,infantile spindle cell RMS variant (SRF-NCOA2)
+SARC_CIC,CIC-DUX4,CIC,HMG-box (capicua),DUX4,homeobox,~95%,true,true,surrogate,fusion_transcript,medium,PMID:16717057,CIC-rearranged sarcoma; t(4;19)/t(10;19); DUX4 D4Z4 macrosatellite is hard to call by RNA-seq -> ETV4/PEA3 + WT1 overexpression surrogate
+SARC_CIC,CIC-FOXO4,CIC,HMG-box (capicua),FOXO4,FOX,minority,true,true,yes,fusion_transcript,low,PMID:25007147,t(X;19) variant
+SARC_CIC,CIC-NUTM1,CIC,HMG-box (capicua),NUTM1,NUT,rare,true,true,yes,fusion_transcript,low,PMID:38851744,rare CIC 3' partner
+SARC_BCOR,BCOR-CCNB3,BCOR,PRC2/Polycomb,CCNB3,cyclin,majority,true,true,yes,fusion_transcript,medium,PMID:22387997,"BCOR-rearranged sarcoma; Xp11 paracentric inversion (cryptic by FISH, RNA-seq detectable)"
+SARC_BCOR,ZC3H7B-BCOR,ZC3H7B,,BCOR,PRC2/Polycomb,minority,true,false,yes,fusion_transcript,low,PMID:29192652,also occurs in high-grade endometrial stromal sarcoma (not entity-specific)
+SARC_BCOR,BCOR-MAML3,BCOR,PRC2/Polycomb,MAML3,Mastermind,rare,true,true,yes,fusion_transcript,low,,variant BCOR fusion
+SARC_BCOR,(none-ITD),,,,,subset,true,false,no,other,medium,,"infantile primitive myxoid mesenchymal tumor / undifferentiated round cell: BCOR internal tandem duplication (ITD), not a fusion"
+SARC_MYOEP,EWSR1-POU5F1,EWSR1,FET,POU5F1,POU-homeobox,subset,true,true,yes,fusion_transcript,medium,PMID:20815032,soft-tissue myoepithelial carcinoma; POU5F1=OCT4 pluripotency factor
+SARC_MYOEP,FUS-POU5F1,FUS,FET,POU5F1,POU-homeobox,minority,true,true,yes,fusion_transcript,low,PMID:25066216,FET-family alternative (FUS)
+SARC_MYOEP,EWSR1-PBX1,EWSR1,FET,PBX1,homeobox(TALE),subset,true,true,yes,fusion_transcript,low,PMID:31994243,myoepithelioma EWSR1 partner
+SARC_MYOEP,EWSR1-ZNF444,EWSR1,FET,ZNF444,,rare,true,true,yes,fusion_transcript,low,PMID:19760602,rare myoepithelial partner
+SARC_SMARCA4,(none),,,,,,false,false,no,other,high,,"SMARCA4/BRG1 deficiency (deletion/truncating mutation), not a fusion"
+ALCL,ALK_rearrangement,NPM1,nucleophosmin,ALK,RTK,~majority of ALK+ ALCL,true,false,yes,fusion_transcript,high,PMID:8122112,ALK+ ALCL; t(2;5)(p23;q35); NPM1-ALK most common ALK partner (also TPM3/ATIC/TFG); ALK-inhibitor target. ALK- ALCL is DUSP22/TP63-rearranged.

--- a/cancerdata/fusions.py
+++ b/cancerdata/fusions.py
@@ -1,0 +1,139 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Characteristic gene fusions / oncogenic translocations per cancer type.
+
+The curated ``cancer-fusions.csv`` reference: one row per concrete 5'/3' gene
+pairing, with the partner protein families annotated (FET, ETS, PAX, FOX, MiT/TFE,
+RTK, Ig locus, …), an ``is_defining`` flag for the characteristic lesion of the
+entity, and the stronger ``pathognomonic`` flag for pairs that map to a single
+entity. This module is the read + query surface: per-type lookup, reverse lookup
+(which types carry a fusion / partner / partner family), and partner sets.
+"""
+
+from __future__ import annotations
+
+from .cancer_types import cancer_type_descendants, resolve_cancer_type
+from .load_dataset import get_data
+
+
+def cancer_fusions_df():
+    """The full curated fusion table (defensive copy).
+
+    Columns: ``cancer_code``, ``fusion_family``, ``gene_5prime``,
+    ``gene_5prime_family``, ``gene_3prime``, ``gene_3prime_family``, ``frequency``,
+    ``is_defining``, ``pathognomonic``, ``rnaseq_detectable``, ``mechanism``,
+    ``confidence``, ``pmid``, ``notes``. Fusion-negative entities carry a single
+    ``fusion_family="(none)"`` row naming the real driver.
+    """
+    return get_data("cancer-fusions").copy()
+
+
+def _truthy(series):
+    # is_defining / pathognomonic load as bool, but compare via lowercased string
+    # so the filter is robust whether the column is bool or str.
+    return series.astype(str).str.lower() == "true"
+
+
+def cancer_fusions(
+    cancer_type=None, *, defining_only=False, pathognomonic_only=False, include_subtypes=False
+):
+    """Fusion rows for one cancer type (alias-resolved), or the whole table when
+    ``cancer_type`` is None.
+
+    ``defining_only`` / ``pathognomonic_only`` filter to the characteristic /
+    diagnostic rows. ``include_subtypes`` also pulls the fusions of every code in
+    the cancer type's subtree (via :func:`cancer_type_descendants`) — e.g. the
+    union over an ``SARC_RMS`` parent once its subtypes are parented under it.
+    """
+    df = cancer_fusions_df()
+    if cancer_type is not None:
+        code = resolve_cancer_type(cancer_type, strict=False) or cancer_type
+        codes = {code}
+        if include_subtypes:
+            codes |= set(cancer_type_descendants(code))
+        df = df[df["cancer_code"].astype(str).isin(codes)]
+    if defining_only:
+        df = df[_truthy(df["is_defining"])]
+    if pathognomonic_only:
+        df = df[_truthy(df["pathognomonic"])]
+    return df.reset_index(drop=True)
+
+
+def fusion_partners(gene, *, side=None):
+    """The set of fusion partners of ``gene`` in the table.
+
+    ``side=None`` returns partners on either end; ``side="5prime"`` the observed
+    3' partners when ``gene`` is 5'; ``side="3prime"`` the observed 5' partners.
+    """
+    if side not in (None, "5prime", "3prime"):
+        raise ValueError("side must be None, '5prime', or '3prime'")
+    g = str(gene).strip().upper()
+    df = cancer_fusions_df()
+    out = set()
+    if side in (None, "5prime"):
+        out |= set(df.loc[df["gene_5prime"].astype(str).str.upper() == g, "gene_3prime"])
+    if side in (None, "3prime"):
+        out |= set(df.loc[df["gene_3prime"].astype(str).str.upper() == g, "gene_5prime"])
+    return {p for p in out if isinstance(p, str) and p.strip()}
+
+
+def cancer_types_with_fusion(
+    fusion=None, *, partner=None, partner_family=None, defining_only=False, as_rows=False
+):
+    """Reverse fusion lookup — the inverse of :func:`cancer_fusions`.
+
+    Pass exactly one of:
+    - ``fusion="EWSR1-FLI1"`` — a directional ``5'-3'`` string (``::`` also accepted);
+    - ``partner="EWSR1"`` — a partner gene on either end;
+    - ``partner_family="FET"`` — a partner-family tag.
+
+    ``defining_only`` restricts to is_defining rows. Returns sorted cancer codes,
+    or the matching rows when ``as_rows=True``.
+    """
+    given = [x for x in (fusion, partner, partner_family) if x is not None]
+    if len(given) != 1:
+        raise ValueError("pass exactly one of fusion=, partner=, or partner_family=")
+    df = cancer_fusions(defining_only=defining_only)
+    g5 = df["gene_5prime"].astype(str).str.upper()
+    g3 = df["gene_3prime"].astype(str).str.upper()
+    if fusion is not None:
+        parts = str(fusion).upper().replace("::", "-").split("-")
+        if len(parts) != 2:
+            raise ValueError(f"fusion must look like '5GENE-3GENE'; got {fusion!r}")
+        a, b = (p.strip() for p in parts)
+        mask = (g5 == a) & (g3 == b)
+    elif partner is not None:
+        p = str(partner).strip().upper()
+        mask = (g5 == p) | (g3 == p)
+    else:
+        fam = str(partner_family).strip().upper()
+        f5 = df["gene_5prime_family"].astype(str).str.upper()
+        f3 = df["gene_3prime_family"].astype(str).str.upper()
+        mask = (f5 == fam) | (f3 == fam)
+    hits = df[mask]
+    if as_rows:
+        return hits.reset_index(drop=True)
+    return sorted({str(c) for c in hits["cancer_code"] if str(c).strip()})
+
+
+def protein_family(gene):
+    """Protein/gene family of a fusion partner (EWSR1→FET, FLI1→ETS, PAX3→PAX,
+    FOXO1→FOX, ALK→RTK), or ``None`` if the gene has no family annotation."""
+    g = str(gene).strip().upper()
+    df = cancer_fusions_df()
+    for col, fam in (("gene_5prime", "gene_5prime_family"), ("gene_3prime", "gene_3prime_family")):
+        hit = df.loc[df[col].astype(str).str.upper() == g, fam]
+        for v in hit:
+            if isinstance(v, str) and v.strip():
+                return v
+    return None

--- a/cancerdata/fusions.py
+++ b/cancerdata/fusions.py
@@ -44,6 +44,16 @@ def _truthy(series):
     return series.astype(str).str.lower() == "true"
 
 
+def _upper(series):
+    """Uppercased view of a gene/family column with NaN preserved as non-matching.
+
+    The fusion-negative ``"(none)"`` rows carry NaN gene names; ``.str.upper()``
+    keeps those NaN (so ``NaN == "X"`` is False) instead of ``.astype(str)``
+    turning them into the literal string ``"NAN"`` that a query could match.
+    """
+    return series.str.upper()
+
+
 def cancer_fusions(
     cancer_type=None, *, defining_only=False, pathognomonic_only=False, include_subtypes=False
 ):
@@ -81,9 +91,9 @@ def fusion_partners(gene, *, side=None):
     df = cancer_fusions_df()
     out = set()
     if side in (None, "5prime"):
-        out |= set(df.loc[df["gene_5prime"].astype(str).str.upper() == g, "gene_3prime"])
+        out |= set(df.loc[_upper(df["gene_5prime"]) == g, "gene_3prime"])
     if side in (None, "3prime"):
-        out |= set(df.loc[df["gene_3prime"].astype(str).str.upper() == g, "gene_5prime"])
+        out |= set(df.loc[_upper(df["gene_3prime"]) == g, "gene_5prime"])
     return {p for p in out if isinstance(p, str) and p.strip()}
 
 
@@ -104,8 +114,8 @@ def cancer_types_with_fusion(
     if len(given) != 1:
         raise ValueError("pass exactly one of fusion=, partner=, or partner_family=")
     df = cancer_fusions(defining_only=defining_only)
-    g5 = df["gene_5prime"].astype(str).str.upper()
-    g3 = df["gene_3prime"].astype(str).str.upper()
+    g5 = _upper(df["gene_5prime"])
+    g3 = _upper(df["gene_3prime"])
     if fusion is not None:
         parts = str(fusion).upper().replace("::", "-").split("-")
         if len(parts) != 2:
@@ -117,9 +127,10 @@ def cancer_types_with_fusion(
         mask = (g5 == p) | (g3 == p)
     else:
         fam = str(partner_family).strip().upper()
-        f5 = df["gene_5prime_family"].astype(str).str.upper()
-        f3 = df["gene_3prime_family"].astype(str).str.upper()
+        f5 = _upper(df["gene_5prime_family"])
+        f3 = _upper(df["gene_3prime_family"])
         mask = (f5 == fam) | (f3 == fam)
+    mask = mask.fillna(False)
     hits = df[mask]
     if as_rows:
         return hits.reset_index(drop=True)
@@ -132,7 +143,7 @@ def protein_family(gene):
     g = str(gene).strip().upper()
     df = cancer_fusions_df()
     for col, fam in (("gene_5prime", "gene_5prime_family"), ("gene_3prime", "gene_3prime_family")):
-        hit = df.loc[df[col].astype(str).str.upper() == g, fam]
+        hit = df.loc[_upper(df[col]) == g, fam]
         for v in hit:
             if isinstance(v, str) and v.strip():
                 return v

--- a/tests/test_fusions.py
+++ b/tests/test_fusions.py
@@ -1,0 +1,74 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Driver fusions per cancer type + reverse lookups (#27, O4)."""
+
+import pytest
+
+from cancerdata import (
+    cancer_fusions,
+    cancer_fusions_df,
+    cancer_type_registry,
+    cancer_types_with_fusion,
+    fusion_partners,
+    protein_family,
+)
+
+
+def test_fusions_for_subtype():
+    # The headline example: the alveolar-RMS subtype's PAX-FOXO1 fusion.
+    arms = cancer_fusions("SARC_RMS_ARMS")
+    pairs = set(zip(arms["gene_5prime"], arms["gene_3prime"]))
+    assert ("PAX3", "FOXO1") in pairs
+    assert ("PAX7", "FOXO1") in pairs
+
+
+def test_defining_only_filter():
+    ews = cancer_fusions("SARC_EWS", defining_only=True)
+    assert (ews["is_defining"].astype(str).str.lower() == "true").all()
+    assert "EWSR1" in set(ews["gene_5prime"])
+
+
+def test_reverse_lookup_by_fusion():
+    assert cancer_types_with_fusion("EWSR1-FLI1") == ["SARC_EWS"]
+    # `::` separator also accepted.
+    assert cancer_types_with_fusion("EWSR1::FLI1") == ["SARC_EWS"]
+
+
+def test_reverse_lookup_by_partner_family():
+    fet = cancer_types_with_fusion(partner_family="FET")
+    assert "SARC_EWS" in fet and "SARC_DSRCT" in fet
+
+
+def test_reverse_lookup_requires_exactly_one_arg():
+    with pytest.raises(ValueError, match="exactly one"):
+        cancer_types_with_fusion("EWSR1-FLI1", partner="EWSR1")
+    with pytest.raises(ValueError, match="exactly one"):
+        cancer_types_with_fusion()
+
+
+def test_fusion_partners_promiscuous():
+    partners = fusion_partners("EWSR1")
+    assert {"FLI1", "ERG"} <= partners
+
+
+def test_fusion_partners_bad_side():
+    with pytest.raises(ValueError, match="side must be"):
+        fusion_partners("EWSR1", side="middle")
+
+
+def test_protein_family():
+    assert protein_family("PAX3") == "PAX"
+    assert protein_family("FLI1") == "ETS"
+    assert protein_family("NOT_A_GENE") is None
+
+
+def test_every_fusion_code_is_a_registry_code():
+    # A fusion row must never reference a cancer code that doesn't exist.
+    fusion_codes = set(cancer_fusions_df()["cancer_code"])
+    codes = set(cancer_type_registry()["code"])
+    missing = sorted(fusion_codes - codes)
+    assert not missing, f"fusion cancer_codes not in the registry: {missing}"

--- a/tests/test_fusions.py
+++ b/tests/test_fusions.py
@@ -66,6 +66,16 @@ def test_protein_family():
     assert protein_family("NOT_A_GENE") is None
 
 
+def test_nan_query_does_not_match_fusion_negative_rows():
+    # The "(none)" fusion-negative rows have NaN gene names; a 'NAN'/'nan' query
+    # must NOT match them (regression: .astype(str) turned NaN into "NAN").
+    assert cancer_types_with_fusion(partner="NAN") == []
+    assert cancer_types_with_fusion(partner="nan") == []
+    assert cancer_types_with_fusion("NAN-NAN") == []
+    assert fusion_partners("NAN") == set()
+    assert protein_family("NAN") is None
+
+
 def test_every_fusion_code_is_a_registry_code():
     # A fusion row must never reference a cancer code that doesn't exist.
     fusion_codes = set(cancer_fusions_df()["cancer_code"])


### PR DESCRIPTION
## Summary
Fourth ontology step (#27) — and the last of the navigation-critical set. Adds the **characteristic driver fusions** layer: *"the driver fusions of the SARC_RMS subtypes"* and the reverse (*"which cancers carry EWSR1-FLI1 / a FET-family fusion"*).

## What changed
New `cancerdata/fusions.py` over **`cancer-fusions.csv`** (171 rows; 5'/3' partners + their protein families, `is_defining`/`pathognomonic` flags, mechanism, frequency):
- **`cancer_fusions(code, *, defining_only, pathognomonic_only, include_subtypes)`** — `cancer_fusions('SARC_RMS_ARMS')` → PAX3-FOXO1, PAX7-FOXO1.
- **`cancer_types_with_fusion(fusion=|partner=|partner_family=)`** — reverse lookup: `'EWSR1-FLI1'` → `[SARC_EWS]`; `partner_family='FET'` → the FET-driven sarcomas (`::` separator accepted).
- **`fusion_partners(gene, *, side=)`** — promiscuous-partner sets (`EWSR1` → FLI1/ERG/ATF1/…).
- **`protein_family(gene)`** — `PAX3`→PAX, `FLI1`→ETS, `ALK`→RTK.

## Consistency guard
A test asserts **every fusion `cancer_code` is a real registry code** (0 orphans today, thanks to O1).

## Curation note (same shape as O3/NET)
The RMS subtypes (`SARC_RMS_ARMS/ERMS/PRMS/SSRMS`) are parented under `SARC`, **not** under `SARC_RMS`, so `cancer_fusions('SARC_RMS', include_subtypes=True)` doesn't roll them up via the tree yet. `include_subtypes` is wired to `cancer_type_descendants`, so it lights up automatically once the SARC_RMS sub-hierarchy is curated upstream (pirlygenes) and re-synced. **Per-subtype queries work fully today.** This + the NET-umbrella gap (O3) are the two registry-hierarchy curation items to take upstream.

## Tests
`test_fusions.py`: per-subtype fusions, defining-only filter, reverse lookups (fusion / partner / family), exactly-one-arg guard, partner sets, protein_family, and fusion-code→registry integrity. Full suite 165 pass (+9); ruff clean.

Addresses #27 (O4).