### PR TITLE
Phase B: per-cohort percentile + n=5 representative generators (#35)

### DIFF
--- a/cancerdata/_build.py
+++ b/cancerdata/_build.py
@@ -22,9 +22,43 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 
+import numpy as np
 import pandas as pd
 
 _ID_COLS = ("Ensembl_Gene_ID", "Symbol")
+
+#: Per-gene cohort percentile breakpoints — dense in the actionable upper tail so
+#: a consumer can place a sample's gene as a percentile rank within the cohort
+#: (matches the shipped ``cancer-reference-expression-percentiles`` schema: 26
+#: ``p{n}`` columns from p0 to p100). Read back by ``expression.cohort_gene_percentiles``.
+PERCENTILE_BREAKPOINTS = (
+    0,
+    1,
+    5,
+    10,
+    15,
+    20,
+    25,
+    30,
+    35,
+    40,
+    45,
+    50,
+    55,
+    60,
+    65,
+    70,
+    75,
+    80,
+    85,
+    90,
+    95,
+    96,
+    97,
+    98,
+    99,
+    100,
+)
 
 #: threshold (within-sample percentile rank) -> output column name.
 #: 0.95 = "in the top 5% of expressed genes in that sample".
@@ -132,3 +166,105 @@ def within_sample_top_fractions(
         out[f"frac_samples_top{pct}pct"] = (ranks >= t).mean(axis=1).to_numpy()
     out["n_samples"] = len(cols)
     return out
+
+
+def cohort_percentile_vectors(
+    df: pd.DataFrame,
+    sample_cols: Iterable[str] | None = None,
+    *,
+    breakpoints: Iterable[int] = PERCENTILE_BREAKPOINTS,
+    store_log1p: bool = True,
+) -> pd.DataFrame:
+    """Per-gene cohort percentile vector (the ``…-percentiles`` artifact).
+
+    For each gene, take its expression across the cohort's samples and reduce that
+    distribution to the ``breakpoints`` percentiles (``p0`` = min … ``p50`` =
+    median … ``p100`` = max). Unlike :func:`within_sample_top_fractions` (the
+    within-sample, across-genes axis), this is the within-cohort, across-samples
+    axis — it lets a consumer place a sample's gene as a percentile rank within
+    the cohort rather than an absolute TPM.
+
+    Computed on whatever rows are passed in — the generator drops technical genes
+    first, so the breakpoints describe the biological clean-TPM view. ``NaN``
+    cells (a gene unmeasured in some samples) are ignored per gene. Stored as
+    ``log1p`` (``store_log1p=True``) in ``float16`` for compactness, exactly the
+    encoding :func:`cancerdata.expression.cohort_gene_percentiles` restores with
+    ``expm1``. Returns one row per gene with ``Ensembl_Gene_ID``, ``Symbol`` and a
+    ``p{n}`` column per breakpoint.
+    """
+    cols = list(sample_cols) if sample_cols is not None else sample_columns(df)
+    if not cols:
+        raise ValueError("no per-sample columns to summarize")
+    bps = list(breakpoints)
+
+    mat = df[cols].to_numpy(dtype=float)
+    if store_log1p:
+        mat = np.log1p(mat)
+    # nanpercentile down the sample axis (axis=1) -> shape (len(bps), n_genes).
+    # all-NaN gene rows yield NaN (np warns); suppress since it's expected.
+    with np.errstate(all="ignore"):
+        q = np.nanpercentile(mat, bps, axis=1)
+
+    out = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": df["Ensembl_Gene_ID"].astype(str).to_numpy(),
+            "Symbol": df["Symbol"].astype(str).to_numpy(),
+        }
+    )
+    for i, bp in enumerate(bps):
+        out[f"p{bp}"] = q[i].astype("float16")
+    return out
+
+
+def cohort_medoids(
+    df: pd.DataFrame,
+    sample_cols: Iterable[str] | None = None,
+    *,
+    k: int = 5,
+    distance_log1p: bool = True,
+) -> pd.DataFrame:
+    """Pick ``k`` representative real per-sample vectors spanning a cohort.
+
+    The packaged cohort references are aggregates; this selects a bounded set of
+    *real* per-sample columns to keep (the ``…-representatives`` artifact). The
+    first pick is the cohort medoid — the sample minimizing total distance to all
+    others (the most central, "typical" tumor). Each subsequent pick is the
+    sample farthest (max–min Euclidean distance) from those already chosen, a
+    deterministic farthest-first traversal that spreads the picks across the
+    within-cohort variation rather than clustering them near the center.
+
+    Distance is computed on ``log1p`` TPM (``distance_log1p=True``) so a few
+    very-high-TPM genes don't dominate the geometry, but the returned values are
+    the **original** TPM (the artifact ships clean TPM; the reader optionally
+    ``log1p``-transforms). Cohorts with ``≤ k`` samples keep all of them, in
+    input order. Returns ``Ensembl_Gene_ID``, ``Symbol`` and the ``k`` selected
+    sample columns (original names), medoid first.
+    """
+    cols = list(sample_cols) if sample_cols is not None else sample_columns(df)
+    if not cols:
+        raise ValueError("no per-sample columns to choose from")
+    base = ["Ensembl_Gene_ID", "Symbol"]
+
+    if len(cols) <= k:
+        return df[base + cols].reset_index(drop=True)
+
+    mat = df[cols].to_numpy(dtype=float).T  # samples × genes
+    if distance_log1p:
+        mat = np.log1p(mat)
+    mat = np.nan_to_num(mat, nan=0.0)
+
+    # Pairwise squared Euclidean via the ||a-b||^2 = ||a||^2 + ||b||^2 - 2a·b
+    # identity (avoids materializing an n×n×g intermediate).
+    gram = mat @ mat.T
+    sq_norms = np.diag(gram)
+    sq = sq_norms[:, None] + sq_norms[None, :] - 2.0 * gram
+    dist = np.sqrt(np.maximum(sq, 0.0))
+
+    selected = [int(np.argmin(dist.sum(axis=1)))]  # central medoid
+    while len(selected) < k:
+        min_to_selected = dist[:, selected].min(axis=1)
+        min_to_selected[selected] = -np.inf  # never re-pick
+        selected.append(int(np.argmax(min_to_selected)))
+
+    keep = [cols[i] for i in selected]
+    return df[base + keep].reset_index(drop=True)

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -145,6 +145,10 @@ def representative_cohort_samples(
         )
     if format not in ("wide", "long"):
         raise ValueError("format must be 'wide' or 'long'")
