### PR TITLE
Restore exact CTA schema coverage (post-#32 review)

### DIFF
--- a/tests/test_base_layer.py
+++ b/tests/test_base_layer.py
@@ -23,6 +23,9 @@ _CONSUMERS = {"pirlygenes", "tsarina", "hitlist", "trufflepig"}
 
 
 def _imported_top_level_modules(path):
+    # Static (AST) scan of `import`/`from ... import` statements. A dynamic import
+    # (importlib.import_module("pirlygenes"), __import__(...)) would evade this —
+    # acceptable for a guard, since a static import is the realistic regression.
     tree = ast.parse(path.read_text(), filename=str(path))
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):

--- a/tests/test_cta_table_integrity.py
+++ b/tests/test_cta_table_integrity.py
@@ -20,17 +20,60 @@ from cancerdata.cta import CTA_unfiltered_gene_names
 
 _CSV = Path(__file__).resolve().parents[1] / "cancerdata" / "data" / "cancer-testis-antigens.csv"
 
-# The HPA-evidence columns that must be present for the restriction synthesis.
-_REQUIRED_COLUMNS = {
+# The exact shipped CTA schema (HPA-only projection, in column order). This is the
+# stable contract downstream consumers read against — an exact, order-sensitive
+# check so an added/dropped/reordered column is caught, not just missing required
+# ones. tsarina's mass-spec columns (ms_restriction/ms_pmids/...) are deliberately
+# absent: the ownership seam keeps the MS/peptide layer downstream.
+CTA_COLUMNS = [
     "Symbol",
+    "Aliases",
+    "Full_Name",
+    "Function",
     "Ensembl_Gene_ID",
+    "source_databases",
+    "protein_reproductive",
+    "protein_thymus",
+    "protein_reliability",
+    "rna_reproductive",
+    "rna_thymus",
+    "protein_strict_expression",
+    "rna_reproductive_frac",
+    "rna_reproductive_and_thymus_frac",
+    "rna_deflated_reproductive_frac",
+    "rna_deflated_reproductive_and_thymus_frac",
+    "Canonical_Transcript_ID",
+    "biotype",
+    "rna_80_pct_filter",
+    "rna_90_pct_filter",
+    "rna_95_pct_filter",
+    "rna_97_pct_filter",
+    "rna_98_pct_filter",
+    "rna_99_pct_filter",
     "passes_filters",
+    "rna_max_ntpm",
     "never_expressed",
+    "rna_testis_ntpm",
+    "rna_ovary_ntpm",
+    "rna_placenta_ntpm",
+    "rna_max_somatic_tissue",
+    "rna_max_somatic_ntpm",
+    "rna_somatic_detected_count",
+    "rna_brain_max_ntpm",
+    "rna_heart_max_ntpm",
+    "rna_lung_max_ntpm",
+    "rna_liver_max_ntpm",
+    "rna_pancreas_max_ntpm",
     "protein_restriction",
+    "protein_testis",
+    "protein_ovary",
+    "protein_placenta",
     "rna_restriction",
+    "rna_restriction_level",
     "restriction",
     "restriction_confidence",
-}
+    "safety_flags",
+]
 
 # tsarina's mass-spec evidence columns must NOT ship in cancerdata's HPA-only table
 # (the ownership seam: HPA-only definition here, MS/peptide downstream).
@@ -40,9 +83,8 @@ _MASS_SPEC_COLUMNS = {"ms_restriction", "ms_pmids", "ms_healthy_somatic_tissues"
 _CURATED_GENES = {"SSX4B", "MAGEA2B", "GAGE10", "CT45A5", "CGB1", "PSG2", "CSH1"}
 
 
-def test_required_columns_present():
-    cols = set(pd.read_csv(_CSV, nrows=0).columns)
-    assert cols >= _REQUIRED_COLUMNS
+def test_schema_matches_contract():
+    assert list(pd.read_csv(_CSV, nrows=0).columns) == CTA_COLUMNS
 
 
 def test_no_mass_spec_columns():


### PR DESCRIPTION
## Summary
Follow-up from reviewing #32. That PR retired the CTA sync script and moved its guards into `test_cta_table_integrity.py`, but in doing so **downgraded the schema check** from exact (`== CANONICAL_COLUMNS`, the full 47-column order-sensitive contract) to a required-**subset** check (`cols >= 8 required`). So an unexpectedly **added, dropped, or reordered** column outside the 8 required ones would pass silently — a real coverage regression for the stable schema downstream consumers read against.

## Fix
- Re-inline the full **`CTA_COLUMNS`** (47, verified byte-identical to the live header) and assert exact order-sensitive equality in `test_schema_matches_contract` — the same pattern the sibling `test_cancer_type_registry.py` already uses. (No dependency on the deleted script; the contract now lives in the test.)
- One-line note in `test_base_layer.py` flagging the AST guard's known blind spot (dynamic `importlib.import_module` evades a static scan).

## Verification
Negative check confirms the exact assertion now catches an added column. Full suite **173 pass**; ruff clean. The no-MS-columns / curated-genes / no-dup-ids guards are unchanged.

Closes the one coverage regression found in the #32 post-merge review.