### PR TITLE
Harden fetch/cache against partial/corrupt caches (#21)

### DIFF
--- a/cancerdata/data_bundle.py
+++ b/cancerdata/data_bundle.py
@@ -129,10 +129,24 @@ def cache_dir() -> Path:
     return cache_root() / f"v{DATA_VERSION}"
 
 
+def _path_complete(path: Path) -> bool:
+    """A downloadable entry counts as present only if it actually holds data.
+
+    A bare file must exist; a directory must contain at least one file. An
+    interrupted extract that created the shard directories but no shards (or a
+    legacy/empty cache dir) would otherwise read as "local" forever and never
+    re-fetch — later reads then fail with confusing empties (issue #21)."""
+    if not path.exists():
+        return False
+    if path.is_dir():
+        return any(f.is_file() for f in path.rglob("*"))
+    return True
+
+
 def is_local() -> bool:
-    """Every downloadable path exists in the cache for this version."""
+    """Every downloadable path is present AND non-empty in the cache."""
     root = cache_dir()
-    return all((root / p).exists() for p in DOWNLOADABLE_PATHS)
+    return all(_path_complete(root / p) for p in DOWNLOADABLE_PATHS)
 
 
 def find(relative_path: str) -> Path | None:

--- a/cancerdata/reference_data.py
+++ b/cancerdata/reference_data.py
@@ -140,19 +140,40 @@ def _write_manifest(manifest: dict) -> None:
         _manifest_path().write_text(json.dumps(manifest, indent=2, sort_keys=True))
 
 
+def _cached_file_ok(name: str, dest: Path) -> bool:
+    """Cheap reuse check: trust an existing cached file only if its size matches
+    the size recorded in the manifest (when one exists). Catches a TSV left
+    truncated by a process killed mid-extract — a partial write that the old
+    ``exists()``-only reuse would have served forever (issue #21). A file with no
+    manifest record is trusted (can't disprove; preserves back-compat). The full
+    content hash is checked only on explicit :func:`verify` to avoid re-hashing a
+    large TSV on every access."""
+    record = _read_manifest().get(name) or {}
+    expected = record.get("bytes")
+    if expected is None or str(record.get("path")) != str(dest):
+        return True
+    try:
+        return dest.stat().st_size == int(expected)
+    except OSError:
+        return False
+
+
 def download(name: str, version: str | None = None, *, force: bool = False) -> Path:
     """Download *name*/*version* into the cache (extracting the ``.zip``) and
-    record it in the manifest. A cached copy is reused unless ``force=True``."""
+    record it in the manifest. A cached copy is reused unless ``force=True`` —
+    or it fails the manifest size check (a truncated/partial cache), in which
+    case it is re-fetched."""
     version = resolve_version(name, version)
     spec = _source(name)
     dest = local_path(name, version)
     url = spec["urls"][version]
 
-    if dest.exists() and not force:
+    if dest.exists() and not force and _cached_file_ok(name, dest):
         return dest
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     tmp_zip = dest.parent / (spec["filename"] + ".zip.part")
+    tmp_tsv = dest.parent / (spec["filename"] + ".part")
     try:
         sys.stderr.write(f"cancerdata: downloading {name} ({url})\n")
         sys.stderr.flush()
@@ -160,13 +181,16 @@ def download(name: str, version: str | None = None, *, force: bool = False) -> P
             shutil.copyfileobj(resp, h, length=1024 * 1024)
         with zipfile.ZipFile(tmp_zip) as zf:
             member = _zip_member(zf, spec["filename"])
-            with zf.open(member) as src, dest.open("wb") as out:
+            with zf.open(member) as src, tmp_tsv.open("wb") as out:
                 shutil.copyfileobj(src, out, length=1024 * 1024)
+        # Atomic promote: a process killed mid-extract leaves tmp_tsv, never a
+        # partial dest. A prior good copy survives a failed re-download untouched.
+        os.replace(tmp_tsv, dest)
     except Exception as e:  # network / zip / IO — surface uniformly
-        dest.unlink(missing_ok=True)
         raise ReferenceDataError(f"failed to download {name} ({url}): {e}") from e
     finally:
         tmp_zip.unlink(missing_ok=True)
+        tmp_tsv.unlink(missing_ok=True)
 
     manifest = _read_manifest()
     manifest[name] = {
@@ -181,6 +205,25 @@ def download(name: str, version: str | None = None, *, force: bool = False) -> P
     return dest
 
 
+def verify(name: str, version: str | None = None) -> bool:
+    """Full-content integrity check of a cached source against the manifest sha256.
+
+    Returns ``True`` when the cached file's sha256 matches what the manifest
+    recorded at download time, ``False`` on mismatch or when the file is missing.
+    Raises if there is no manifest record to check against (nothing to verify).
+    Unlike the cheap size check on reuse, this re-hashes the file — call it
+    deliberately (a cache audit), not on every access."""
+    version = resolve_version(name, version)
+    dest = local_path(name, version)
+    record = _read_manifest().get(name) or {}
+    expected = record.get("sha256")
+    if not expected:
+        raise ReferenceDataError(f"no manifest sha256 recorded for {name!r}; nothing to verify")
+    if not dest.exists():
+        return False
+    return hashlib.sha256(dest.read_bytes()).hexdigest() == expected
+
+
 def _zip_member(zf: zipfile.ZipFile, preferred: str) -> str:
     """Pick the .tsv member to extract (preferred name, else the first .tsv)."""
     names = zf.namelist()
@@ -193,9 +236,12 @@ def _zip_member(zf: zipfile.ZipFile, preferred: str) -> str:
 
 
 def ensure(name: str, version: str | None = None) -> Path:
-    """Return a local path to *name*/*version*, downloading if absent."""
+    """Return a local path to *name*/*version*, downloading if absent or if the
+    cached copy fails the manifest size check (a truncated/partial file)."""
     path = local_path(name, version)
-    return path if path.exists() else download(name, version)
+    if path.exists() and _cached_file_ok(name, path):
+        return path
+    return download(name, version)
 
 
 def status() -> list[dict]:

--- a/cancerdata/reference_data.py
+++ b/cancerdata/reference_data.py
@@ -124,6 +124,26 @@ def _manifest_path() -> Path:
     return cache_dir() / "manifest.json"
 
 
+def _manifest_key(name: str, version: str) -> str:
+    """Manifest record key. Keyed by ``(name, version)`` so each cached version of
+    a multi-version source (e.g. ``hpa_rna_consensus`` v23 + latest) keeps its own
+    size/sha256 record — a single per-name record would only validate whichever
+    version was downloaded last."""
+    return f"{name}@{version}"
+
+
+def _manifest_record(name: str, version: str) -> dict:
+    """The manifest record for ``(name, version)``. Falls back to a legacy
+    per-name record (pre-versioned-key manifests) so an existing cache keeps its
+    provenance until the next download rewrites it in the new layout."""
+    manifest = _read_manifest()
+    record = manifest.get(_manifest_key(name, version))
+    if record is not None:
+        return record
+    legacy = manifest.get(name) or {}
+    return legacy if legacy.get("version") == version else {}
+
+
 def _read_manifest() -> dict:
     path = _manifest_path()
     if not path.exists():
@@ -140,17 +160,16 @@ def _write_manifest(manifest: dict) -> None:
         _manifest_path().write_text(json.dumps(manifest, indent=2, sort_keys=True))
 
 
-def _cached_file_ok(name: str, dest: Path) -> bool:
+def _cached_file_ok(name: str, version: str, dest: Path) -> bool:
     """Cheap reuse check: trust an existing cached file only if its size matches
-    the size recorded in the manifest (when one exists). Catches a TSV left
-    truncated by a process killed mid-extract — a partial write that the old
-    ``exists()``-only reuse would have served forever (issue #21). A file with no
-    manifest record is trusted (can't disprove; preserves back-compat). The full
-    content hash is checked only on explicit :func:`verify` to avoid re-hashing a
-    large TSV on every access."""
-    record = _read_manifest().get(name) or {}
-    expected = record.get("bytes")
-    if expected is None or str(record.get("path")) != str(dest):
+    the size recorded in the manifest for this ``(name, version)`` (when one
+    exists). Catches a TSV left truncated by a process killed mid-extract — a
+    partial write that the old ``exists()``-only reuse would have served forever
+    (issue #21). A file with no manifest record is trusted (can't disprove;
+    preserves back-compat). The full content hash is checked only on explicit
+    :func:`verify` to avoid re-hashing a large TSV on every access."""
+    expected = _manifest_record(name, version).get("bytes")
+    if expected is None:
         return True
     try:
         return dest.stat().st_size == int(expected)
@@ -168,7 +187,7 @@ def download(name: str, version: str | None = None, *, force: bool = False) -> P
     dest = local_path(name, version)
     url = spec["urls"][version]
 
-    if dest.exists() and not force and _cached_file_ok(name, dest):
+    if dest.exists() and not force and _cached_file_ok(name, version, dest):
         return dest
 
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -193,7 +212,8 @@ def download(name: str, version: str | None = None, *, force: bool = False) -> P
         tmp_tsv.unlink(missing_ok=True)
 
     manifest = _read_manifest()
-    manifest[name] = {
+    manifest[_manifest_key(name, version)] = {
+        "name": name,
         "version": version,
         "url": url,
         "path": str(dest),
@@ -215,10 +235,11 @@ def verify(name: str, version: str | None = None) -> bool:
     deliberately (a cache audit), not on every access."""
     version = resolve_version(name, version)
     dest = local_path(name, version)
-    record = _read_manifest().get(name) or {}
-    expected = record.get("sha256")
+    expected = _manifest_record(name, version).get("sha256")
     if not expected:
-        raise ReferenceDataError(f"no manifest sha256 recorded for {name!r}; nothing to verify")
+        raise ReferenceDataError(
+            f"no manifest sha256 recorded for {name!r} {version}; nothing to verify"
+        )
     if not dest.exists():
         return False
     return hashlib.sha256(dest.read_bytes()).hexdigest() == expected
@@ -238,19 +259,19 @@ def _zip_member(zf: zipfile.ZipFile, preferred: str) -> str:
 def ensure(name: str, version: str | None = None) -> Path:
     """Return a local path to *name*/*version*, downloading if absent or if the
     cached copy fails the manifest size check (a truncated/partial file)."""
+    version = resolve_version(name, version)
     path = local_path(name, version)
-    if path.exists() and _cached_file_ok(name, path):
+    if path.exists() and _cached_file_ok(name, version, path):
         return path
     return download(name, version)
 
 
 def status() -> list[dict]:
     """One row per source: cached?, version, size, description."""
-    manifest = _read_manifest()
     rows = []
     for name, spec in REFERENCE_SOURCES.items():
         path = local_path(name)
-        record = manifest.get(name) or {}
+        record = _manifest_record(name, DEFAULT_HPA_VERSION)
         rows.append(
             {
                 "name": name,

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -48,6 +48,28 @@ def test_status_reports_missing_without_download(monkeypatch, tmp_path):
     assert all(not v["present"] for v in snap["items"].values())
 
 
+def test_is_local_requires_nonempty_dirs(monkeypatch, tmp_path):
+    # #21: an interrupted extract that created the shard directories but no
+    # shards must NOT read as "local" (else ensure_local never re-fetches).
+    root = tmp_path / f"v{DATA_VERSION}"
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(root))
+    # Create every downloadable path but leave the directories empty.
+    for p in data_bundle.DOWNLOADABLE_PATHS:
+        target = root / p
+        if target.suffix:  # a file entry
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("x")
+        else:  # a directory entry — created but empty
+            target.mkdir(parents=True, exist_ok=True)
+    assert data_bundle.is_local() is False
+    # Now drop a shard into each directory entry -> complete.
+    for p in data_bundle.DOWNLOADABLE_PATHS:
+        target = root / p
+        if not target.suffix:
+            (target / "shard.parquet").write_text("data")
+    assert data_bundle.is_local() is True
+
+
 def test_prune_keeps_current(monkeypatch, tmp_path):
     root = tmp_path / "bundled_data"
     (root / "v1.0.0").mkdir(parents=True)

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -12,22 +12,24 @@ import pytest
 from cancerdata import reference_data
 
 
-def _seed_cache(name, content: bytes):
-    """Write a cached TSV + a manifest recording its true size/sha256."""
-    dest = reference_data.local_path(name)
+def _seed_cache(name, content: bytes, version="v23"):
+    """Write a cached TSV + a manifest recording its true size/sha256, merging
+    into any existing manifest (so multiple versions can be seeded)."""
+    dest = reference_data.local_path(name, version)
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_bytes(content)
-    manifest = {
-        name: {
-            "version": "v23",
-            "url": "http://example/test",
-            "path": str(dest),
-            "bytes": len(content),
-            "sha256": hashlib.sha256(content).hexdigest(),
-            "downloaded_at": "2024-01-01T00:00:00+00:00",
-        }
+    manifest_path = reference_data.cache_dir() / "manifest.json"
+    manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
+    manifest[reference_data._manifest_key(name, version)] = {
+        "name": name,
+        "version": version,
+        "url": "http://example/test",
+        "path": str(dest),
+        "bytes": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+        "downloaded_at": "2024-01-01T00:00:00+00:00",
     }
-    (reference_data.cache_dir() / "manifest.json").write_text(json.dumps(manifest))
+    manifest_path.write_text(json.dumps(manifest))
     return dest
 
 
@@ -75,9 +77,9 @@ def test_cached_file_ok_detects_truncation(monkeypatch, tmp_path):
     # #21: a TSV left truncated by a killed extract must NOT be served as valid.
     monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
     dest = _seed_cache("hpa_rna_consensus", b"Gene\tTissue\tnTPM\n" * 100)
-    assert reference_data._cached_file_ok("hpa_rna_consensus", dest) is True
+    assert reference_data._cached_file_ok("hpa_rna_consensus", "v23", dest) is True
     dest.write_bytes(b"Gene\tTissue\n")  # truncated -> size no longer matches manifest
-    assert reference_data._cached_file_ok("hpa_rna_consensus", dest) is False
+    assert reference_data._cached_file_ok("hpa_rna_consensus", "v23", dest) is False
 
 
 def test_cached_file_ok_trusts_unrecorded(monkeypatch, tmp_path):
@@ -86,7 +88,32 @@ def test_cached_file_ok_trusts_unrecorded(monkeypatch, tmp_path):
     dest = reference_data.local_path("hpa_rna_consensus")
     dest.parent.mkdir(parents=True)
     dest.write_text("Gene\tTissue\tnTPM\n")
-    assert reference_data._cached_file_ok("hpa_rna_consensus", dest) is True
+    assert reference_data._cached_file_ok("hpa_rna_consensus", "v23", dest) is True
+
+
+def test_cached_file_ok_is_per_version(monkeypatch, tmp_path):
+    # Each cached version keeps its own size record: truncating v23 must be
+    # detected even after a (good) 'latest' was the last thing downloaded.
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    v23 = _seed_cache("hpa_rna_consensus", b"v23-data" * 50, version="v23")
+    latest = _seed_cache("hpa_rna_consensus", b"latest-data" * 80, version="latest")
+    assert reference_data._cached_file_ok("hpa_rna_consensus", "v23", v23) is True
+    assert reference_data._cached_file_ok("hpa_rna_consensus", "latest", latest) is True
+    v23.write_bytes(b"trunc")  # corrupt only v23
+    assert reference_data._cached_file_ok("hpa_rna_consensus", "v23", v23) is False
+    # 'latest' is unaffected — its own record still matches.
+    assert reference_data._cached_file_ok("hpa_rna_consensus", "latest", latest) is True
+
+
+def test_verify_is_per_version(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    _seed_cache("hpa_rna_consensus", b"v23-data" * 50, version="v23")
+    latest = _seed_cache("hpa_rna_consensus", b"latest-data" * 80, version="latest")
+    assert reference_data.verify("hpa_rna_consensus", "v23") is True
+    assert reference_data.verify("hpa_rna_consensus", "latest") is True
+    latest.write_bytes(b"corrupted")
+    assert reference_data.verify("hpa_rna_consensus", "latest") is False
+    assert reference_data.verify("hpa_rna_consensus", "v23") is True  # unaffected
 
 
 def test_ensure_refetches_corrupt_cache(monkeypatch, tmp_path):

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -4,9 +4,31 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import hashlib
+import json
+
 import pytest
 
 from cancerdata import reference_data
+
+
+def _seed_cache(name, content: bytes):
+    """Write a cached TSV + a manifest recording its true size/sha256."""
+    dest = reference_data.local_path(name)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(content)
+    manifest = {
+        name: {
+            "version": "v23",
+            "url": "http://example/test",
+            "path": str(dest),
+            "bytes": len(content),
+            "sha256": hashlib.sha256(content).hexdigest(),
+            "downloaded_at": "2024-01-01T00:00:00+00:00",
+        }
+    }
+    (reference_data.cache_dir() / "manifest.json").write_text(json.dumps(manifest))
+    return dest
 
 
 def test_cache_dir_honors_env(monkeypatch, tmp_path):
@@ -47,3 +69,52 @@ def test_single_cell_registered():
     spec = reference_data.REFERENCE_SOURCES["hpa_single_cell"]
     assert spec["filename"] == "rna_single_cell_type.tsv"
     assert "v23" in spec["urls"]
+
+
+def test_cached_file_ok_detects_truncation(monkeypatch, tmp_path):
+    # #21: a TSV left truncated by a killed extract must NOT be served as valid.
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    dest = _seed_cache("hpa_rna_consensus", b"Gene\tTissue\tnTPM\n" * 100)
+    assert reference_data._cached_file_ok("hpa_rna_consensus", dest) is True
+    dest.write_bytes(b"Gene\tTissue\n")  # truncated -> size no longer matches manifest
+    assert reference_data._cached_file_ok("hpa_rna_consensus", dest) is False
+
+
+def test_cached_file_ok_trusts_unrecorded(monkeypatch, tmp_path):
+    # A file with no manifest record can't be disproven -> trusted (back-compat).
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    dest = reference_data.local_path("hpa_rna_consensus")
+    dest.parent.mkdir(parents=True)
+    dest.write_text("Gene\tTissue\tnTPM\n")
+    assert reference_data._cached_file_ok("hpa_rna_consensus", dest) is True
+
+
+def test_ensure_refetches_corrupt_cache(monkeypatch, tmp_path):
+    # ensure() must re-download when the cached file fails the size check.
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    dest = _seed_cache("hpa_rna_consensus", b"x" * 500)
+    dest.write_bytes(b"x" * 3)  # corrupt: size mismatch
+
+    called = {}
+
+    def fake_download(name, version=None, *, force=False):
+        called["name"] = name
+        return dest
+
+    monkeypatch.setattr(reference_data, "download", fake_download)
+    reference_data.ensure("hpa_rna_consensus")
+    assert called.get("name") == "hpa_rna_consensus"
+
+
+def test_verify_matches_and_mismatches(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    dest = _seed_cache("hpa_rna_consensus", b"Gene\tTissue\tnTPM\nA\tB\t1\n")
+    assert reference_data.verify("hpa_rna_consensus") is True
+    dest.write_bytes(b"corrupted")
+    assert reference_data.verify("hpa_rna_consensus") is False
+
+
+def test_verify_without_manifest_raises(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    with pytest.raises(reference_data.ReferenceDataError, match="nothing to verify"):
+        reference_data.verify("hpa_rna_consensus")


### PR DESCRIPTION
Closes the cache-poisoning gaps in #21 (the staging-dir atomic tarball extract already fixed the first of the three).

### `data_bundle.is_local()` — reject empty shard directories
`is_local()` previously returned `True` if each downloadable path merely *existed*. For the **directory** entries (the per-cohort shard dirs), an interrupted extract that created the directory but no shards read as "local" forever — `ensure_local()` never re-fetched and later reads failed with confusing empties / `FileNotFoundError`. Now a directory entry counts as present only if it contains ≥1 file.

### `reference_data` (HPA) — atomic write + truncation-aware reuse
- The extracted TSV is written to a `.part` temp and `os.replace`d into place **atomically**. A process killed mid-extract leaves the temp, never a partial `dest`; a prior good copy survives a failed re-download untouched (the old code wrote straight to `dest`).
- `download()` / `ensure()` reuse a cached file only when its size matches the manifest's recorded `bytes` (cheap truncation check) — a mismatch triggers a re-fetch instead of serving a partial TSV forever. Files with no manifest record stay trusted (back-compat).
- New `verify(name)` does a full sha256 audit against the manifest on demand (kept out of the hot path so it doesn't re-hash a large TSV on every access).

### Tests (6)
Empty-dir detection; truncation detection + `ensure()` re-fetch; unrecorded-file trust; `verify()` match / mismatch / no-manifest. Full suite 261 passed; ruff clean.

### Remaining #21 piece
Shipping + checking an expected sha256 for the pinned ~340 MB tarball *before* extract needs checksums published per release. The staging-dir extract + `tarfile` validation already reject truncated / non-tar bodies (they fall back to the next source), so the practical corruption risk is largely covered; the checksum manifest is a release-process follow-up.