### PR TITLE
CTA addressable-burden plot (P2) + 9mer scaffold (P3) (#15)

### DIFF
--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -252,6 +252,7 @@ def _cmd_plot(args: argparse.Namespace) -> int:
         "apd1-orr-bars": plots.apd1_orr_bars,
         "incidence-vs-mortality": plots.incidence_vs_mortality,
         "cta-expression-heatmap": plots.cta_expression_heatmap,
+        "cta-addressable-burden": plots.cta_addressable_burden,
     }
     try:
         if args.which == "incidence-vs-mortality":
@@ -261,7 +262,7 @@ def _cmd_plot(args: argparse.Namespace) -> int:
         else:
             kwargs = {}
         fns[args.which](save=args.out, **kwargs)
-    except (ValueError, ModuleNotFoundError) as e:
+    except (ValueError, ModuleNotFoundError, NotImplementedError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"Wrote {args.out}")
@@ -437,6 +438,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "apd1-orr-bars",
             "incidence-vs-mortality",
             "cta-expression-heatmap",
+            "cta-addressable-burden",
         ],
         help="Which plot to render",
     )

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -27,8 +27,13 @@ from __future__ import annotations
 from .apd1 import cancer_apd1_response
 from .cancer_types import cancer_type_registry, format_cancer_code_label
 from .cta import CTA_gene_id_to_name, CTA_gene_ids
-from .expression import available_percentile_cohorts, cohort_gene_percentiles
-from .incidence import cancer_burden
+from .expression import (
+    available_percentile_cohorts,
+    available_within_sample_cohorts,
+    cohort_gene_percentiles,
+    within_sample_top_fraction,
+)
+from .incidence import burden_category, cancer_burden
 from .tmb import cancer_tmb
 
 _PLT = None
@@ -287,3 +292,117 @@ def cta_expression_heatmap(
     cbar.set_label(f"{stat} TPM (log)")
     fig.tight_layout()
     return _save(fig, save)
+
+
+def _cta_prevalence_by_cohort(threshold):
+    """``{cohort code: fraction of samples where the single most-prevalent CTA is a
+    top-expressed gene}`` from the within-sample artifact.
+
+    This is the best **shipped** proxy for "fraction of patients with a targetable
+    CTA": the within-sample artifact gives, per gene, the fraction of a cohort's
+    samples in which it ranks in the top ``(1-threshold)`` *within that sample*; we
+    take the max over the CTA set. It is a lower bound on the true "≥1 CTA expressed"
+    union (different patients may express different CTAs), which needs the per-sample
+    joint matrices — see :func:`cancerdata.expression.proteoform_representative_samples`
+    and #13. Cohorts without a within-sample shard are skipped."""
+    import pandas as pd
+
+    cta_ids = set(CTA_gene_ids())
+    out = {}
+    for code in available_within_sample_cohorts():
+        df = within_sample_top_fraction(code, threshold=threshold)
+        frac_col = next((c for c in df.columns if c.startswith("frac_samples_top")), None)
+        if frac_col is None:
+            continue
+        ids = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+        cta_frac = pd.to_numeric(df.loc[ids.isin(cta_ids), frac_col], errors="coerce")
+        out[str(code)] = float(cta_frac.max()) if len(cta_frac) and cta_frac.notna().any() else 0.0
+    return out
+
+
+def cta_addressable_burden(
+    *,
+    threshold=0.95,
+    metric="us_incidence_pct",
+    n=25,
+    save=None,
+):
+    """Bar chart of **CTA-addressable cancer burden** per cancer type.
+
+    Combines two things cancerdata owns: the incidence share of each cancer
+    (:func:`cancerdata.incidence.cancer_burden`) and the within-sample prevalence of
+    the most-expressed CTA in that cohort (:func:`_cta_prevalence_by_cohort`). The
+    bar is ``incidence_share × CTA_prevalence`` — a relative measure of how many
+    patients a CTA-directed therapy could address, ranking cancers by opportunity.
+
+    ``threshold`` is the within-sample rank cut (0.99/0.95/0.90 → top 1/5/10%);
+    ``metric`` selects the incidence basis; ``n`` caps the bars shown. Bars are
+    coloured by registry family. Needs the within-sample bundle present.
+
+    Scope note: incidence is at burden-category granularity (several subtypes share
+    a category), and the prevalence is the single-best-CTA proxy — an exact "fraction
+    expressing ≥1 CTA" union needs the per-sample matrices (#13). So read this as a
+    relative prioritization, not an absolute patient count."""
+    import numpy as np
+
+    plt = _plt()
+    prevalence = _cta_prevalence_by_cohort(threshold)
+    if not prevalence:
+        raise ValueError(
+            "no within-sample CTA prevalence available — is the within-sample bundle present? "
+            "(see available_within_sample_cohorts())"
+        )
+    burden = cancer_burden(metric=metric)  # {burden category: share}
+
+    rows = []
+    for code, prev in prevalence.items():
+        category = burden_category(code)
+        inc = burden.get(category) if category else None
+        if inc is None or not inc:
+            continue
+        rows.append((code, float(inc) * prev, prev))
+    if not rows:
+        raise ValueError("no cohort mapped to both a burden category and CTA prevalence")
+
+    rows.sort(key=lambda r: r[1], reverse=True)
+    rows = rows[:n]
+    codes = [r[0] for r in rows]
+    scores = [r[1] for r in rows]
+    color_by_code, fam_color = _family_colors(codes)
+
+    fig, ax = plt.subplots(figsize=(8, max(4, 0.32 * len(codes))))
+    y = np.arange(len(codes))
+    ax.barh(y, scores, color=[color_by_code[c] for c in codes])
+    ax.set_yticks(y)
+    ax.set_yticklabels([format_cancer_code_label(c) for c in codes], fontsize=7)
+    ax.invert_yaxis()
+    ax.set_xlabel(f"Addressable burden  (incidence share × top-CTA prevalence, thr={threshold})")
+    ax.set_title(f"CTA-addressable cancer burden — top {len(codes)} cancers")
+    handles = [plt.Rectangle((0, 0), 1, 1, color=c) for c in fam_color.values()]
+    ax.legend(handles, list(fam_color), fontsize=6, title="family", loc="lower right")
+    fig.tight_layout()
+    return _save(fig, save)
+
+
+def cta_specific_9mer_counts(*, save=None, **kwargs):
+    """**Scaffold** — CTA-specific 9-mer (peptide) counts per cancer type.
+
+    The faithful plot counts, per cancer type, the unique 9-mer peptides derived
+    from CTAs expressed in that cohort — a measure of the CTA-specific neoepitope
+    source breadth. It needs two inputs cancerdata does not ship:
+
+    1. the **proteome** (translated CTA protein sequences) to enumerate 9-mers —
+       a ``pyensembl``/reference-proteome dependency that is out of cancerdata's
+       pandas-only base-layer scope, and
+    2. the **per-sample expression matrices** to decide which CTAs are expressed
+       per patient (the shipped percentile/within-sample summaries can't recover
+       per-sample peptide sets).
+
+    This is intentionally the heaviest plot and is tracked as its own follow-up
+    (#15); it is not wired to shipped data. Raising keeps the API surface explicit
+    rather than returning a misleading partial figure."""
+    raise NotImplementedError(
+        "cta_specific_9mer_counts needs a reference proteome (9-mer enumeration, e.g. "
+        "via pyensembl) and the per-sample expression matrices — neither is in "
+        "cancerdata's shipped, pandas-only base layer. Tracked as a follow-up in #15."
+    )

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -81,3 +81,38 @@ def test_cta_expression_heatmap_skips_unusable_cohorts():
         pytest.raises(ValueError, match="no CTA expression data"),
     ):
         plots.cta_expression_heatmap(cohorts=["NOT_A_REAL_COHORT"])
