### PR TITLE
Unified data catalog over the bundle + HPA backends (#35 D-cat)

### DIFF
--- a/cancerdata/catalog.py
+++ b/cancerdata/catalog.py
@@ -63,13 +63,20 @@ class Dataset:
 
 def datasets() -> list[Dataset]:
     """Every managed dataset across both backends (bundle members + HPA sources)."""
+    bundle_names = list(data_bundle.DOWNLOADABLE_PATHS)
+    hpa_names = list(reference_data.REFERENCE_SOURCES)
+    collisions = set(bundle_names) & set(hpa_names)
+    if collisions:
+        # The catalog routes by name; a name in both backends would silently
+        # shadow one of them. Fail loudly instead of mis-routing.
+        raise RuntimeError(f"dataset name collision across backends: {sorted(collisions)}")
     out = [
         Dataset(name, _BUNDLE, _BUNDLE_DESCRIPTIONS.get(name, "expression bundle artifact"))
-        for name in data_bundle.DOWNLOADABLE_PATHS
+        for name in bundle_names
     ]
     out += [
-        Dataset(name, _HPA, spec["description"])
-        for name, spec in reference_data.REFERENCE_SOURCES.items()
+        Dataset(name, _HPA, reference_data.REFERENCE_SOURCES[name]["description"])
+        for name in hpa_names
     ]
     return out
 
@@ -116,20 +123,26 @@ def ensure(name: str) -> Path:
 
 
 def fetch(name: str = "all", *, force: bool = False) -> list[str]:
-    """Download dataset(s). ``name="all"`` materializes everything (the bundle is
-    fetched once, not once per member). Returns the dataset names fetched."""
+    """Materialize dataset(s), downloading what's missing. ``name="all"`` covers
+    everything (the bundle tarball is fetched once, not once per member).
+
+    Returns the dataset names that were **actually downloaded** — already-cached
+    datasets are skipped (unless ``force``) and not reported.
+    """
     targets = [d.name for d in datasets()] if name == "all" else [dataset(name).name]
-    fetched = []
+    downloaded = []
     # The bundle is one tarball — fetch it a single time if any member is targeted.
-    if any(dataset(n).kind == _BUNDLE for n in targets):
-        if force or not data_bundle.is_local():
-            data_bundle.fetch()
-        fetched += [n for n in targets if dataset(n).kind == _BUNDLE]
+    bundle_targets = [n for n in targets if dataset(n).kind == _BUNDLE]
+    if bundle_targets and (force or not data_bundle.is_local()):
+        data_bundle.fetch()
+        downloaded += bundle_targets
     for n in targets:
         if dataset(n).kind == _HPA:
+            already = reference_data.local_path(n).exists()
             reference_data.download(n, force=force)
-            fetched.append(n)
-    return fetched
+            if force or not already:
+                downloaded.append(n)
+    return downloaded
 
 
 def _size_bytes(p: Path | None) -> int:

--- a/cancerdata/catalog.py
+++ b/cancerdata/catalog.py
@@ -1,0 +1,161 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One catalog over every managed (fetchable) dataset.
+
+cancerdata holds two kinds of heavy/external data behind separate machinery: the
+version-pinned per-cohort **expression bundle** (:mod:`cancerdata.data_bundle`, a
+single GitHub-release tarball) and the **HPA** protein/RNA reference tables
+(:mod:`cancerdata.reference_data`, per-source downloads from proteinatlas.org).
+This module is the unified facade over both — one ``Dataset`` model and one
+fetch/cache/status API — so a caller (or the CLI) manages everything uniformly
+without knowing which backend a dataset lives in.
+
+    from cancerdata import catalog
+    catalog.datasets()                       # every managed dataset
+    catalog.status()                         # uniform present/size rows
+    catalog.ensure("hpa_normal_tissue")      # download if needed -> Path
+    catalog.ensure("cancer-reference-expression-percentiles")
+    catalog.fetch("all")                     # materialize everything
+
+The small curated tables (registry, TMB, fusions, …) ship in the wheel and need
+no management, so they are intentionally not in the catalog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import data_bundle, reference_data
+
+_BUNDLE = "bundle"
+_HPA = "hpa"
+
+#: Human-readable descriptions for the expression-bundle members.
+_BUNDLE_DESCRIPTIONS = {
+    "cancer-reference-expression": "per-cohort RNA-seq expression shards",
+    "cancer-reference-expression-representatives": "per-cohort medoid/exemplar samples",
+    "cancer-reference-expression-percentiles": "per-gene tail-weighted percentile vectors",
+    "pan-cancer-expression.csv": "pan-cancer HPA-tissue + TCGA expression matrix",
+    "hpa-cell-type-expression.csv": "HPA cell-type nTPM matrix",
+}
+
+
+@dataclass(frozen=True)
+class Dataset:
+    """A managed dataset: its ``name``, the backend ``kind`` (``"bundle"`` or
+    ``"hpa"``), and a one-line ``description``."""
+
+    name: str
+    kind: str
+    description: str
+
+
+def datasets() -> list[Dataset]:
+    """Every managed dataset across both backends (bundle members + HPA sources)."""
+    out = [
+        Dataset(name, _BUNDLE, _BUNDLE_DESCRIPTIONS.get(name, "expression bundle artifact"))
+        for name in data_bundle.DOWNLOADABLE_PATHS
+    ]
+    out += [
+        Dataset(name, _HPA, spec["description"])
+        for name, spec in reference_data.REFERENCE_SOURCES.items()
+    ]
+    return out
+
+
+def _by_name() -> dict[str, Dataset]:
+    return {d.name: d for d in datasets()}
+
+
+def dataset(name: str) -> Dataset:
+    """The :class:`Dataset` for ``name``; raises ``KeyError`` if unknown."""
+    try:
+        return _by_name()[name]
+    except KeyError:
+        avail = ", ".join(sorted(_by_name()))
+        raise KeyError(f"unknown dataset {name!r}; available: {avail}") from None
+
+
+def path(name: str) -> Path | None:
+    """The dataset's on-disk location if present in the cache, else ``None``
+    (never triggers a download)."""
+    d = dataset(name)
+    if d.kind == _HPA:
+        p = reference_data.local_path(name)
+        return p if p.exists() else None
+    return data_bundle.find(name)
+
+
+def ensure(name: str) -> Path:
+    """Local path to ``name``, downloading if absent. Returns the path.
+
+    HPA sources fetch per-file; a bundle member triggers the one-time tarball
+    download (all bundle members arrive together).
+    """
+    d = dataset(name)
+    if d.kind == _HPA:
+        return reference_data.ensure(name)
+    data_bundle.ensure_local()
+    resolved = data_bundle.find(name)
+    if resolved is None:
+        raise FileNotFoundError(
+            f"{name!r} missing from the expression bundle after fetch ({data_bundle.cache_dir()})"
+        )
+    return resolved
+
+
+def fetch(name: str = "all", *, force: bool = False) -> list[str]:
+    """Download dataset(s). ``name="all"`` materializes everything (the bundle is
+    fetched once, not once per member). Returns the dataset names fetched."""
+    targets = [d.name for d in datasets()] if name == "all" else [dataset(name).name]
+    fetched = []
+    # The bundle is one tarball — fetch it a single time if any member is targeted.
+    if any(dataset(n).kind == _BUNDLE for n in targets):
+        if force or not data_bundle.is_local():
+            data_bundle.fetch()
+        fetched += [n for n in targets if dataset(n).kind == _BUNDLE]
+    for n in targets:
+        if dataset(n).kind == _HPA:
+            reference_data.download(n, force=force)
+            fetched.append(n)
+    return fetched
+
+
+def _size_bytes(p: Path | None) -> int:
+    if p is None or not p.exists():
+        return 0
+    if p.is_dir():
+        return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+    return p.stat().st_size
+
+
+def status(name: str | None = None) -> list[dict]:
+    """Uniform status rows over the catalog: ``name``, ``kind``, ``present``,
+    ``path``, ``size_bytes``, ``description``. One dataset if ``name`` given."""
+    names = [dataset(name).name] if name is not None else [d.name for d in datasets()]
+    rows = []
+    for n in names:
+        d = dataset(n)
+        p = path(n)
+        rows.append(
+            {
+                "name": n,
+                "kind": d.kind,
+                "present": p is not None,
+                "path": str(p) if p is not None else None,
+                "size_bytes": _size_bytes(p),
+                "description": d.description,
+            }
+        )
+    return rows

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -87,3 +87,24 @@ def test_fetch_all_fetches_bundle_once_and_each_hpa(monkeypatch):
     assert calls["bundle_fetch"] == 1
     assert set(calls["hpa"]) == set(reference_data.REFERENCE_SOURCES)
     assert set(fetched) == {d.name for d in catalog.datasets()}
+
+
+def test_fetch_reports_only_actual_downloads(monkeypatch):
+    # Everything already cached + no force -> nothing is reported as downloaded.
+    monkeypatch.setattr(data_bundle, "is_local", lambda: True)
+    monkeypatch.setattr(data_bundle, "fetch", lambda *a, **k: pytest.fail("should not fetch"))
+
+    class _P:
+        def exists(self):
+            return True
+
+    monkeypatch.setattr(reference_data, "local_path", lambda n, *a, **k: _P())
+    monkeypatch.setattr(reference_data, "download", lambda n, *a, **k: None)
+    assert catalog.fetch("all") == []
+
+
+def test_datasets_disjoint_backends():
+    # The catalog routes by name; the two backends must never share a name.
+    bundle = set(data_bundle.DOWNLOADABLE_PATHS)
+    hpa = set(reference_data.REFERENCE_SOURCES)
+    assert bundle.isdisjoint(hpa)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,89 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unified data catalog over the bundle + HPA backends (#35, D-cat)."""
+
+import pytest
+
+from cancerdata import catalog, data_bundle, reference_data
+
+
+def test_datasets_span_both_backends():
+    ds = catalog.datasets()
+    kinds = {d.kind for d in ds}
+    assert kinds == {"bundle", "hpa"}
+    names = {d.name for d in ds}
+    assert set(data_bundle.DOWNLOADABLE_PATHS) <= names
+    assert set(reference_data.REFERENCE_SOURCES) <= names
+
+
+def test_dataset_lookup_and_unknown():
+    assert catalog.dataset("hpa_normal_tissue").kind == "hpa"
+    assert catalog.dataset("cancer-reference-expression-percentiles").kind == "bundle"
+    with pytest.raises(KeyError, match="unknown dataset"):
+        catalog.dataset("not_a_dataset")
+
+
+def test_status_uniform_and_absent(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / "bundle" / "vX"))
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path / "ref"))
+    rows = catalog.status()
+    assert {r["name"] for r in rows} == {d.name for d in catalog.datasets()}
+    assert all(
+        set(r) == {"name", "kind", "present", "path", "size_bytes", "description"} for r in rows
+    )
+    assert all(r["present"] is False and r["size_bytes"] == 0 for r in rows)
+
+
+def test_path_none_when_absent_then_present(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path / "ref"))
+    assert catalog.path("hpa_normal_tissue") is None
+    # Materialize the HPA file where reference_data expects it.
+    target = reference_data.local_path("hpa_normal_tissue")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("Gene\tTissue\n")
+    assert catalog.path("hpa_normal_tissue") == target
+    assert catalog.status("hpa_normal_tissue")[0]["present"] is True
+
+
+def test_ensure_delegates_to_backends(monkeypatch, tmp_path):
+    # HPA -> reference_data.ensure
+    called = {}
+
+    def fake_hpa_ensure(n, *a, **k):
+        called["hpa"] = n
+        return tmp_path / "h.tsv"
+
+    monkeypatch.setattr(reference_data, "ensure", fake_hpa_ensure)
+    assert catalog.ensure("hpa_single_cell") == tmp_path / "h.tsv"
+    assert called["hpa"] == "hpa_single_cell"
+
+    # bundle -> ensure_local() then find()
+    def fake_ensure_local(*a, **k):
+        called["bundle_fetch"] = True
+
+    monkeypatch.setattr(data_bundle, "ensure_local", fake_ensure_local)
+    monkeypatch.setattr(data_bundle, "find", lambda n: tmp_path / n)
+    out = catalog.ensure("pan-cancer-expression.csv")
+    assert out == tmp_path / "pan-cancer-expression.csv"
+    assert called["bundle_fetch"] is True
+
+
+def test_fetch_all_fetches_bundle_once_and_each_hpa(monkeypatch):
+    calls = {"bundle_fetch": 0, "hpa": []}
+    monkeypatch.setattr(data_bundle, "is_local", lambda: False)
+    monkeypatch.setattr(
+        data_bundle,
+        "fetch",
+        lambda *a, **k: calls.__setitem__("bundle_fetch", calls["bundle_fetch"] + 1),
+    )
+    monkeypatch.setattr(reference_data, "download", lambda n, *a, **k: calls["hpa"].append(n))
+
+    fetched = catalog.fetch("all")
+    # The tarball is fetched exactly once despite 5 bundle members.
+    assert calls["bundle_fetch"] == 1
+    assert set(calls["hpa"]) == set(reference_data.REFERENCE_SOURCES)
+    assert set(fetched) == {d.name for d in catalog.datasets()}


