### PR TITLE
Surface per-cohort scale in the data inventory (#35)

### DIFF
--- a/cancerdata/catalog.py
+++ b/cancerdata/catalog.py
@@ -153,6 +153,16 @@ def _size_bytes(p: Path | None) -> int:
     return p.stat().st_size
 
 
+def _cohort_count(p: Path | None) -> int | None:
+    """Per-cohort file count for a directory dataset (one file per cancer cohort);
+    ``None`` for a single-file dataset. This is the cohort scale held *inside* an
+    expression artifact — e.g. ``cancer-reference-expression-percentiles`` is one
+    catalog entry but ~118 cancer cohorts."""
+    if p is None or not p.is_dir():
+        return None
+    return sum(1 for f in p.iterdir() if f.is_file() and not f.name.startswith("_"))
+
+
 def inventory() -> list[dict]:
     """The complete cancerdata-domain data inventory — the full picture behind the
     fetchable :func:`datasets`. One row per dataset with ``name``, ``held``
@@ -163,13 +173,14 @@ def inventory() -> list[dict]:
     bundle_member = {p.removesuffix(".csv"): p for p in data_bundle.DOWNLOADABLE_PATHS}
     rows: list[dict] = []
 
-    def _add(name, held, category, description, available):
+    def _add(name, held, category, description, available, cohorts=None):
         rows.append(
             {
                 "name": name,
                 "held": held,
                 "category": category,
                 "available": available,
+                "cohorts": cohorts,
                 "description": description,
             }
         )
@@ -177,7 +188,8 @@ def inventory() -> list[dict]:
     for name, (cat, desc) in sorted(data_manifest.WHEEL.items()):
         _add(name, "wheel", cat, desc, True)  # ships in the wheel — always present
     for name, (cat, desc) in sorted(data_manifest.BUNDLE.items()):
-        _add(name, "bundle", cat, desc, data_bundle.find(bundle_member[name]) is not None)
+        member = data_bundle.find(bundle_member[name])
+        _add(name, "bundle", cat, desc, member is not None, _cohort_count(member))
     for name, (cat, desc) in sorted(data_manifest.HPA.items()):
         _add(name, "hpa", cat, desc, reference_data.local_path(name).exists())
     for name, (cat, desc) in sorted(data_manifest.SOURCE.items()):
@@ -189,7 +201,8 @@ def inventory() -> list[dict]:
 
 def status(name: str | None = None) -> list[dict]:
     """Uniform status rows over the catalog: ``name``, ``kind``, ``present``,
-    ``path``, ``size_bytes``, ``description``. One dataset if ``name`` given."""
+    ``path``, ``size_bytes``, ``cohorts`` (per-cohort file count for directory
+    datasets, else ``None``), ``description``. One dataset if ``name`` given."""
     names = [dataset(name).name] if name is not None else [d.name for d in datasets()]
     rows = []
     for n in names:
@@ -202,6 +215,7 @@ def status(name: str | None = None) -> list[dict]:
                 "present": p is not None,
                 "path": str(p) if p is not None else None,
                 "size_bytes": _size_bytes(p),
+                "cohorts": _cohort_count(p),
                 "description": d.description,
             }
         )

--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -103,12 +103,17 @@ def _cmd_data(args: argparse.Namespace) -> int:
 
     if args.action == "list":
         # The full inventory: every cancerdata-domain dataset and how it's held.
-        print(f"{'Dataset':<46} {'Held':<8} {'Avail':<6} {'Category':<14} Description")
-        print("-" * 110)
+        # `Cohorts` is the per-cohort file count held *inside* a directory dataset.
+        print(
+            f"{'Dataset':<46} {'Held':<8} {'Avail':<6} {'Cohorts':>8} {'Category':<14} Description"
+        )
+        print("-" * 120)
         for r in catalog.inventory():
             avail = "yes" if r["available"] else "-"
+            cohorts = str(r["cohorts"]) if r["cohorts"] is not None else "-"
             print(
-                f"{r['name']:<46} {r['held']:<8} {avail:<6} {r['category']:<14} {r['description']}"
+                f"{r['name']:<46} {r['held']:<8} {avail:<6} {cohorts:>8} "
+                f"{r['category']:<14} {r['description']}"
             )
         return 0
 
