### PR TITLE
Derive the CTA exclusion from gene family — fixes the H1-6 drift (#27)

### DIFF
--- a/cancerdata/cta.py
+++ b/cancerdata/cta.py
@@ -28,6 +28,7 @@ here. ``restriction`` and ``restriction_confidence`` in the bundled table are th
 
 from __future__ import annotations
 
+import re
 from functools import lru_cache
 
 import pandas as pd
@@ -39,21 +40,41 @@ from .load_dataset import get_data
 #: ``never_expressed`` flag (low but corroborated testis signal). Unversioned ENSG.
 MANUALLY_EXPRESSED_CTA: frozenset[str] = frozenset({"ENSG00000171405"})  # XAGE5
 
-#: Genes present in a source database but excluded from the CTA universe — core
-#: histones and alpha-tubulins (housekeeping structural genes, not tumor-restricted
-#: antigens). The placental hCG-beta locus CGB8 is **not** excluded: it passes the
-#: HPA reproductive-restriction filter exactly like its siblings CGB1/2/3/5/7 (all
-#: kept), so excluding it alone was an inconsistency (see #20).
-NON_CTA_EXCLUDED_GENE_IDS: frozenset[str] = frozenset(
-    {
-        "ENSG00000274618",  # H4C6
-        "ENSG00000146047",  # H2BC1
-        "ENSG00000276410",  # H2BC3
-        "ENSG00000124610",  # H1-1
-        "ENSG00000198033",  # TUBA3C
-        "ENSG00000152086",  # TUBA3E
-    }
-)
+
+def _alpha_tubulin_symbol(symbol: str) -> bool:
+    """Alpha-tubulin family (``TUBA1A``, ``TUBA3C``, …) — ubiquitous structural
+    housekeeping genes, not tumor-restricted antigens."""
+    return bool(re.match(r"^TUBA\d", str(symbol)))
+
+
+@lru_cache(maxsize=1)
+def _non_cta_excluded_gene_ids() -> frozenset[str]:
+    """Unversioned Ensembl IDs excluded from the CTA universe by a gene-family rule:
+    a candidate that is a **core histone** (member of ``histone-genes.csv``) or an
+    **alpha-tubulin** is a ubiquitous structural housekeeping gene that entered via a
+    source database but is not a tumor-restricted antigen.
+
+    Deriving the set from gene family (rather than a hand-listed set of IDs) keeps it
+    self-maintaining and consistent: it caught H1-6, a core histone that passed the
+    HPA filter exactly like its deny-listed siblings H2BC1/H1-1 but had been left in
+    (the same one-gene inconsistency fixed for CGB8 in #20). The placental hCG-beta
+    locus CGB8 is **not** here — it is a real reproductive-restricted antigen like
+    CGB1/2/3/5/7, not a housekeeping gene.
+    """
+    from .gene_families import gene_family_ids
+
+    df = get_data("cancer-testis-antigens", copy=False)
+    if "Ensembl_Gene_ID" not in df.columns:
+        return frozenset()
+    unversioned = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+    histones = unversioned.isin(gene_family_ids("histone"))
+    tubulins = df["Symbol"].map(_alpha_tubulin_symbol) if "Symbol" in df.columns else False
+    return frozenset(unversioned[histones | tubulins])
+
+
+#: Backwards-compatible alias: the family-derived exclusion set (see
+#: :func:`_non_cta_excluded_gene_ids`). Computed once at import.
+NON_CTA_EXCLUDED_GENE_IDS: frozenset[str] = _non_cta_excluded_gene_ids()
 
 _PASSES_FILTERS_COLUMN = "passes_filters"
 _LEGACY_FILTERED_COLUMN = "filtered"

--- a/tests/test_cta.py
+++ b/tests/test_cta.py
@@ -47,6 +47,21 @@ def test_non_cta_excluded_genes_dropped():
     assert cta.NON_CTA_EXCLUDED_GENE_IDS.isdisjoint(cta.CTA_unfiltered_gene_ids())
 
 
+def test_no_histone_or_tubulin_survives_in_cta_universe():
+    # The exclusion is a gene-family rule, not a hand-list: EVERY core histone
+    # and alpha-tubulin candidate is dropped, so a sibling can't be left in (the
+    # H1-6-vs-H2BC1 inconsistency the family rule fixed). Guards future drift.
+    from cancerdata.gene_families import gene_family_ids
+    from cancerdata.load_dataset import get_data
+
+    raw = get_data("cancer-testis-antigens")
+    uid = raw["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+    histone_candidates = set(uid[uid.isin(gene_family_ids("histone"))])
+    tubulin_candidates = set(uid[raw["Symbol"].str.match(r"^TUBA\d", na=False)])
+    survivors = (histone_candidates | tubulin_candidates) & cta.CTA_unfiltered_gene_ids()
+    assert not survivors, f"housekeeping structural genes left in the CTA universe: {survivors}"
+
+
 def test_cgb8_not_deny_listed():
     # #20: CGB8 was hardcoded out as "placental hCG-beta" while its hCG-beta
     # siblings (CGB1/2/3/5/7) flow through the normal HPA filter. CGB8 must be


### PR DESCRIPTION
Continues the de-special-casing of the CTA curation found while drilling into the cancerdata↔pirlygenes differences.

`NON_CTA_EXCLUDED_GENE_IDS` was a hand-listed set of 6 Ensembl IDs (4 core histones + 2 alpha-tubulins) dropped from the CTA universe. It carried the **same one-gene inconsistency that #20 fixed for CGB8**: `H1-6` is a core histone that passes the HPA reproductive-restriction filter exactly like its deny-listed siblings `H2BC1`/`H1-1`, but it had been left in.

**Fix — replace the hand-list with a gene-family rule.** A candidate is excluded iff it's a **core histone** (member of `histone-genes.csv`) or an **alpha-tubulin** (`TUBA\d`). This:
- fixes the inconsistency — `H1-6` is now excluded with its siblings (6 → 7 genes),
- is self-maintaining — a new histone/tubulin paralog entering via a source DB is caught automatically,
- drops the 4 hand-listed entries (`H1-1`, `H2BC3`, `H4C6`, `TUBA3E`) that were redundant (they already failed the HPA filter),
- keeps **CGB8 in** (it's a real reproductive-restricted antigen like CGB1/2/3/5/7, not a housekeeping gene).

Read-side filtering only: the shipped `cancer-testis-antigens.csv` and the regenerated HPA columns are unchanged, so `test_regeneration_reproduces_shipped_table` still passes. A new guard asserts no histone/tubulin candidate can survive in the CTA universe. Full suite 271 passed.

**Still open (the one genuine curation judgment):** `MANUALLY_EXPRESSED_CTA` — the single-gene `XAGE5` rescue from `never_expressed`. Bringing that decision to you separately since it changes the downstream CTA gene set either way.