### PR TITLE
Normalization engine: clean TPM + helpers (#35 Phase N)

### DIFF
--- a/cancerdata/data_manifest.py
+++ b/cancerdata/data_manifest.py
@@ -50,12 +50,12 @@ WHEEL: dict[str, tuple[str, str]] = {
     "cancer-apd1-response": ("response", "anti-PD-1 monotherapy ORR per type"),
     "cancer-reference-expression-samples": ("expression", "per-sample curation manifest"),
     "expression_sources": ("expression", "cohort expression-source registry"),
-    # normalization references (R-norm; consumed by the clean_tpm_v4 engine)
+    # normalization references (R-norm; consumed by the clean TPM engine)
     "housekeeping-genes": ("normalization", "housekeeping panel for normalization"),
     "censored-gene-reference-tpm": ("normalization", "fixed surrogate TPM for censored genes"),
     "clean-tpm-censored-genes": (
         "normalization",
-        "technical+ribosomal genes censored by clean_tpm_v4",
+        "technical+ribosomal genes censored by clean TPM",
     ),
     "histone-genes": ("normalization", "histone-cluster genes"),
     "ribosomal-protein-genes": ("normalization", "ribosomal-protein genes"),

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -130,7 +130,7 @@ def representative_cohort_samples(
 
     The packaged cohort references are per-cohort aggregates; this returns a
     bounded set of real joint per-sample vectors per cohort — medoids spanning
-    the within-cohort variation — in the same ``clean_tpm_v4`` basis.
+    the within-cohort variation — in the same ``clean TPM`` basis.
 
     ``cancer_types`` accepts a code, alias, or iterable; a computed-aggregate
     code expands to its member subtypes; ``None`` returns every cohort that ships
@@ -140,7 +140,7 @@ def representative_cohort_samples(
     if normalize not in ("tpm_clean", "tpm_clean_log1p"):
         raise ValueError(
             "representative_cohort_samples normalize must be 'tpm_clean' or "
-            "'tpm_clean_log1p' (the artifact ships only in clean_tpm_v4)"
+            "'tpm_clean_log1p' (the artifact ships only in clean TPM)"
         )
     if format not in ("wide", "long"):
         raise ValueError("format must be 'wide' or 'long'")
@@ -203,7 +203,7 @@ def cohort_gene_percentiles(cancer_type, *, as_tpm: bool = True) -> pd.DataFrame
     p100`` — dense in the actionable upper tail. Lets a consumer place a sample's
     gene as a **percentile rank within the cohort** instead of an absolute TPM.
 
-    Computed on the biological clean_tpm_v4 view (technical genes dropped).
+    Computed on the biological clean TPM view (technical genes dropped).
     Stored compactly as ``log1p`` + float16; ``as_tpm=True`` (default)
     ``expm1``-restores clean-TPM values, ``as_tpm=False`` returns the stored
     log1p values. Raises if the cohort has no per-sample data (summary-only
@@ -308,7 +308,7 @@ def proteoform_representative_samples(
     when reads can't be uniquely assigned between identical-protein loci. Genes in
     no group pass through unchanged.
 
-    Always operates on linear ``clean_tpm_v4`` (summing log1p values would be
+    Always operates on linear ``clean TPM`` (summing log1p values would be
     wrong); ``log1p`` afterward if you need it. This is the runtime,
     every-cohort proteoform view over the shipped medoid samples; the same
     :func:`cancerdata._build.sum_proteoform_tpm` core can run inside the offline

--- a/cancerdata/gene_families.py
+++ b/cancerdata/gene_families.py
@@ -16,8 +16,8 @@ The curated families behind cancerdata's normalization: the technical-RNA loci
 whose RNA-seq abundance is library-prep artifact rather than biology (mtDNA, NUMT
 pseudogenes, rRNA, nuclear-retained lncRNAs), the ribosomal-protein / histone /
 hemoglobin / small-ncRNA families, the housekeeping panel, and the censored-gene
-surrogate TPMs. This is the read surface; the clean_tpm_v4 engine that consumes
-them lands in the normalization phase.
+surrogate TPMs. This is the read surface; the clean-TPM engine that consumes them
+lives in :mod:`cancerdata.normalization`.
 """
 
 from __future__ import annotations
@@ -94,10 +94,15 @@ def housekeeping_gene_ids() -> frozenset[str]:
     return _unversioned_ids(get_data("housekeeping-genes", copy=False))
 
 
-@lru_cache(maxsize=1)
-def clean_tpm_censored_gene_ids() -> frozenset[str]:
-    """Unversioned Ensembl IDs censored by clean_tpm_v4 (technical + ribosomal)."""
-    return _unversioned_ids(get_data("clean-tpm-censored-genes", copy=False))
+@lru_cache(maxsize=2)
+def clean_tpm_censored_gene_ids(*, include_ribosomal_proteins: bool = True) -> frozenset[str]:
+    """Unversioned Ensembl IDs censored by the clean-TPM transform — technical RNA
+    plus, by default, ribosomal-protein genes. Pass
+    ``include_ribosomal_proteins=False`` for the strict technical-only set."""
+    df = get_data("clean-tpm-censored-genes", copy=False)
+    if not include_ribosomal_proteins:
+        df = df[df["category"].astype(str) == "technical"]
+    return _unversioned_ids(df)
 
 
 @lru_cache(maxsize=1)

--- a/cancerdata/normalization.py
+++ b/cancerdata/normalization.py
@@ -1,0 +1,158 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Expression normalization — putting per-cohort RNA-seq in a comparable space.
+
+The headline transform is **clean TPM** (:func:`clean_tpm`): a two-compartment
+renormalization that forces the technical/QC compartment (mtDNA, rRNA, the
+polyA-bias lncRNAs MALAT1/NEAT1, and — by default — ribosomal proteins) to a fixed
+fraction of the per-sample budget and the biological compartment to the rest,
+renormalizing within each. The variable, pipeline-driven technical fraction no
+longer inflates real genes, so biological clean TPM is directly comparable across
+samples and sources. Plus the supporting helpers: drop technical genes for a
+biology-only view, housekeeping/log/rank transforms.
+
+Censored-gene and gene-family lists come from :mod:`cancerdata.gene_families`.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from . import gene_families
+
+_ID_COLUMNS = ("Ensembl_Gene_ID", "Symbol")
+
+
+def _value_cols(df: pd.DataFrame, value_cols=None) -> list[str]:
+    if value_cols is not None:
+        return list(value_cols)
+    return [c for c in df.columns if c not in _ID_COLUMNS]
+
+
+def _unversioned(series: pd.Series) -> pd.Series:
+    return series.astype(str).str.split(".").str[0]
+
+
+def _censored_mask(gene_table: pd.DataFrame, *, exclude_ribosomal_proteins: bool) -> pd.Series:
+    """Boolean (row-aligned to ``gene_table``) for the clean-TPM censored genes."""
+    if "Ensembl_Gene_ID" not in gene_table.columns:
+        raise ValueError("clean TPM needs an 'Ensembl_Gene_ID' column (censoring is ENSG-keyed)")
+    ids = gene_families.clean_tpm_censored_gene_ids(
+        include_ribosomal_proteins=exclude_ribosomal_proteins
+    )
+    return _unversioned(gene_table["Ensembl_Gene_ID"]).isin(ids)
+
+
+def clean_tpm(
+    values: pd.DataFrame,
+    gene_table: pd.DataFrame | None = None,
+    *,
+    removable: pd.Series | None = None,
+    exclude_ribosomal_proteins: bool = True,
+    technical_fraction: float = 0.25,
+) -> pd.DataFrame:
+    """Two-compartment **clean TPM** on a gene×sample matrix.
+
+    ``values`` is genes (rows) × samples (cols). Provide a ``gene_table``
+    (``Symbol`` + ``Ensembl_Gene_ID``, row-aligned to ``values``) so the censored
+    (technical/ribosomal) rows can be identified, or an explicit boolean
+    ``removable`` mask.
+
+    The technical compartment is forced to ``technical_fraction`` of the 1e6
+    budget (default 25%) and the biological compartment to the remaining
+    ``1 - technical_fraction`` (75%), each renormalized internally. So every sample
+    is the same fraction technical, the biological compartment lands on a constant
+    750k budget, and biological clean TPM is cross-sample / cross-source comparable
+    (a sample with no technical mass keeps technical at 0; biology still fills 75%).
+    """
+    if not 0.0 < technical_fraction < 1.0:
+        raise ValueError("technical_fraction must be in (0, 1)")
+    if removable is None:
+        if gene_table is None:
+            raise ValueError("clean_tpm needs either gene_table or removable")
+        removable = _censored_mask(
+            gene_table, exclude_ribosomal_proteins=exclude_ribosomal_proteins
+        )
+    rem = removable.to_numpy()
+
+    tech_budget = technical_fraction * 1_000_000.0
+    bio_budget = (1.0 - technical_fraction) * 1_000_000.0
+    tech_sum = values.loc[rem].sum(axis=0)
+    bio_sum = values.loc[~rem].sum(axis=0)
+
+    tscale = pd.Series(0.0, index=values.columns, dtype=float)
+    bscale = pd.Series(0.0, index=values.columns, dtype=float)
+    tscale.loc[tech_sum > 0] = tech_budget / tech_sum.loc[tech_sum > 0]
+    bscale.loc[bio_sum > 0] = bio_budget / bio_sum.loc[bio_sum > 0]
+
+    clean = values.astype(float).copy()
+    clean.loc[rem] = values.loc[rem].mul(tscale, axis=1)
+    clean.loc[~rem] = values.loc[~rem].mul(bscale, axis=1)
+    return clean.fillna(0.0)
+
+
+def drop_technical_genes(
+    df: pd.DataFrame, *, exclude_ribosomal_proteins: bool = True
+) -> pd.DataFrame:
+    """Biology-only view: drop the clean-TPM censored rows (technical RNA, and by
+    default ribosomal proteins). Row order preserved."""
+    mask = _censored_mask(df, exclude_ribosomal_proteins=exclude_ribosomal_proteins)
+    return df.loc[~mask].reset_index(drop=True)
+
+
+def filter_technical_rna(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop the strict technical-RNA loci (mtDNA / NUMT / rRNA / nuclear-retained
+    lncRNA) — a lighter filter than :func:`drop_technical_genes` (keeps ribosomal
+    proteins). Row order preserved."""
+    mask = _unversioned(df["Ensembl_Gene_ID"]).isin(gene_families.technical_rna_gene_ids())
+    return df.loc[~mask].reset_index(drop=True)
+
+
+def normalize_to_housekeeping(df: pd.DataFrame, value_cols=None) -> pd.DataFrame:
+    """Rescale each value column by its housekeeping-gene median (unitless: 1.0 =
+    baseline). NaN/non-positive housekeeping median -> that column becomes NaN."""
+    cols = _value_cols(df, value_cols)
+    hk = gene_families.housekeeping_gene_ids()
+    hk_rows = _unversioned(df["Ensembl_Gene_ID"]).isin(hk)
+    out = df.copy()
+    for c in cols:
+        med = df.loc[hk_rows, c].median()
+        out[c] = df[c] / med if med and med > 0 else np.nan
+    return out
+
+
+def log2_transform(df: pd.DataFrame, value_cols=None, *, pseudocount: float = 1.0) -> pd.DataFrame:
+    """``log2(x + pseudocount)`` over the value columns."""
+    cols = _value_cols(df, value_cols)
+    out = df.copy()
+    out[cols] = np.log2(df[cols].to_numpy(dtype=float) + pseudocount)
+    return out
+
+
+def log1p_transform(df: pd.DataFrame, value_cols=None) -> pd.DataFrame:
+    """``log1p(x)`` over the value columns."""
+    cols = _value_cols(df, value_cols)
+    out = df.copy()
+    out[cols] = np.log1p(df[cols].to_numpy(dtype=float))
+    return out
+
+
+def percentile_rank(df: pd.DataFrame, value_cols=None) -> pd.DataFrame:
+    """Within-sample percentile rank (0–100) per gene — each value column ranked
+    independently. Pipeline-robust (rank is preserved across quantifiers where
+    absolute TPM is not)."""
+    cols = _value_cols(df, value_cols)
+    out = df.copy()
+    out[cols] = df[cols].rank(axis=0, pct=True) * 100.0
+    return out

--- a/cancerdata/normalization.py
+++ b/cancerdata/normalization.py
@@ -67,7 +67,8 @@ def clean_tpm(
     ``values`` is genes (rows) × samples (cols). Provide a ``gene_table``
     (``Symbol`` + ``Ensembl_Gene_ID``, row-aligned to ``values``) so the censored
     (technical/ribosomal) rows can be identified, or an explicit boolean
-    ``removable`` mask.
+    ``removable`` mask **positionally aligned to ``values``'s rows** (it is applied
+    by position, not by index label).
 
     The technical compartment is forced to ``technical_fraction`` of the 1e6
     budget (default 25%) and the biological compartment to the remaining

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,84 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Expression normalization: clean TPM + helpers (#35, Phase N)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from cancerdata import gene_families as gf
+from cancerdata import normalization as norm
+
+
+def _matrix():
+    tech = list(gf.gene_family_ids("mitochondrial"))[:2]
+    gt = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": [*tech, "ENSG00000111111", "ENSG00000222222", "ENSG00000333333"],
+            "Symbol": ["MT1", "MT2", "BIO1", "BIO2", "BIO3"],
+        }
+    )
+    vals = pd.DataFrame(
+        {"s1": [100.0, 200, 300, 400, 500], "s2": [10.0, 0, 100, 200, 300]}, index=gt.index
+    )
+    return gt, vals
+
+
+def test_clean_tpm_two_compartment_budget():
+    gt, vals = _matrix()
+    clean = norm.clean_tpm(vals, gt)
+    rem = norm._censored_mask(gt, exclude_ribosomal_proteins=True).to_numpy()
+    # technical -> 250k, biological -> 750k, exactly, per sample.
+    assert np.allclose(clean.loc[rem].sum(), 250_000.0)
+    assert np.allclose(clean.loc[~rem].sum(), 750_000.0)
+    # within-biology ratios preserved (300:400:500)
+    bio = clean.loc[~rem, "s1"].to_numpy()
+    assert np.allclose(bio / bio.min(), [1.0, 4 / 3, 5 / 3])
+
+
+def test_clean_tpm_no_technical_mass():
+    gt, vals = _matrix()
+    rem = norm._censored_mask(gt, exclude_ribosomal_proteins=True)
+    vals.loc[rem] = 0.0  # a sample/library with no technical reads
+    clean = norm.clean_tpm(vals, gt)
+    assert np.allclose(clean.loc[rem.to_numpy()].sum(), 0.0)  # technical stays 0
+    assert np.allclose(clean.loc[~rem.to_numpy()].sum(), 750_000.0)  # biology still 75%
+
+
+def test_clean_tpm_validates():
+    gt, vals = _matrix()
+    with pytest.raises(ValueError, match="technical_fraction"):
+        norm.clean_tpm(vals, gt, technical_fraction=1.5)
+    with pytest.raises(ValueError, match="gene_table or removable"):
+        norm.clean_tpm(vals)
+
+
+def test_drop_technical_vs_filter_technical_rna():
+    gt, _ = _matrix()
+    df = gt.assign(s1=1.0)
+    # drop_technical_genes removes the censored set (incl. ribosomal); the two
+    # mito genes here are technical, so both go.
+    assert len(norm.drop_technical_genes(df)) == 3
+    assert len(norm.filter_technical_rna(df)) == 3  # mito is technical RNA too
+
+
+def test_log_and_rank_helpers():
+    gt, vals = _matrix()
+    df = vals.assign(Ensembl_Gene_ID=gt["Ensembl_Gene_ID"], Symbol=gt["Symbol"])
+    log1p = norm.log1p_transform(df)
+    assert np.allclose(log1p["s1"], np.log1p(vals["s1"]))
+    rank = norm.percentile_rank(df)
+    assert rank["s1"].max() <= 100.0 and rank["s1"].min() >= 0.0
+
+
+def test_normalize_to_housekeeping():
+    # housekeeping genes present -> column scaled by their median (1.0 = baseline)
+    hk = list(gf.housekeeping_gene_ids())[:2]
+    gt = pd.DataFrame({"Ensembl_Gene_ID": [*hk, "ENSG00000999999"], "Symbol": ["H1", "H2", "X"]})
+    df = gt.assign(s1=[10.0, 30.0, 100.0])  # hk median = 20
+    out = norm.normalize_to_housekeeping(df)
+    assert np.allclose(out["s1"], [0.5, 1.5, 5.0])


### PR DESCRIPTION
## Summary
The normalization engine — puts per-cohort RNA-seq in a comparable space. Named **clean TPM** (no `v4` suffix, per your call).

## What changed
- **`cancerdata/normalization.py`**:
  - **`clean_tpm(matrix, gene_table)`** — two-compartment renormalization: the technical/QC compartment (mtDNA, rRNA, MALAT1/NEAT1, + ribosomal proteins by default) is forced to `technical_fraction` (25%) of the 1e6 budget and the biological compartment to the remaining 75%, each renormalized internally. So the variable pipeline-driven technical fraction no longer inflates real genes, and **biological clean TPM is cross-sample/cross-source comparable**. Verified: 250k/750k split exact, within-compartment ratios preserved, no-technical-mass samples keep technical at 0.
  - `drop_technical_genes()` / `filter_technical_rna()` — biology-only views.
  - `normalize_to_housekeeping()`, `log2_transform()`, `log1p_transform()`, `percentile_rank()`.
- Censored/family lists come from `gene_families` (R-norm); `clean_tpm_censored_gene_ids` gains `include_ribosomal_proteins=`.
- **Renamed** the remaining `clean_tpm_v4` prose to "clean TPM" (the data `processing_pipeline` provenance strings are left as-is — they record how the shipped data was actually built).

## Tests
`test_normalization.py`: two-compartment budget + ratio preservation, no-technical-mass, validation, drop/filter views, log/rank, housekeeping scaling. Full suite **233 pass** (+6); ruff clean.

Next: CTA regeneration (Phase C). Part of #35.