+    if include_provenance and format != "long":
+        # Provenance is per-representative (one row each); it only attaches to the
+        # long form. Fail loudly rather than silently dropping the request.
+        raise ValueError("include_provenance=True requires format='long'")
 
     root = _representatives_root()
     available = set(available_representative_cohorts())

--- a/scripts/generate_cohort_percentiles.py
+++ b/scripts/generate_cohort_percentiles.py
@@ -1,0 +1,109 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build the per-gene × cohort *percentile-vector* artifact (within-cohort axis).
+
+For each cohort with a per-sample expression matrix, reduce every gene's
+distribution across that cohort's samples to a dense set of percentile
+breakpoints (p0…p100, dense in the upper tail). This is the within-cohort,
+across-samples axis — "where does this gene sit in the cohort's distribution" —
+the complement of the within-sample artifact. A consumer can then place a new
+sample's gene as a percentile rank within the cohort instead of an absolute TPM.
+
+It is computed from the full per-sample matrices, which are never shipped (see
+``source_matrices`` for the per-cohort fetch). Pass ``--drop-genes`` with the
+clean-TPM censored-gene list so the breakpoints describe the biological view the
+reader expects (``cancerdata.gene_families.clean_tpm_censored_gene_ids``).
+
+Input
+-----
+A directory of per-cohort parquet files, one per cohort code
+(``<INPUT>/<CODE>.parquet``), each with ``Ensembl_Gene_ID`` + ``Symbol`` columns
+and one column per sample (clean TPM).
+
+Output
+------
+``cancerdata/data/cancer-reference-expression-percentiles/<CODE>.parquet`` with
+``Ensembl_Gene_ID, Symbol`` and 26 ``p{n}`` columns, stored log1p + float16 — the
+exact encoding ``expression.cohort_gene_percentiles`` restores with ``expm1``.
+
+Run:
+    python scripts/generate_cohort_percentiles.py --input <per-sample-dir>
+
+After building, ensure ``cancer-reference-expression-percentiles`` is in
+``data_bundle.DOWNLOADABLE_PATHS``, rebuild + upload the data tarball, and bump
+``DATA_VERSION`` (never bump it before the tarball is uploaded — a 404 hangs fetch).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cancerdata._build import cohort_percentile_vectors, sample_columns
+
+_DATA_DIR = Path(__file__).resolve().parents[1] / "cancerdata" / "data"
+OUT_DIR = _DATA_DIR / "cancer-reference-expression-percentiles"
+
+
+def _load_drop_genes(path: Path | None) -> set[str]:
+    if path is None:
+        return set()
+    return {line.strip() for line in path.read_text().splitlines() if line.strip()}
+
+
+def build(input_dir: Path, *, drop_genes: set[str], out_dir: Path = OUT_DIR) -> None:
+    """Build the percentile-vector artifact for each cohort under ``input_dir``."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shards = sorted(input_dir.glob("*.parquet"))
+    if not shards:
+        raise SystemExit(f"no per-sample parquet files under {input_dir}")
+    n = 0
+    for shard in shards:
+        code = shard.stem
+        df = pd.read_parquet(shard)
+        if drop_genes:
+            df = df[~df["Ensembl_Gene_ID"].astype(str).isin(drop_genes)].reset_index(drop=True)
+        cols = sample_columns(df)
+        if not cols:
+            print(f"  {code}: no sample columns, skipped", flush=True)
+            continue
+        out = cohort_percentile_vectors(df, cols)
+        out.to_parquet(out_dir / f"{code}.parquet", index=False, compression="zstd")
+        n += 1
+        print(f"  {code}: {len(out)} genes (n={len(cols)})", flush=True)
+    total_mb = sum(f.stat().st_size for f in out_dir.glob("*.parquet")) / 1e6
+    print(f"\ndone: {n} cohorts, {total_mb:.1f} MB -> {out_dir}", flush=True)
+
+
+def main(argv=None) -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--input", required=True, type=Path, help="Dir of per-cohort per-sample parquet files"
+    )
+    p.add_argument(
+        "--drop-genes",
+        type=Path,
+        default=None,
+        help="Optional newline-delimited Ensembl IDs of technical genes to drop",
+    )
+    args = p.parse_args(argv)
+    build(args.input, drop_genes=_load_drop_genes(args.drop_genes))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_representatives.py
+++ b/scripts/generate_representatives.py
@@ -1,0 +1,114 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build the per-cohort *representative-samples* artifact (n=5 medoids).
+
+The packaged cohort references are aggregates (median/percentile vectors); some
+consumers need a few *real* joint per-sample vectors per cohort — e.g. to show
+co-expression that an aggregate washes out. For each cohort this keeps ``k``
+medoid samples: the cohort medoid (most central tumor) first, then farthest-first
+picks that span the within-cohort variation (see ``_build.cohort_medoids``).
+
+Computed from the full per-sample matrices, which are never shipped (see
+``source_matrices`` for the per-cohort fetch). The kept columns store the
+**original** clean TPM (the reader optionally ``log1p``-transforms); only the
+medoid *distance* geometry uses log1p so a few high-TPM genes don't dominate.
+
+Input
+-----
+A directory of per-cohort parquet files, one per cohort code
+(``<INPUT>/<CODE>.parquet``), each with ``Ensembl_Gene_ID`` + ``Symbol`` columns
+and one column per sample (clean TPM).
+
+Output
+------
+``cancerdata/data/cancer-reference-expression-representatives/<CODE>.parquet``
+with ``Ensembl_Gene_ID, Symbol`` and up to ``k`` representative columns named
+``<CODE>__rep{i}`` (medoid first), plus a shared ``_provenance.csv`` mapping each
+``representative_id`` to its source sample, cohort, and cohort size — the columns
+``expression.representative_cohort_samples(include_provenance=True)`` reads back.
+
+Run:
+    python scripts/generate_representatives.py --input <per-sample-dir> [--k 5]
+
+After building, ensure ``cancer-reference-expression-representatives`` is in
+``data_bundle.DOWNLOADABLE_PATHS``, rebuild + upload the data tarball, and bump
+``DATA_VERSION`` (never bump it before the tarball is uploaded — a 404 hangs fetch).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cancerdata._build import cohort_medoids, sample_columns
+
+_DATA_DIR = Path(__file__).resolve().parents[1] / "cancerdata" / "data"
+OUT_DIR = _DATA_DIR / "cancer-reference-expression-representatives"
+_BASE = ["Ensembl_Gene_ID", "Symbol"]
+
+
+def build(input_dir: Path, *, k: int = 5, out_dir: Path = OUT_DIR) -> None:
+    """Build the representative-samples artifact for each cohort under ``input_dir``."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shards = sorted(input_dir.glob("*.parquet"))
+    if not shards:
+        raise SystemExit(f"no per-sample parquet files under {input_dir}")
+    n = 0
+    provenance: list[dict] = []
+    for shard in shards:
+        code = shard.stem
+        df = pd.read_parquet(shard)
+        n_cohort = len(sample_columns(df))
+        if n_cohort == 0:
+            print(f"  {code}: no sample columns, skipped", flush=True)
+            continue
+        reps = cohort_medoids(df, k=k)
+        source_cols = [c for c in reps.columns if c not in _BASE]
+        rep_ids = [f"{code}__rep{i}" for i in range(1, len(source_cols) + 1)]
+        reps = reps.rename(columns=dict(zip(source_cols, rep_ids)))
+        reps.to_parquet(out_dir / f"{code}.parquet", index=False, compression="zstd")
+        for rep_id, src in zip(rep_ids, source_cols):
+            provenance.append(
+                {
+                    "representative_id": rep_id,
+                    "source_cohort": code,
+                    "source_sample": src,
+                    "n_cohort_samples": n_cohort,
+                }
+            )
+        n += 1
+        print(f"  {code}: {len(rep_ids)} reps of {n_cohort} samples", flush=True)
+    pd.DataFrame(provenance).to_csv(out_dir / "_provenance.csv", index=False)
+    total_mb = sum(f.stat().st_size for f in out_dir.glob("*.parquet")) / 1e6
+    print(f"\ndone: {n} cohorts, {total_mb:.1f} MB -> {out_dir}", flush=True)
+
+
+def main(argv=None) -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--input", required=True, type=Path, help="Dir of per-cohort per-sample parquet files"
+    )
+    p.add_argument(
+        "--k", type=int, default=5, help="Representatives to keep per cohort (default 5)"
+    )
+    args = p.parse_args(argv)
+    build(args.input, k=args.k)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_representatives.py
+++ b/scripts/generate_representatives.py
@@ -60,6 +60,34 @@ from cancerdata._build import cohort_medoids, sample_columns
 _DATA_DIR = Path(__file__).resolve().parents[1] / "cancerdata" / "data"
 OUT_DIR = _DATA_DIR / "cancer-reference-expression-representatives"
 _BASE = ["Ensembl_Gene_ID", "Symbol"]
