### PR TITLE
Unified data inventory + completeness guard (#35 D-manifest)

### DIFF
--- a/cancerdata/catalog.py
+++ b/cancerdata/catalog.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import data_bundle, reference_data
+from . import data_bundle, data_manifest, reference_data
 
 _BUNDLE = "bundle"
 _HPA = "hpa"
@@ -151,6 +151,40 @@ def _size_bytes(p: Path | None) -> int:
     if p.is_dir():
         return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
     return p.stat().st_size
+
+
+def inventory() -> list[dict]:
+    """The complete cancerdata-domain data inventory — the full picture behind the
+    fetchable :func:`datasets`. One row per dataset with ``name``, ``held``
+    (``wheel`` / ``bundle`` / ``hpa`` / ``source`` / ``planned``), ``category``,
+    ``available`` (present locally / shipped), and ``description``. Driven by
+    :mod:`cancerdata.data_manifest` so it stays exhaustive against pirlygenes.
+    """
+    bundle_member = {p.removesuffix(".csv"): p for p in data_bundle.DOWNLOADABLE_PATHS}
+    rows: list[dict] = []
+
+    def _add(name, held, category, description, available):
+        rows.append(
+            {
+                "name": name,
+                "held": held,
+                "category": category,
+                "available": available,
+                "description": description,
+            }
+        )
+
+    for name, (cat, desc) in sorted(data_manifest.WHEEL.items()):
+        _add(name, "wheel", cat, desc, True)  # ships in the wheel — always present
+    for name, (cat, desc) in sorted(data_manifest.BUNDLE.items()):
+        _add(name, "bundle", cat, desc, data_bundle.find(bundle_member[name]) is not None)
+    for name, (cat, desc) in sorted(data_manifest.HPA.items()):
+        _add(name, "hpa", cat, desc, reference_data.local_path(name).exists())
+    for name, (cat, desc) in sorted(data_manifest.SOURCE.items()):
+        _add(name, "source", cat, desc, False)  # not distributed through cancerdata yet
+    for name, (cat, desc) in sorted(data_manifest.PLANNED.items()):
+        _add(name, "planned", cat, desc, False)  # cancerdata-domain, still to port
+    return rows
 
 
 def status(name: str | None = None) -> list[dict]:

--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -102,8 +102,14 @@ def _cmd_data(args: argparse.Namespace) -> int:
     from . import catalog
 
     if args.action == "list":
-        for d in catalog.datasets():
-            print(f"{d.name:<46} {d.kind:<7} {d.description}")
+        # The full inventory: every cancerdata-domain dataset and how it's held.
+        print(f"{'Dataset':<46} {'Held':<8} {'Avail':<6} {'Category':<14} Description")
+        print("-" * 110)
+        for r in catalog.inventory():
+            avail = "yes" if r["available"] else "-"
+            print(
+                f"{r['name']:<46} {r['held']:<8} {avail:<6} {r['category']:<14} {r['description']}"
+            )
         return 0
 
     if args.action == "status":

--- a/cancerdata/data_manifest.py
+++ b/cancerdata/data_manifest.py
@@ -1,0 +1,260 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The complete, classified inventory of cancerdata-domain data.
+
+This is the single declarative source of truth for *what data cancerdata owns*
+and how each dataset is held. It keeps the base layer honest: every dataset is
+classified into exactly one bucket, and a guard test (test_data_manifest.py)
+asserts the buckets partition the frozen pirlygenes inventory exhaustively and
+disjointly — so as cancerdata absorbs pirlygenes, nothing is silently dropped or
+double-owned.
+
+Held buckets (cancerdata domain):
+  WHEEL     — small curated tables shipped in the wheel (no fetch).
+  BUNDLE    — heavy expression artifacts in the version-pinned release tarball.
+  HPA       — Human Protein Atlas reference tables fetched per-source on demand.
+  SOURCE    — the raw per-sample TPM matrices (a separate large optional bundle).
+  PLANNED   — cancerdata-domain tables still to port (they feed the normalization
+              / CTA-regeneration / ontology phases).
+  SUPERSEDED— a pirlygenes table cancerdata replaced with its own regenerated one.
+
+OUT_OF_SCOPE — pirlygenes data that is NOT cancerdata's domain (target selection,
+  therapy/modality, surfaceome, analysis gene sets) and stays in tsarina/hitlist.
+
+The catalog (:mod:`cancerdata.catalog`) manages the fetchable subset; this module
+is the inventory + classification.
+"""
+
+from __future__ import annotations
+
+#: {name: (category, description)} — small curated tables shipped in the wheel.
+WHEEL: dict[str, tuple[str, str]] = {
+    "cancer-type-registry": ("ontology", "cancer-type codes, hierarchy, family/tissue"),
+    "cancer-subtype-groupings": ("ontology", "cross-cutting MSI/POLE/HPV/MYCN axes"),
+    "cancer-cohort-aggregates": ("ontology", "computed histology rollups (SARC_RMS, …)"),
+    "cohort-registry": ("ontology", "first-class cohort vocabulary"),
+    "cancer-fusions": ("ontology", "characteristic driver fusions per cancer type"),
+    "cancer-code-burden-map": ("ontology", "anatomic burden-category overrides"),
+    "cancer-incidence-mortality": ("epidemiology", "incidence/mortality by burden category"),
+    "cancer-tmb": ("genomics", "median tumor mutational burden per type"),
+    "cancer-apd1-response": ("response", "anti-PD-1 monotherapy ORR per type"),
+    "cancer-reference-expression-samples": ("expression", "per-sample curation manifest"),
+    "expression_sources": ("expression", "cohort expression-source registry"),
+}
+
+#: {name: (category, description)} — heavy artifacts in the release tarball.
+#: Names match ``data_bundle.DOWNLOADABLE_PATHS`` (sans extension); kept in sync by a test.
+BUNDLE: dict[str, tuple[str, str]] = {
+    "cancer-reference-expression": ("expression", "per-cohort RNA-seq summary shards"),
+    "cancer-reference-expression-percentiles": ("expression", "per-gene percentile vectors"),
+    "cancer-reference-expression-representatives": ("expression", "per-cohort medoid samples"),
+    "pan-cancer-expression": ("expression", "pan-cancer HPA-tissue + TCGA matrix"),
+    "hpa-cell-type-expression": ("hpa", "HPA cell-type nTPM matrix"),
+}
+
+#: {name: (category, description)} — HPA tables fetched per-source (not pirlygenes files).
+HPA: dict[str, tuple[str, str]] = {
+    "hpa_rna_consensus": ("hpa", "HPA RNA consensus per-tissue nTPM"),
+    "hpa_normal_tissue": ("hpa", "HPA IHC protein detection per tissue"),
+    "hpa_single_cell": ("hpa", "HPA single-cell-type RNA nTPM"),
+}
+
+#: The raw per-sample TPM matrices — every derived artifact is built from these.
+SOURCE: dict[str, tuple[str, str]] = {
+    "per-sample-tpm-matrices": ("expression", "raw per-sample cohort TPM (build inputs)"),
+}
+
+#: {name: (category, description)} — cancerdata-domain tables still to port.
+PLANNED: dict[str, tuple[str, str]] = {
+    # normalization references (Phase N / clean_tpm_v4)
+    "housekeeping-genes": ("normalization", "housekeeping panel for normalization"),
+    "censored-gene-reference-tpm": ("normalization", "fixed surrogate TPM for censored genes"),
+    "clean-tpm-censored-genes": (
+        "normalization",
+        "technical+ribosomal genes censored by clean_tpm_v4",
+    ),
+    "histone-genes": ("normalization", "histone-cluster genes"),
+    "ribosomal-protein-genes": ("normalization", "ribosomal-protein genes"),
+    "ribosomal-protein-pseudogenes": ("normalization", "ribosomal-protein pseudogenes"),
+    "mitochondrial-genes": ("normalization", "mtDNA-encoded genes"),
+    "rrna-and-pseudogenes": ("normalization", "rRNA + rRNA pseudogenes"),
+    "numt-pseudogenes": ("normalization", "NUMT-like nuclear-mito pseudogenes"),
+    "small-noncoding-rnas": ("normalization", "small non-coding RNA loci"),
+    "nuclear-retained-lncrnas": ("normalization", "polyA-bias nuclear-retained lncRNAs"),
+    "hemoglobin-genes": ("normalization", "hemoglobin genes"),
+    # gene-id / symbol resolution
+    "ensembl-id-aliases": ("gene-id", "retired→current Ensembl gene-id aliases"),
+    "ncbi-symbol-synonyms": ("gene-id", "NCBI gene symbol synonyms"),
+    "extra-tx-mappings": ("gene-id", "supplemental transcript→gene mappings"),
+    "cdna-identical-gene-groups": ("gene-id", "cDNA-identical gene groups"),
+    "proteoform-collapse-overrides": ("gene-id", "manual proteoform-collapse overrides"),
+    # ontology metadata (O5)
+    "cancer-key-genes": ("ontology", "per-type biomarkers + therapy targets"),
+    "cancer-driver-genes": ("ontology", "per-type driver genes"),
+    "cancer-driver-variants": ("ontology", "per-type driver variants"),
+    "cancer-type-genes": ("ontology", "role-stratified per-type genes"),
+    "cancer-viral-antigens": ("ontology", "per-oncovirus targetable antigens"),
+    "disease-state-rules": ("ontology", "narrative disease-state rules"),
+    "narrative-gene-sets": ("ontology", "named narrative gene sets"),
+    "degenerate-subtype-pairs": ("ontology", "expression-degenerate subtype pairs"),
+    "rare-cancer-fusion-rules": ("ontology", "direct fusion rules for rare cancers"),
+    "fusion-surrogate-expression": ("ontology", "expression surrogates for fusions"),
+    "fusion-expression-effects": ("ontology", "downstream-expression rules per fusion"),
+    # expression-source metadata
+    "cancer-expression-source-candidates": ("expression", "candidate expression sources per type"),
+    "cancer-frameshift-burden": ("genomics", "per-type frameshift-indel burden"),
+}
+
+#: pirlygenes tables cancerdata replaced with its own regenerated equivalent.
+SUPERSEDED: dict[str, str] = {
+    "protein-identical-gene-groups": "proteoform-groups-genome (byte-identical, regenerated)",
+    "cta-protein-groups": "proteoform-groups (byte-identical; pirlygenes' is ≥90% identity)",
+}
+
+#: pirlygenes data that is NOT cancerdata's domain — target selection / therapy /
+#: surfaceome / analysis gene sets. These stay in tsarina / hitlist.
+OUT_OF_SCOPE: frozenset[str] = frozenset(
+    {
+        # therapeutic modality / drug data
+        "ADC-approved",
+        "ADC-trials",
+        "ADC-withdrawn",
+        "bispecific-antibodies-approved",
+        "CAR-T-approved",
+        "TCR-T-approved",
+        "TCR-T-trials",
+        "multispecific-tcell-engager-trials",
+        "radioligand-targets",
+        # surfaceome / targetability
+        "surface-proteins",
+        "cancer-surfaceome",
+        # therapy signatures / evidence
+        "therapy-benefit-toxicity-evidence",
+        "therapy-response-signatures",
+        "estimate-signatures",
+        "immune-receptor-segments",
+        # analysis / QC gene sets
+        "tme-markers",
+        "stem-cell-marker-panels",
+        "culture-stress-genes",
+        "ffpe-sensitive-markers",
+        "degradation-gene-pairs",
+        "mutation-expression-effects",
+        "rare-cancer-rna-surrogates",
+        # differential-expression signatures
+        "tumor-up-vs-matched-normal",
+        "heme-tumor-up-vs-matched-normal",
+        # gene-set panels (analysis / target selection)
+        "cancer-lineage-panels",
+        "cancer-family-panels",
+        "lineage-genes",
+        "gene-sets",
+        # build QC
+        "artifact-expectations",
+    }
+)
+
+#: Frozen snapshot of pirlygenes' shipped ``data/`` inventory (file stems + artifact
+#: dirs), 2026-06. The guard test partitions this against the buckets above; a new
+#: pirlygenes dataset must be consciously classified rather than silently missed.
+PIRLYGENES_DATA: frozenset[str] = frozenset(
+    {
+        "ADC-approved",
+        "ADC-trials",
+        "ADC-withdrawn",
+        "artifact-expectations",
+        "bispecific-antibodies-approved",
+        "cancer-apd1-response",
+        "cancer-code-burden-map",
+        "cancer-cohort-aggregates",
+        "cancer-driver-genes",
+        "cancer-driver-variants",
+        "cancer-expression-source-candidates",
+        "cancer-family-panels",
+        "cancer-frameshift-burden",
+        "cancer-fusions",
+        "cancer-incidence-mortality",
+        "cancer-key-genes",
+        "cancer-lineage-panels",
+        "cancer-reference-expression",
+        "cancer-reference-expression-percentiles",
+        "cancer-reference-expression-representatives",
+        "cancer-reference-expression-samples",
+        "cancer-subtype-groupings",
+        "cancer-surfaceome",
+        "cancer-tmb",
+        "cancer-type-genes",
+        "cancer-type-registry",
+        "cancer-viral-antigens",
+        "CAR-T-approved",
+        "cdna-identical-gene-groups",
+        "censored-gene-reference-tpm",
+        "clean-tpm-censored-genes",
+        "cohort-registry",
+        "cta-protein-groups",
+        "culture-stress-genes",
+        "degenerate-subtype-pairs",
+        "degradation-gene-pairs",
+        "disease-state-rules",
+        "ensembl-id-aliases",
+        "estimate-signatures",
+        "expression_sources",
+        "extra-tx-mappings",
+        "ffpe-sensitive-markers",
+        "fusion-expression-effects",
+        "fusion-surrogate-expression",
+        "gene-sets",
+        "heme-tumor-up-vs-matched-normal",
+        "hemoglobin-genes",
+        "histone-genes",
+        "housekeeping-genes",
+        "hpa-cell-type-expression",
+        "immune-receptor-segments",
+        "lineage-genes",
+        "mitochondrial-genes",
+        "multispecific-tcell-engager-trials",
+        "mutation-expression-effects",
+        "narrative-gene-sets",
+        "ncbi-symbol-synonyms",
+        "nuclear-retained-lncrnas",
+        "numt-pseudogenes",
+        "pan-cancer-expression",
+        "protein-identical-gene-groups",
+        "proteoform-collapse-overrides",
+        "radioligand-targets",
+        "rare-cancer-fusion-rules",
+        "rare-cancer-rna-surrogates",
+        "ribosomal-protein-genes",
+        "ribosomal-protein-pseudogenes",
+        "rrna-and-pseudogenes",
+        "small-noncoding-rnas",
+        "stem-cell-marker-panels",
+        "surface-proteins",
+        "TCR-T-approved",
+        "TCR-T-trials",
+        "therapy-benefit-toxicity-evidence",
+        "therapy-response-signatures",
+        "tme-markers",
+        "tumor-up-vs-matched-normal",
+    }
+)
+
+
+def captured() -> set[str]:
+    """cancerdata-domain datasets already held (wheel + bundle + superseded)."""
+    return set(WHEEL) | set(BUNDLE) | set(SUPERSEDED)
+
+
+def in_scope() -> set[str]:
+    """Every cancerdata-domain dataset — captured plus still-planned."""
+    return captured() | set(PLANNED)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -116,8 +116,8 @@ def test_datasets_disjoint_backends():
 def test_cli_data_list(capsys):
     assert cli.main(["data", "list"]) == 0
     out = capsys.readouterr().out
-    for d in catalog.datasets():
-        assert d.name in out
+    for r in catalog.inventory():
+        assert r["name"] in out
 
 
 def test_cli_data_status_absent(monkeypatch, tmp_path, capsys):
@@ -161,3 +161,36 @@ def test_cli_help_never_crashes():
         if isinstance(action, argparse._SubParsersAction):
             for subparser in action.choices.values():
                 subparser.format_help()  # each subcommand's own argument help
+
+
+# ---- full inventory (manifest-driven) ----
+
+
+def test_inventory_covers_all_held_buckets():
+    from cancerdata import data_manifest
+
+    rows = catalog.inventory()
+    names = {r["name"] for r in rows}
+    assert set(data_manifest.WHEEL) <= names
+    assert set(data_manifest.PLANNED) <= names
+    assert {"per-sample-tpm-matrices"} <= names  # the raw source matrices
+    held = {r["held"] for r in rows}
+    assert held == {"wheel", "bundle", "hpa", "source", "planned"}
+
+
+def test_inventory_wheel_always_available():
+    wheel = [r for r in catalog.inventory() if r["held"] == "wheel"]
+    assert wheel and all(r["available"] for r in wheel)
+
+
+def test_inventory_planned_not_available():
+    planned = [r for r in catalog.inventory() if r["held"] == "planned"]
+    assert planned and all(not r["available"] for r in planned)
+
+
+def test_cli_data_list_shows_full_inventory(capsys):
+    assert cli.main(["data", "list"]) == 0
+    out = capsys.readouterr().out
+    assert "housekeeping-genes" in out  # a planned dataset appears
+    assert "per-sample-tpm-matrices" in out  # the raw source matrices appear
+    assert "planned" in out and "wheel" in out

--- a/tests/test_data_manifest.py
+++ b/tests/test_data_manifest.py
@@ -1,0 +1,69 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Completeness guard: the manifest must classify every pirlygenes dataset (#35)."""
+
+from pathlib import Path
+
+from cancerdata import data_bundle, data_manifest, reference_data
+
+_DATA_DIR = Path(__file__).resolve().parents[1] / "cancerdata" / "data"
+
+_BUCKETS = {
+    "WHEEL": set(data_manifest.WHEEL),
+    "BUNDLE": set(data_manifest.BUNDLE),
+    "PLANNED": set(data_manifest.PLANNED),
+    "SUPERSEDED": set(data_manifest.SUPERSEDED),
+    "OUT_OF_SCOPE": set(data_manifest.OUT_OF_SCOPE),
+}
+
+
+def test_every_pirlygenes_dataset_is_classified():
+    # Each of the 77 frozen pirlygenes assets must fall in exactly one bucket —
+    # so nothing pirlygenes ships is silently dropped or left unclassified.
+    classified = set().union(*_BUCKETS.values())
+    unclassified = data_manifest.PIRLYGENES_DATA - classified
+    assert not unclassified, f"unclassified pirlygenes datasets: {sorted(unclassified)}"
+
+
+def test_buckets_are_disjoint():
+    names = list(_BUCKETS)
+    for i, a in enumerate(names):
+        for b in names[i + 1 :]:
+            overlap = _BUCKETS[a] & _BUCKETS[b]
+            assert not overlap, f"{a} & {b} overlap: {sorted(overlap)}"
+
+
+def test_classification_only_covers_known_pirlygenes_data():
+    # A bucket entry that isn't a real pirlygenes asset is a typo/stale classification
+    # (HPA + SOURCE are runtime/derived, not pirlygenes files, so excluded).
+    classified = set().union(*_BUCKETS.values())
+    stray = classified - data_manifest.PIRLYGENES_DATA
+    assert not stray, f"classified names not in the pirlygenes snapshot: {sorted(stray)}"
+
+
+def _wheel_file_exists(name: str) -> bool:
+    return any((_DATA_DIR / f"{name}{ext}").exists() for ext in (".csv", ".csv.gz", ".yaml"))
+
+
+def test_wheel_tables_actually_ship():
+    missing = [n for n in data_manifest.WHEEL if not _wheel_file_exists(n)]
+    assert not missing, f"WHEEL tables not present in the wheel: {missing}"
+
+
+def test_planned_tables_not_yet_present():
+    # PLANNED = still to port; if one is already in data/, move it to WHEEL.
+    present = [n for n in data_manifest.PLANNED if _wheel_file_exists(n)]
+    assert not present, f"PLANNED tables already shipped — promote to WHEEL: {present}"
+
+
+def test_bundle_matches_downloadable_paths():
+    bundle_stems = {p.removesuffix(".csv") for p in data_bundle.DOWNLOADABLE_PATHS}
+    assert bundle_stems == set(data_manifest.BUNDLE)
+
+
+def test_hpa_matches_reference_sources():
+    assert set(data_manifest.HPA) == set(reference_data.REFERENCE_SOURCES)


