### PR TITLE
Resolve cancer-type aliases in samples_for_cancer_code (#22)

### DIFF
--- a/cancerdata/samples.py
+++ b/cancerdata/samples.py
@@ -26,6 +26,7 @@ from functools import lru_cache
 
 import pandas as pd
 
+from .cancer_types import resolve_cancer_type
 from .load_dataset import get_data
 
 
@@ -40,9 +41,13 @@ def sample_manifest() -> pd.DataFrame:
 
 
 def samples_for_cancer_code(code: str, *, included_only: bool = True) -> pd.DataFrame:
-    """Manifest rows assigned to a cancer code (included samples by default)."""
+    """Manifest rows assigned to a cancer code (included samples by default).
+
+    The code is alias-resolved, so ``"prostate"`` / ``"lung_adeno"`` / a pre-rename
+    code all work (an unknown code passes through and simply matches nothing)."""
+    resolved = resolve_cancer_type(code, strict=False) or code
     df = _manifest()
-    sub = df[df["cancer_code"].astype(str) == code]
+    sub = df[df["cancer_code"].astype(str) == resolved]
     if included_only and "included" in sub.columns:
         sub = sub[sub["included"].astype(str).str.lower().isin(("true", "1"))]
     return sub.copy()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,0 +1,35 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Per-sample curation manifest — incl. alias resolution (#22)."""
+
+from cancerdata import sample_manifest, samples_for_cancer_code
+
+
+def _a_present_code_with_alias():
+    # LAML is in the manifest and has the alias 'aml'.
+    codes = set(sample_manifest()["cancer_code"].astype(str))
+    assert "LAML" in codes
+    return "LAML", "aml"
+
+
+def test_samples_for_cancer_code_resolves_aliases():
+    code, alias = _a_present_code_with_alias()
+    by_code = samples_for_cancer_code(code)
+    by_alias = samples_for_cancer_code(alias)
+    assert len(by_code) > 0
+    assert by_alias.equals(by_code)  # alias resolves to the same canonical rows
+
+
+def test_unknown_code_returns_empty_not_error():
+    assert samples_for_cancer_code("NOT_A_REAL_CODE").empty
+
+
+def test_included_only_filters():
+    code, _ = _a_present_code_with_alias()
+    incl = samples_for_cancer_code(code, included_only=True)
+    allrows = samples_for_cancer_code(code, included_only=False)
+    assert len(incl) <= len(allrows)


### PR DESCRIPTION
## Summary
Fixes #22. `samples_for_cancer_code` compared the raw input against the manifest's `cancer_code` with **no alias resolution**, so `samples_for_cancer_code('aml')` / `'prostate'` / a pre-rename code silently returned an **empty** frame — unlike every other cancerdata accessor.

## Fix
Alias-resolve the code (`resolve_cancer_type(code, strict=False) or code`): `'aml'` → `LAML` → its 601 samples; an unknown code passes through and matches nothing (no crash, consistent with a graceful lookup).

## Tests
`test_samples.py`: alias resolves to the same canonical rows, unknown→empty, included-only filter. Full suite **240 pass** (+3); ruff clean.

Closes #22.