+#: Columns representative_cohort_samples(include_provenance=True) merges back in.
+_PROVENANCE_COLUMNS = ["representative_id", "source_cohort", "source_project", "n_cohort_samples"]
+
+
+def _cohort_provenance(code: str) -> tuple[str, str]:
+    """Best-effort ``(source_cohort, source_project)`` for a cancer code.
+
+    Looks the code up in the source-matrices registry (``cancer_code ->
+    source_cohort``) and that cohort up in the cohort registry (``-> source_project``).
+    Either lookup failing — an unregistered code, or running this generator on an
+    arbitrary input dir — falls back gracefully so the column is always present.
+    """
+    source_cohort, source_project = code, ""
+    try:
+        from cancerdata.source_matrices import cohort_info
+
+        info = cohort_info(code)
+        source_cohort = str(info.get("source_cohort") or code)
+    except Exception:
+        return source_cohort, source_project
+    try:
+        from cancerdata.cancer_types import cohort_registry
+
+        entry = cohort_registry().get(source_cohort, {})
+        source_project = str(entry.get("source_project") or "")
+    except Exception:
+        pass
+    return source_cohort, source_project
 
 
 def build(input_dir: Path, *, k: int = 5, out_dir: Path = OUT_DIR) -> None:
@@ -82,18 +110,22 @@ def build(input_dir: Path, *, k: int = 5, out_dir: Path = OUT_DIR) -> None:
         rep_ids = [f"{code}__rep{i}" for i in range(1, len(source_cols) + 1)]
         reps = reps.rename(columns=dict(zip(source_cols, rep_ids)))
         reps.to_parquet(out_dir / f"{code}.parquet", index=False, compression="zstd")