### PR DESCRIPTION
## Summary
Makes the data system **capture all** cancerdata-domain data in one elegant, unified inventory — and proves it can't drift. Answers the review: the catalog managed only the fetchable subset, so wheel tables, the raw per-sample matrices, and ~30 unported reference tables were invisible.

## What changed
- **`cancerdata/data_manifest.py`** — the single declarative source of truth: every cancerdata-domain dataset classified by how it's held:
  - **wheel** (11) — small curated tables in the package
  - **bundle** (5) — heavy expression artifacts in the release tarball
  - **hpa** (3) — per-source HPA downloads
  - **source** (1) — the raw per-sample TPM matrices (~21 GB; still to distribute)
  - **planned** (30) — cancerdata-domain tables still to port (normalization refs, gene-id resolution, ontology O5, expression metadata)
  - plus **SUPERSEDED** (cancerdata regenerated its own) and **OUT_OF_SCOPE** (29 target-selection/therapy/analysis tables that stay in tsarina/hitlist).
- **Completeness guard** (`test_data_manifest.py`): the buckets **partition the frozen 77-asset pirlygenes inventory exhaustively and disjointly**; every wheel table actually ships; planned aren't yet present; bundle/hpa stay in sync with the backends. A new pirlygenes dataset now *must* be consciously classified.
- **`catalog.inventory()`** + **`cancerdata data list`** surface the full picture (50 datasets) with held / category / availability. `datasets()`/`ensure()`/`fetch()` unchanged.

```
$ cancerdata data list
Dataset                              Held     Avail  Category      Description
cancer-type-registry                 wheel    yes    ontology      cancer-type codes, hierarchy, …
cancer-reference-expression          bundle   yes    expression    per-cohort RNA-seq summary shards
hpa_normal_tissue                    hpa      -      hpa           HPA IHC protein detection per tissue
per-sample-tpm-matrices              source   -      expression    raw per-sample cohort TPM (build inputs)
housekeeping-genes                   planned  -      normalization housekeeping panel …
…
```

## Result
The system now **knows about every dataset it should hold**, the gaps are explicit and tracked (30 planned + the per-sample matrices), and the guard keeps it honest. Tests **199 pass** (+18); ruff clean.

Next (per #35): **Phase R** ports the 30 planned tables (R-norm first, feeds normalization), **D-source** distributes the per-sample matrices. Part of #35.