### PR TITLE
Reconcile CGB8 into the CTA universe (#20)

### DIFF
--- a/cancerdata/cta.py
+++ b/cancerdata/cta.py
@@ -40,14 +40,16 @@ from .load_dataset import get_data
 MANUALLY_EXPRESSED_CTA: frozenset[str] = frozenset({"ENSG00000171405"})  # XAGE5
 
 #: Genes present in a source database but excluded from the CTA universe — core
-#: histones, placental hCG-beta, alpha-tubulins (not tumor-restricted antigens).
+#: histones and alpha-tubulins (housekeeping structural genes, not tumor-restricted
+#: antigens). The placental hCG-beta locus CGB8 is **not** excluded: it passes the
+#: HPA reproductive-restriction filter exactly like its siblings CGB1/2/3/5/7 (all
+#: kept), so excluding it alone was an inconsistency (see #20).
 NON_CTA_EXCLUDED_GENE_IDS: frozenset[str] = frozenset(
     {
         "ENSG00000274618",  # H4C6
         "ENSG00000146047",  # H2BC1
         "ENSG00000276410",  # H2BC3
         "ENSG00000124610",  # H1-1
-        "ENSG00000213030",  # CGB8 (placental hCG-beta)
         "ENSG00000198033",  # TUBA3C
         "ENSG00000152086",  # TUBA3E
     }

--- a/tests/test_cta.py
+++ b/tests/test_cta.py
@@ -47,6 +47,16 @@ def test_non_cta_excluded_genes_dropped():
     assert cta.NON_CTA_EXCLUDED_GENE_IDS.isdisjoint(cta.CTA_unfiltered_gene_ids())
 
 
+def test_cgb8_not_deny_listed():
+    # #20: CGB8 was hardcoded out as "placental hCG-beta" while its hCG-beta
+    # siblings (CGB1/2/3/5/7) flow through the normal HPA filter. CGB8 must be
+    # curated by that same filter, not a one-gene deny-list. It passes the filter
+    # (protein REPRODUCTIVE), so it lands in the filtered set like CGB2.
+    assert "ENSG00000213030" not in cta.NON_CTA_EXCLUDED_GENE_IDS
+    assert "CGB8" in cta.CTA_unfiltered_gene_names()
+    assert "CGB8" in cta.CTA_filtered_gene_names()
+
+
 def test_evidence_has_no_ms_columns():
     # MS-runtime columns stay in the target-selection layer, not cancerdata.
     cols = set(cta.CTA_evidence().columns)


### PR DESCRIPTION
Closes the last open item of #20 (the CGB8 divergence). The architectural duplication and the sub-floor confidence cap (tsarina#114) were already resolved by the native CTA regeneration in #47; this handles the remaining one-gene curation drift.

**What was wrong:** `CGB8` (ENSG00000213030) was hardcoded into `NON_CTA_EXCLUDED_GENE_IDS` with the rationale "placental hCG-beta (not tumor-restricted antigens)". But that rationale doesn't hold up against its own siblings — CGB1/2/3/5/7 all flow through the normal HPA reproductive-restriction filter, and several PSG placental genes ship as CTAs. CGB8 passes that filter identically (`protein_restriction=REPRODUCTIVE`, `passes_filters=True`, `never_expressed=False`). Excluding it alone was exactly the drift vs tsarina#111 that #20 flagged.

**Fix:** drop CGB8 from the deny-list so it's curated by the HPA pipeline like its siblings. It lands in the expressed CTA set (table goes 381 → 382 rows). A new `test_cgb8_not_deny_listed` pins the invariant so it can't silently re-drift.

The deny-list now holds only true housekeeping structural genes (core histones, alpha-tubulins). All 242 tests pass; ruff clean.