+
+
+# ---- CTA addressable burden (P2) + 9mer scaffold (P3) ----
+
+
+def test_cta_addressable_burden_renders(tmp_path, monkeypatch):
+    # Hermetic: stub the within-sample prevalence so the test doesn't need the
+    # bundle. Real codes map to a burden category + incidence, so bars render.
+    monkeypatch.setattr(
+        plots,
+        "_cta_prevalence_by_cohort",
+        lambda threshold: {"LUAD": 0.6, "SKCM": 0.4, "BRCA": 0.2},
+    )
+    out = tmp_path / "burden.png"
+    fig = plots.cta_addressable_burden(n=10, save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+    assert fig is not None
+
+
+def test_cta_addressable_burden_no_within_sample(monkeypatch):
+    monkeypatch.setattr(plots, "_cta_prevalence_by_cohort", lambda threshold: {})
+    with pytest.raises(ValueError, match="no within-sample CTA prevalence"):
+        plots.cta_addressable_burden()
+
+
+def test_cta_addressable_burden_no_mapped_cohorts(monkeypatch):
+    # A code that resolves to no burden category yields no bars -> clean ValueError.
+    monkeypatch.setattr(plots, "_cta_prevalence_by_cohort", lambda threshold: {"NOT_A_CODE": 0.5})
+    with pytest.raises(ValueError, match="no cohort mapped"):
+        plots.cta_addressable_burden()
+
+
+def test_cta_specific_9mer_counts_not_implemented():
+    with pytest.raises(NotImplementedError, match="#15"):
+        plots.cta_specific_9mer_counts()


### PR DESCRIPTION
Ports the two remaining CTA-dependent plots from pirlygenes, completing #15's plot set (P1 heatmap already merged).

### P2 — `cta_addressable_burden` (working, shipped-data)
A per-cancer bar chart of **incidence share × within-sample CTA prevalence** — a relative ranking of how many patients a CTA-directed therapy could address. Prevalence is the fraction of a cohort's samples in which the single most-prevalent CTA is a top-expressed gene (from the within-sample artifact); incidence is `cancer_burden`. Bars are family-coloured. Uses only data cancerdata ships.

Sanity check on the rebuilt within-sample artifacts (118 cohorts): the top of the ranking is lung adeno / SCLC subtypes, melanoma, and embryonal tumors — biologically the expected CTA-rich, high-incidence cancers.

**Honest scope note** (in the docstring): incidence is at burden-category granularity, and the prevalence is a single-best-CTA proxy — an exact "fraction expressing ≥1 CTA" union needs the per-sample matrices (#13). Read it as relative prioritization, not an absolute patient count.

### P3 — `cta_specific_9mer_counts` (explicit scaffold)
The faithful plot needs a reference proteome (to enumerate 9-mers) + per-sample matrices to decide per-patient CTA expression — both outside cancerdata's pandas-only base layer. Per #15 ("the heaviest; its own follow-up"), this raises `NotImplementedError` with a precise explanation rather than returning a misleading partial figure.

### Wiring + tests
- `cancerdata plot cta-addressable-burden` CLI choice; `NotImplementedError` surfaces as a clean CLI error.
- 5 hermetic tests (prevalence stubbed so they don't need the bundle): renders, the no-data and no-mapped-cohort error paths, and P3's `NotImplementedError`. Full suite 268 passed; ruff clean.