### PR TITLE
Generalize the XAGE5 rescue into a uniform never-expressed rule (#27)

### DIFF
--- a/cancerdata/cta.py
+++ b/cancerdata/cta.py
@@ -36,9 +36,23 @@ import pandas as pd
 from .cta_tissues import HPA_EXPRESSION_FLOOR_NTPM
 from .load_dataset import get_data
 
-#: Borderline-but-real CTAs kept in the expressed set despite an HPA
-#: ``never_expressed`` flag (low but corroborated testis signal). Unversioned ENSG.
-MANUALLY_EXPRESSED_CTA: frozenset[str] = frozenset({"ENSG00000171405"})  # XAGE5
+
+def _never_expressed_rescue_mask(df: pd.DataFrame) -> pd.Series:
+    """Row mask for ``never_expressed`` CTAs kept in the expressed set anyway.
+
+    A uniform rule, not a per-gene list: a never-expressed gene is rescued when its
+    HPA evidence is ``restriction_confidence == MODERATE`` and
+    ``rna_restriction_level == STRICT`` — i.e. it has reproductive-restricted RNA
+    just below the protein floor, the signature of a borderline-but-real CTA
+    (testis ~1-2 nTPM). This replaces the old one-gene XAGE5 override, which
+    rescued a single gene while ~15 peers with equal/stronger signal were dropped;
+    the rule keeps XAGE5 and all of them on the same principled basis.
+    """
+    if not {"restriction_confidence", "rna_restriction_level"} <= set(df.columns):
+        return pd.Series(False, index=df.index)
+    moderate = df["restriction_confidence"].astype(str).str.upper() == "MODERATE"
+    strict = df["rna_restriction_level"].astype(str).str.upper() == "STRICT"
+    return moderate & strict
 
 
 def _alpha_tubulin_symbol(symbol: str) -> bool:
@@ -185,11 +199,7 @@ def _cta_by_column(
         mask = passes_filters_mask(df)
     if exclude_never_expressed and "never_expressed" in df.columns:
         never = df["never_expressed"].astype(str).str.lower() == "true"
-        if "Ensembl_Gene_ID" in df.columns:
-            rescued = (
-                df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0].isin(MANUALLY_EXPRESSED_CTA)
-            )
-            never = never & ~rescued
+        never = never & ~_never_expressed_rescue_mask(df)
         mask = mask & ~never
     subset = df[mask]
     result: set[str] = set()

--- a/cancerdata/cta_tissues.py
+++ b/cancerdata/cta_tissues.py
@@ -14,9 +14,9 @@
 
 Ported (HPA-only) from ``tsarina.tissues`` so cancerdata can regenerate the
 bundled ``cancer-testis-antigens.csv`` restriction/filter columns from HPA data
-alone. The MS-related and manual-curation constants are intentionally NOT here:
-``MANUALLY_EXPRESSED_CTA`` and ``NON_CTA_EXCLUDED_GENE_IDS`` already live in
-:mod:`cancerdata.cta`.
+alone. The MS-related constants and the CTA-universe membership rules (the
+gene-family exclusion and the never-expressed rescue) are intentionally NOT
+here — they live in :mod:`cancerdata.cta`.
 
 Three tiers of reproductive tissue sets determine how strictly a gene's
 expression must be confined to qualify as a cancer-testis antigen:

--- a/tests/test_cta.py
+++ b/tests/test_cta.py
@@ -34,9 +34,19 @@ def test_canonical_ctas_present():
         assert g in expressed
 
 
-def test_manually_rescued_cta_kept():
-    # XAGE5 is HPA never_expressed but manually rescued into the expressed set.
-    assert "ENSG00000171405" in cta.CTA_gene_ids()
+def test_never_expressed_rescue_is_a_uniform_rule():
+    # never_expressed CTAs with MODERATE confidence + STRICT reproductive RNA are
+    # kept in the expressed set by a uniform rule (not a one-gene XAGE5 override).
+    # XAGE5 is rescued, and so are its peers with the same signature.
+    expressed = cta.CTA_gene_ids()
+    assert "ENSG00000171405" in expressed  # XAGE5
+    assert "MAGEA2B" in cta.CTA_gene_names()  # a same-signature peer, also kept
+    # The rescue is exactly the rule, applied to every row.
+    df = cta.cta_dataframe()
+    rescued = df[cta._never_expressed_rescue_mask(df)]
+    never = rescued["never_expressed"].astype(str).str.lower() == "true"
+    kept = set(rescued.loc[never, "Ensembl_Gene_ID"].astype(str).str.split(".").str[0])
+    assert kept and kept <= cta.CTA_gene_ids()
 
 
 def test_non_cta_excluded_genes_dropped():


### PR DESCRIPTION
Removes the last hand-curated special case in the CTA membership logic, per your call to **generalize to a rule**.

`MANUALLY_EXPRESSED_CTA` force-kept exactly one gene (XAGE5) in the expressed CTA set despite HPA flagging it `never_expressed`, while ~15 peers with equal-or-stronger testis signal were dropped. The investigation showed this is arbitrary — XAGE5 sits mid-pack at 1.1 nTPM with the identical (MODERATE, STRICT) signature as its peers, so there's no HPA-only basis to single it out.

**Fix:** replace the one-gene frozenset with a uniform row-level rule, `_never_expressed_rescue_mask` — a `never_expressed` CTA is rescued iff `restriction_confidence == MODERATE` **and** `rna_restriction_level == STRICT` (reproductive-restricted RNA just below the protein floor: the signature of a borderline-but-real CTA). This keeps XAGE5 **and** all 16 same-signature genes (CSTL1, GFY, MAGEA2B, POTEF, SPANXN1, ZNF729, …) on the same principled basis.

- `CTA_gene_names()`: 274 → 288 (+14 borderline CTAs now included uniformly).
- Read-side only — the shipped `cancer-testis-antigens.csv` and the regenerated HPA columns are unchanged; `test_regeneration_reproduces_shipped_table` still passes.
- Test updated to assert the rescue is the *rule applied to every row*, not a one-gene list. Full suite 271 passed.

This completes the CTA membership de-special-casing (deny-list → family rule in #59; rescue → uniform rule here). Remaining CTA cleanups (`CROSS_REACTIVE_IHC` → data flag, dead-config removal) and the `cancer-lineage-groups` ontology port follow.