### PR DESCRIPTION
## Summary
First step of the elegant unified data-management system (tracking #35). `cancerdata.catalog` is **one model + one API over both heavy-data backends** — the version-pinned per-cohort expression bundle (`data_bundle`, a release tarball) and the HPA protein/RNA reference tables (`reference_data`, per-source downloads). Callers (and the CLI, next) manage everything uniformly without caring which backend a dataset lives in.

## API
```python
from cancerdata import catalog
catalog.datasets()        # 8 managed datasets: 5 bundle members + 3 HPA sources
catalog.status()          # uniform rows: name, kind, present, path, size_bytes, description
catalog.path(name)        # cached location or None (never downloads)
catalog.ensure(name)      # download if absent -> Path
catalog.fetch("all")       # materialize everything (tarball fetched once, not per-member)
```

## Design
- A frozen `Dataset(name, kind, description)` model; `kind` is `"bundle"` or `"hpa"`.
- **Delegates** to the existing backends — zero behavior change to `data_bundle` / `reference_data`. This is a facade, not a rewrite.
- HPA datasets fetch per-file; any bundle member triggers the one-time whole-tarball download (`fetch("all")` fetches it exactly once despite 5 members).
- The small curated tables ship in the wheel and need no management, so they're intentionally out of the catalog.

## Tests
`test_catalog.py`: both-backend listing, lookup + unknown→KeyError, uniform status (absent → present), path resolution, ensure-delegation, and the fetch-bundle-once invariant. All network-free via monkeypatch. Full suite **179 pass** (+6); ruff clean.

## Next
D-cli: a unified `cancerdata data list|status|fetch|path|prune` CLI over this catalog (with back-compat aliases for `fetch`/`status`/`sources`). Then the native CTA regeneration phase.

Part of #35.