+        source_cohort, source_project = _cohort_provenance(code)
         for rep_id, src in zip(rep_ids, source_cols):
             provenance.append(
                 {
                     "representative_id": rep_id,
-                    "source_cohort": code,
+                    "source_cohort": source_cohort,
+                    "source_project": source_project,
                     "source_sample": src,
                     "n_cohort_samples": n_cohort,
                 }
             )
         n += 1
         print(f"  {code}: {len(rep_ids)} reps of {n_cohort} samples", flush=True)
-    pd.DataFrame(provenance).to_csv(out_dir / "_provenance.csv", index=False)
+    # Stable column order; source_sample is kept as extra provenance the reader ignores.
+    prov_df = pd.DataFrame(provenance, columns=[*_PROVENANCE_COLUMNS, "source_sample"])
+    prov_df.to_csv(out_dir / "_provenance.csv", index=False)
     total_mb = sum(f.stat().st_size for f in out_dir.glob("*.parquet")) / 1e6
     print(f"\ndone: {n} cohorts, {total_mb:.1f} MB -> {out_dir}", flush=True)
 

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -1,0 +1,193 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from cancerdata import _build
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load_script(name):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _matrix(genes, samples, values):
+    """genes × samples DataFrame with id columns."""
+    df = pd.DataFrame(values, columns=samples)
+    df.insert(0, "Symbol", [f"G{i}" for i in range(len(genes))])
+    df.insert(0, "Ensembl_Gene_ID", genes)
+    return df
+
+
+# ---------- cohort_percentile_vectors ----------
+
+
+def test_percentile_vectors_schema_matches_reader():
+    # 26 dense breakpoints p0..p100, plus the two id columns — the exact schema
+    # expression.cohort_gene_percentiles reads back.
+    genes = ["A", "B"]
+    vals = np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]])
+    out = _build.cohort_percentile_vectors(_matrix(genes, list("wxyz"), vals))
+    bp_cols = [c for c in out.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    assert len(bp_cols) == 26
+    assert bp_cols[0] == "p0" and bp_cols[-1] == "p100"
+    assert "p50" in bp_cols
+    assert len(out) == 2
+
+
+def test_percentile_vectors_log1p_roundtrip():
+    # Stored log1p; expm1 of p0/p50/p100 recovers min/median/max of the gene's
+    # across-sample distribution (the reader's as_tpm=True path).
+    vals = np.array([[0.0, 10.0, 100.0, 1000.0]])
+    out = _build.cohort_percentile_vectors(_matrix(["A"], list("wxyz"), vals))
+    row = out.iloc[0]
+    assert np.isclose(np.expm1(np.float32(row["p0"])), 0.0, atol=1e-1)
+    assert np.isclose(np.expm1(np.float32(row["p100"])), 1000.0, rtol=2e-2)
+    # median of [0,10,100,1000] in log1p space, restored
+    expected_med = np.median(np.log1p(vals[0]))
+    assert np.isclose(np.float32(row["p50"]), expected_med, rtol=2e-2)
+
+
+def test_percentile_vectors_ignores_nan():
+    # A gene unmeasured in some samples: NaN cells are dropped, not treated as 0.
+    vals = np.array([[np.nan, 10.0, 10.0, 10.0]])
+    out = _build.cohort_percentile_vectors(_matrix(["A"], list("wxyz"), vals))
+    assert np.isclose(np.expm1(np.float32(out.iloc[0]["p50"])), 10.0, rtol=2e-2)
+
+
+def test_percentile_vectors_requires_samples():
+    with pytest.raises(ValueError):
+        _build.cohort_percentile_vectors(_matrix(["A"], [], np.empty((1, 0))))
+
+
+# ---------- cohort_medoids ----------
+
+
+def test_medoids_returns_base_plus_k():
+    rng = np.arange(50.0).reshape(5, 10)  # 5 genes × 10 samples
+    out = _build.cohort_medoids(
+        _matrix([f"g{i}" for i in range(5)], [f"s{j}" for j in range(10)], rng), k=3
+    )
+    rep_cols = [c for c in out.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    assert len(rep_cols) == 3
+    assert list(out["Ensembl_Gene_ID"]) == [f"g{i}" for i in range(5)]
+
+
+def test_medoids_small_cohort_keeps_all():
+    vals = np.array([[1.0, 2.0]])
+    out = _build.cohort_medoids(_matrix(["A"], ["s1", "s2"], vals), k=5)
+    assert [c for c in out.columns if c not in ("Ensembl_Gene_ID", "Symbol")] == ["s1", "s2"]
+
+
+def test_medoids_central_first_then_outlier():
+    # 4 near-identical "typical" samples + 1 far outlier. The medoid (pick 1)
+    # must come from the dense cluster; the farthest pick (2) must be the outlier.
+    genes = [f"g{i}" for i in range(6)]
+    typical = np.tile(np.array([[1.0], [2.0], [3.0], [4.0], [5.0], [6.0]]), (1, 4))
+    typical = typical + np.array([[0, 0.01, -0.01, 0.0]] * 6)  # tiny jitter
+    outlier = np.array([[100.0], [100.0], [100.0], [100.0], [100.0], [100.0]])
+    vals = np.hstack([typical, outlier])
+    samples = ["t1", "t2", "t3", "t4", "outlier"]
+    out = _build.cohort_medoids(_matrix(genes, samples, vals), k=2)
+    picks = [c for c in out.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    assert picks[0] != "outlier"  # central medoid from the dense cluster
+    assert picks[1] == "outlier"  # farthest-first grabs the outlier
+
+
+def test_medoids_preserve_original_tpm():
+    # Distance uses log1p internally, but stored values are the original TPM.
+    vals = np.array([[7.0, 8.0, 9.0]])
+    out = _build.cohort_medoids(_matrix(["A"], ["s1", "s2", "s3"], vals), k=3)
+    kept = out[[c for c in out.columns if c not in ("Ensembl_Gene_ID", "Symbol")]].to_numpy()
+    assert set(kept.ravel()) == {7.0, 8.0, 9.0}
+
+
+def test_medoids_deterministic():
+    rng = (np.arange(60.0) * 1.7 % 11).reshape(6, 10)
+    df = _matrix([f"g{i}" for i in range(6)], [f"s{j}" for j in range(10)], rng)
+    a = _build.cohort_medoids(df, k=4)
+    b = _build.cohort_medoids(df, k=4)
+    assert list(a.columns) == list(b.columns)
+
+
+# ---------- generator scripts (end-to-end on a synthetic per-sample dir) ----------
+
+
+def _write_cohort(tmp_path, code, genes, samples, values):
+    df = _matrix(genes, samples, values)
+    path = tmp_path / f"{code}.parquet"
+    df.to_parquet(path, index=False)
+    return path
+
+
+def test_percentiles_generator_writes_readable_shards(tmp_path):
+    gen = _load_script("generate_cohort_percentiles")
+    inp = tmp_path / "in"
+    inp.mkdir()
+    _write_cohort(
+        inp,
+        "COHORT_A",
+        ["A", "B"],
+        list("wxyz"),
+        np.array([[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]]),
+    )
+    out = tmp_path / "out"
+    gen.build(inp, drop_genes=set(), out_dir=out)
+    shard = pd.read_parquet(out / "COHORT_A.parquet")
+    assert len(shard) == 2
+    bp_cols = [c for c in shard.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    assert len(bp_cols) == 26
+    # p100 of gene A (max 4.0), stored log1p
+    a = shard[shard["Ensembl_Gene_ID"] == "A"].iloc[0]
+    assert np.isclose(np.expm1(np.float32(a["p100"])), 4.0, rtol=2e-2)
+
+
+def test_percentiles_generator_drops_genes(tmp_path):
+    gen = _load_script("generate_cohort_percentiles")
+    inp = tmp_path / "in"
+    inp.mkdir()
+    _write_cohort(
+        inp,
+        "COHORT_A",
+        ["KEEP", "DROPME"],
+        ["s1", "s2"],
+        np.array([[1.0, 2.0], [9.0, 9.0]]),
+    )
+    out = tmp_path / "out"
+    gen.build(inp, drop_genes={"DROPME"}, out_dir=out)
+    shard = pd.read_parquet(out / "COHORT_A.parquet")
+    assert list(shard["Ensembl_Gene_ID"]) == ["KEEP"]
+
+
+def test_representatives_generator_writes_shards_and_provenance(tmp_path):
+    gen = _load_script("generate_representatives")
+    inp = tmp_path / "in"
+    inp.mkdir()
+    # 6 samples so k=3 actually selects a subset
+    vals = np.array([[float(g * 10 + s) for s in range(6)] for g in range(4)])
+    _write_cohort(inp, "COHORT_A", [f"g{i}" for i in range(4)], [f"s{j}" for j in range(6)], vals)
+    out = tmp_path / "out"
+    gen.build(inp, k=3, out_dir=out)
+
+    shard = pd.read_parquet(out / "COHORT_A.parquet")
+    rep_cols = [c for c in shard.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    assert rep_cols == ["COHORT_A__rep1", "COHORT_A__rep2", "COHORT_A__rep3"]
+
+    prov = pd.read_csv(out / "_provenance.csv")
+    assert set(prov["representative_id"]) == set(rep_cols)
+    assert (prov["n_cohort_samples"] == 6).all()
+    assert (prov["source_cohort"] == "COHORT_A").all()

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -190,4 +190,10 @@ def test_representatives_generator_writes_shards_and_provenance(tmp_path):
     prov = pd.read_csv(out / "_provenance.csv")
     assert set(prov["representative_id"]) == set(rep_cols)
     assert (prov["n_cohort_samples"] == 6).all()
+    # The reader merges on these exact columns — all must be present (source_project
+    # is best-effort and empty for an unregistered synthetic code, but the column
+    # must exist so consumers don't KeyError).
+    for col in ("representative_id", "source_cohort", "source_project", "n_cohort_samples"):
+        assert col in prov.columns
+    # Unregistered code -> source_cohort falls back to the code itself.
     assert (prov["source_cohort"] == "COHORT_A").all()

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -58,3 +58,10 @@ def test_cohort_gene_percentiles_resolves_alias(percentile_cache):
 def test_cohort_gene_percentiles_missing_raises(percentile_cache):
     with pytest.raises(ValueError, match="no percentile vector"):
         expression.cohort_gene_percentiles("BRCA")
+
+
+def test_representatives_provenance_requires_long_format():
+    # Provenance is per-representative; asking for it in the default wide form is
+    # a no-op, so it must fail loudly rather than silently dropping the request.
+    with pytest.raises(ValueError, match="include_provenance=True requires format='long'"):
+        expression.representative_cohort_samples("PRAD", include_provenance=True)


### PR DESCRIPTION
Adds the two build-side generators that complete cancerdata's "**regenerate, not just hold**" goal for expression artifacts (#35 Phase B). Alongside the existing `generate_within_sample_top5.py`, cancerdata can now reproduce all three per-cohort artifacts from the raw per-sample matrices.

### What's added
- **`_build.cohort_percentile_vectors`** — per-gene, across-sample percentile vector: 26 tail-dense breakpoints (`p0..p100`), stored `log1p` + `float16`. This is the exact encoding `expression.cohort_gene_percentiles` restores with `expm1`, so the read side reads it unchanged.
- **`_build.cohort_medoids`** — deterministic n=5 representative selection: cohort medoid first (most central tumor, min total distance), then farthest-first picks that span the within-cohort variation. Distance is on `log1p` TPM (so a few high-TPM genes don't dominate the geometry); stored values are the **original** clean TPM the reader expects.
- **`scripts/generate_cohort_percentiles.py`** and **`scripts/generate_representatives.py`** — thin wrappers mirroring the within-sample generator (per-cohort parquet in/out, `--drop-genes` for the clean-TPM basis, a `_provenance.csv` sidecar mapping each `representative_id` → source sample/cohort/size, which `representative_cohort_samples(include_provenance=True)` reads back).

### Testing
12 unit + end-to-end tests: schema matches the readers, `log1p` round-trip recovers min/median/max, per-gene NaN handling, central-then-outlier selection, original-TPM preservation, determinism, and the generator scripts' file writes + provenance on a synthetic per-sample dir. Full suite 254 passed; ruff clean.

### Blocker (scoped honestly)
The real run still awaits the **never-shipped per-sample matrices** (the same external blocker as #13/D4). Per the established protocol for blocked work, the generators + pure cores are landed and fully tested on synthetic fixtures now, so producing the artifacts is a one-command step once the matrices are fetchable via `source_matrices`.