### PR TITLE
Maintainability cleanup: registry single-copy, shared thresholds, burden drift guard (#23)

### DIFF
--- a/cancerdata/cancer_types.py
+++ b/cancerdata/cancer_types.py
@@ -23,6 +23,7 @@ in ``data/cohort-registry.csv`` and ``data/cancer-cohort-aggregates.csv``.
 from __future__ import annotations
 
 import threading
+from functools import lru_cache
 
 from .load_dataset import get_data
 
@@ -219,6 +220,7 @@ def _clear_caches():
     not part of the public surface.
     """
     CANCER_TYPE_NAMES.clear_cache()
+    _registry_frame.cache_clear()
 
 
 def resolve_cancer_type(cancer_type, *, strict=True):
@@ -483,6 +485,13 @@ def cancer_type_families():
 # ---------- Cancer-type registry ----------
 
 
+@lru_cache(maxsize=1)
+def _registry_frame():
+    """Cached registry frame (shared, read-only). Internal hot-path callers use
+    this; the public :func:`cancer_type_registry` returns a defensive copy."""
+    return get_data("cancer-type-registry", copy=False)
+
+
 def cancer_type_registry():
     """Return the cancer-type registry: one row per code with family / tissue /
     template / parent / source.
@@ -493,7 +502,7 @@ def cancer_type_registry():
     ``primary_template``, ``parent_code``, ``expression_source``, ``notes`` and
     more. Returns a defensive copy so callers can mutate freely.
     """
-    return get_data("cancer-type-registry").copy()
+    return _registry_frame().copy()
 
 
 def cancer_types_in_family(family):
@@ -528,7 +537,7 @@ def cancer_type_subtypes_of(parent_code):
 
 def _parent_of_map():
     """``{code: parent_code}`` from the registry (empty parents dropped)."""
-    df = cancer_type_registry()
+    df = _registry_frame()
     out = {}
     for code, parent in zip(df["code"], df["parent_code"]):
         if isinstance(parent, str) and parent:
@@ -577,7 +586,7 @@ def cancer_subtype_group(group_code, *, under=None):
 
 def _children_map():
     """``{parent_code: [child codes in registry order]}``."""
-    df = cancer_type_registry()
+    df = _registry_frame()
     out: dict[str, list[str]] = {}
     for code, parent in zip(df["code"], df["parent_code"]):
         if isinstance(parent, str) and parent:

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -35,6 +35,7 @@ import numpy as np
 import pandas as pd
 
 from . import data_bundle
+from ._build import WITHIN_SAMPLE_THRESHOLDS as _WITHIN_SAMPLE_THRESHOLD_COLS
 from .cancer_types import cohort_aggregates, resolve_cancer_type
 from .load_dataset import _BUNDLED_DATA_DIR
 
@@ -226,12 +227,9 @@ def cohort_gene_percentiles(cancer_type, *, as_tpm: bool = True) -> pd.DataFrame
 
 # ---------- within-sample percentile prevalence (signal a) ----------
 
-#: within-sample percentile-rank threshold -> output column in the artifact.
-_WITHIN_SAMPLE_THRESHOLD_COLS = {
-    0.99: "frac_samples_top1pct",
-    0.95: "frac_samples_top5pct",
-    0.90: "frac_samples_top10pct",
-}
+#: within-sample percentile-rank threshold -> output column: ``_WITHIN_SAMPLE_THRESHOLD_COLS``
+#: (imported above from :data:`cancerdata._build.WITHIN_SAMPLE_THRESHOLDS`) is the single
+#: source of truth shared with the generator, so the read side and write side can't drift.
 
 
 def _within_sample_root(*, proteoform: bool = False) -> Path:

--- a/cancerdata/incidence.py
+++ b/cancerdata/incidence.py
@@ -80,6 +80,7 @@ _PRIMARY_TISSUE_BURDEN = {
     "prostate": "prostate",
     "colon": "colorectal",
     "rectum": "colorectal",
+    "colorectum": "colorectal",  # the CRC parent node (subtypes split colon/rectum)
     "pancreas": "pancreas",
     "liver": "liver",
     "bile_duct": "gallbladder_biliary",
@@ -121,6 +122,8 @@ _PRIMARY_TISSUE_BURDEN = {
     "skin": "melanoma",
     "epidermis": "non_melanoma_skin",  # BCC / cSCC keratinocyte carcinomas
     "ependyma": "brain_cns",
+    "meninges": "brain_cns",
+    "choroid_plexus": "brain_cns",
     "sellar_suprasellar": "brain_cns",
     "pons_midline": "brain_cns",
     "pituitary": "brain_cns",
@@ -137,6 +140,9 @@ _PRIMARY_TISSUE_BURDEN = {
     "nerve_sheath": "soft_tissue_sarcoma",
     "vascular_endothelium": "soft_tissue_sarcoma",
     "gi_wall": "soft_tissue_sarcoma",
+    # Site-agnostic NET parent node; organ-specific NET subtypes carry their own
+    # primary_tissue (pancreas, lung, ...) and route there instead.
+    "neuroendocrine": "other_and_unknown_primary",
 }
 # Heme (non-plasma): lymph node -> lymphoma; marrow/blood/spleen -> leukemia.
 # AML and Hodgkin are exceptions carried in cancer-code-burden-map.csv.

--- a/cancerdata/proteoforms.py
+++ b/cancerdata/proteoforms.py
@@ -134,7 +134,10 @@ def proteoform_for_gene(gene: str) -> str | None:
     symbol (case-insensitive). ``None`` if the gene isn't in any group."""
     key = str(gene).split(".")[0]
     mapping = _member_to_label()
-    return mapping.get(key) or mapping.get(str(gene).upper())
+    label = mapping.get(key)
+    if label is None:
+        label = mapping.get(str(gene).upper())
+    return label
 
 
 def gene_to_proteoform() -> dict[str, str]:

--- a/tests/test_incidence.py
+++ b/tests/test_incidence.py
@@ -47,3 +47,16 @@ def test_burden_category_override_table():
 
 def test_burden_category_unknown_returns_none():
     assert incidence.burden_category("not_a_real_cancer") is None
+
+
+def test_every_registry_code_resolves_to_a_burden_category():
+    # Drift guard: the primary_tissue/family -> burden maps in incidence.py must
+    # cover the registry's vocabulary. A new registry primary_tissue/family that
+    # nothing maps would silently yield None here.
+    from cancerdata.cancer_types import cancer_type_registry
+
+    registry = cancer_type_registry()
+    unmapped = [
+        code for code in registry["code"].astype(str) if incidence.burden_category(code) is None
+    ]
+    assert not unmapped, f"registry codes with no burden category: {unmapped}"


### PR DESCRIPTION
Closes #23 — the full maintainability cluster from review.

1. **Registry re-copy on hot paths.** `cancer_type_registry()` is now backed by an `lru_cache`'d `_registry_frame()` that parses the CSV once; the public function copies only on the boundary. Internal `_parent_of_map`/`_children_map` read the shared frame directly (no per-call copy). `_clear_caches()` drops `_registry_frame` too, so the test hook that swaps the registry CSV stays correct.
2. **Duplicated thresholds.** `expression.py` now imports `WITHIN_SAMPLE_THRESHOLDS` from `_build.py` (one source of truth; read side and write side can't drift).
3. **Shared-cache mutation** (`_proteoform_frame`) — already fixed earlier (D2).
4. **Hardcoded burden map drift.** New test asserts every registry code resolves to a non-None burden category. It caught 4 real gaps now fixed: `colorectum` (CRC parent), `meninges` + `choroid_plexus` (→ brain_cns), and the site-agnostic `neuroendocrine` parent (→ other_and_unknown_primary).
5. **`proteoform_for_gene` truthiness fallback.** Now uses `is None`, so an empty label can't silently retry through the symbol namespace.

All 241 tests pass; ruff format + check clean.