@@ -118,12 +123,18 @@ def _cmd_data(args: argparse.Namespace) -> int:
         except KeyError as e:
             print(f"Error: {e}", file=sys.stderr)
             return 1
-        print(f"{'Dataset':<46} {'Kind':<7} {'Present':<8} {'Size':>10}  Description")
-        print("-" * 100)
+        print(
+            f"{'Dataset':<46} {'Kind':<7} {'Present':<8} {'Size':>10} {'Cohorts':>8}  Description"
+        )
+        print("-" * 110)
         for r in rows:
             present = "yes" if r["present"] else "no"
             size = _fmt_bytes(r["size_bytes"])
-            print(f"{r['name']:<46} {r['kind']:<7} {present:<8} {size:>10}  {r['description']}")
+            cohorts = str(r["cohorts"]) if r["cohorts"] is not None else "-"
+            print(
+                f"{r['name']:<46} {r['kind']:<7} {present:<8} {size:>10} {cohorts:>8}  "
+                f"{r['description']}"
+            )
         return 0
 
     if args.action == "fetch":

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -33,7 +33,8 @@ def test_status_uniform_and_absent(monkeypatch, tmp_path):
     rows = catalog.status()
     assert {r["name"] for r in rows} == {d.name for d in catalog.datasets()}
     assert all(
-        set(r) == {"name", "kind", "present", "path", "size_bytes", "description"} for r in rows
+        set(r) == {"name", "kind", "present", "path", "size_bytes", "cohorts", "description"}
+        for r in rows
     )
     assert all(r["present"] is False and r["size_bytes"] == 0 for r in rows)
 
@@ -194,3 +195,19 @@ def test_cli_data_list_shows_full_inventory(capsys):
     assert "housekeeping-genes" in out  # a planned dataset appears
     assert "per-sample-tpm-matrices" in out  # the raw source matrices appear
     assert "planned" in out and "wheel" in out
+
+
+def test_cohort_count_surfaces_per_cohort_scale(monkeypatch, tmp_path):
+    # A directory dataset reports the per-cohort file count (the cancer-type scale
+    # held *inside* one catalog entry); single-file/absent datasets report None.
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / "vX"))
+    member = tmp_path / "vX" / "cancer-reference-expression-percentiles"
+    member.mkdir(parents=True)
+    for code in ("ACC", "BRCA", "LUAD"):
+        (member / f"{code}.parquet").write_bytes(b"x")
+    (member / "_provenance.csv").write_text("x")  # excluded (leading underscore)
+
+    rows = {r["name"]: r for r in catalog.status()}
+    assert rows["cancer-reference-expression-percentiles"]["cohorts"] == 3
+    # a single-file dataset has no per-cohort breakdown
+    assert rows["pan-cancer-expression.csv"]["cohorts"] is None


### PR DESCRIPTION
## Why
`cancerdata data list` showed **50 datasets**, which understated the data: the catalog counts *artifacts* (fetch-units), but the per-cancer-type expression lives **inside** a few directory datasets (one file per cohort). The 100+ cancer types were captured but invisible.

## What changed
Added a **`cohorts`** count to `catalog.status()` / `catalog.inventory()` (and the `data list` / `data status` CLI columns): for a directory dataset it's the number of per-cohort files; for a single-file dataset it's `None`.

```
Dataset                                      Held    Avail  Cohorts  Category    …
cancer-reference-expression                  bundle  yes         75  expression  per-cohort summary shards
cancer-reference-expression-percentiles      bundle  yes        118  expression  per-gene percentile vectors
cancer-reference-expression-representatives  bundle  yes        118  expression  per-cohort medoid samples
```

So one catalog entry = 118 cancer cohorts. (Registry has 160 codes; 118 have per-sample-derived expression; 129 raw per-sample matrices.)

## Tests
`test_catalog.py`: cohort count = per-cohort file count (excludes `_provenance`), `None` for single-file datasets; status key-set updated. Full suite **205 pass**; ruff clean.

Part of #35.