### PR TITLE
Validate Phase B generators against pirlygenes reference data (#35)

### DIFF
--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -4,7 +4,9 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import glob
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -15,6 +17,19 @@ import pytest
 from cancerdata import _build
 
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+# Optional real-data parity: the per-sample matrices + pirlygenes' shipped
+# percentile artifact live only on a maintainer's machine (~22 GB cache), so this
+# is gated like the HPA-dependent tests and skips cleanly everywhere else.
+_ACC_MATRIX = glob.glob(
+    os.path.expanduser("~/.cache/pirlygenes/expression/*/derived/tcga_acc_per_sample_tpm.parquet")
+)
+_ACC_REF = Path(
+    os.path.expanduser(
+        "~/code/pirlygenes/pirlygenes/data/cancer-reference-expression-percentiles/ACC.parquet"
+    )
+)
+_PARITY_READY = bool(_ACC_MATRIX) and _ACC_REF.exists()
 
 
 def _load_script(name):
@@ -197,3 +212,35 @@ def test_representatives_generator_writes_shards_and_provenance(tmp_path):
         assert col in prov.columns
     # Unregistered code -> source_cohort falls back to the code itself.
     assert (prov["source_cohort"] == "COHORT_A").all()
+
+
+# ---------- real-data parity (skipped without the maintainer's matrix cache) ----------
+
+
+@pytest.mark.skipif(not _PARITY_READY, reason="per-sample matrix cache / pirlygenes ref absent")
+def test_percentiles_reproduce_pirlygenes_reference():
+    # End-to-end on REAL data: raw per-sample matrix -> clean_tpm -> percentile
+    # vectors must reproduce pirlygenes' shipped percentile artifact for the same
+    # cohort. Proves the generator + cancerdata's clean_tpm port are faithful.
+    from cancerdata import normalization as nz
+
+    raw = pd.read_parquet(_ACC_MATRIX[0])
+    samples = [c for c in raw.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    gene_table = raw[["Symbol", "Ensembl_Gene_ID"]]
+    clean = nz.clean_tpm(raw[samples], gene_table=gene_table)
+    clean_df = pd.concat([gene_table, clean], axis=1)
+
+    mine = _build.cohort_percentile_vectors(clean_df, samples).set_index("Ensembl_Gene_ID")
+    ref = pd.read_parquet(_ACC_REF).set_index("Ensembl_Gene_ID")
+    # Column schema is identical.
+    assert [c for c in mine.columns if c != "Symbol"] == [c for c in ref.columns if c != "Symbol"]
+
+    common = mine.index.intersection(ref.index)
+    assert len(common) > 10_000
+    # The deterministic mid/upper percentiles match (expm1 back to TPM); tiny tail
+    # deviation at p99 is float16 rounding, so correlation must be essentially 1.
+    for col in ("p50", "p95"):
+        a = np.expm1(mine.loc[common, col].astype("float32"))
+        b = np.expm1(ref.loc[common, col].astype("float32"))
+        mask = (a > 0) | (b > 0)
+        assert np.corrcoef(a[mask], b[mask])[0, 1] > 0.999


### PR DESCRIPTION
Adds a real-data parity test proving the Phase B percentile generator is faithful.

**Discovery:** the per-sample TPM matrices are actually present in the maintainer's cache (~22 GB, 129 `<CODE>_per_sample_tpm.parquet` files under `~/.cache/pirlygenes/expression/<cohort>/derived/`) — not "never shipped" as the earlier issues assumed. So the generators can be run and validated on real data.

**Validation:** end-to-end on the ACC cohort — raw per-sample matrix → cancerdata `clean_tpm` (two-compartment) → `cohort_percentile_vectors` — reproduces pirlygenes' shipped `ACC.parquet` percentile artifact:
- identical 26-column `p0..p100` schema
- p50 / p95 correlation ≈ 1.0000, median Δ = 0.000 TPM (p99 corr 0.9945, the tiny tail deviation being float16 rounding)

This confirms both the generator and the `clean_tpm` port (#46) are faithful, de-risking a full artifact rebuild.

The test is gated like the HPA-dependent tests (`skipif` on the local cache + reference being present), so it runs on the maintainer's machine and skips cleanly in CI / elsewhere. Full suite 264 passed; ruff clean.

**Remaining for a full rebuild + ship** (scoped follow-up, not in this PR): a matrix-filename→cancer-code mapping (e.g. `tcga_acc`→`ACC`), running the three generators across all 129 cohorts, a `DATA_VERSION` bump, and uploading the tarball to a cancerdata release.