### PR TITLE
Data-drive cross-reactive IHC overrides + remove dead config (#27)

### DIFF
--- a/cancerdata/cta_regen.py
+++ b/cancerdata/cta_regen.py
@@ -37,6 +37,8 @@ Public entry point: :func:`regenerate_cta_columns`.
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 import pandas as pd
 
 from . import cta as _cta
@@ -50,24 +52,26 @@ from .cta_tissues import (
     SAFETY_NTPM_THRESHOLD,
     SAFETY_TISSUE_GROUPS,
 )
+from .load_dataset import get_data
 
 # ── Curated overrides ──────────────────────────────────────────────────────
 
-#: Genes whose v23 HPA IHC is treated as **unreliable** (forced to "no data"),
-#: so they fall back to the RNA-only restriction call. These are sequence-near-
-#: identical CT/paralog antigens whose shared antibody cross-reacts: the somatic
-#: protein "detected" by HPA is at Low level in tissues where the gene's RNA is
-#: ~0 nTPM (heart/glandular cells), the hallmark of cross-reactivity. Curated
-#: override -- keyed by (unversioned) Ensembl gene ID. Ported from tsarina's
-#: ``scripts/regenerate_table.py``.
-CROSS_REACTIVE_IHC: frozenset[str] = frozenset(
-    {
-        "ENSG00000176746",  # MAGEB6 -- kidney IHC, RNA 0; Enhanced but RNA-discordant
-        "ENSG00000155622",  # XAGE2  -- scattered Low glandular IHC, RNA ~0 (placenta-restricted)
-        "ENSG00000278085",  # CT45A8 -- heart Low IHC, RNA 0; CT45A1 paralog (shared antibody)
-        "ENSG00000270946",  # CT45A9 -- heart Low IHC, RNA 0; CT45A1 paralog (shared antibody)
-    }
-)
+
+@lru_cache(maxsize=1)
+def cross_reactive_ihc() -> frozenset[str]:
+    """Unversioned Ensembl IDs whose v23 HPA IHC is treated as **unreliable**
+    (forced to "no data"), so they fall back to the RNA-only restriction call.
+
+    These are sequence-near-identical CT/paralog antigens whose shared antibody
+    cross-reacts: HPA "detects" Low protein in tissues where the gene's RNA is
+    ~0 nTPM (heart/glandular cells), the hallmark of cross-reactivity. The set is
+    curation knowledge that needs a human, so it lives in an auditable data file
+    (``cta-ihc-unreliable.csv``: gene id, symbol, reason) rather than a hardcoded
+    list. (Ported from tsarina's ``scripts/regenerate_table.py``.)
+    """
+    df = get_data("cta-ihc-unreliable", copy=False)
+    return frozenset(df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0])
+
 
 #: Reproductive (+thymus) tissues, lowercased, for the protein restriction call.
 _PROTEIN_REPRODUCTIVE: frozenset[str] = frozenset(t.lower() for t in ALL_REPRODUCTIVE_TISSUES)
@@ -191,7 +195,7 @@ def _recompute_protein_columns(seed: pd.DataFrame, normal_tissue: pd.DataFrame) 
 
     Faithful port of ``tsarina/scripts/regenerate_table._recompute_protein_columns``:
 
-    * a gene absent from the IHC table, in :data:`CROSS_REACTIVE_IHC`, or
+    * a gene absent from the IHC table, in :func:`cross_reactive_ihc`, or
       detecting protein in no tissue (Level not Low/Medium/High) -> all four
       columns are ``"no data"`` (the original pipeline collapsed "antibody
       present, nothing detected" into ``no data``);
@@ -207,9 +211,10 @@ def _recompute_protein_columns(seed: pd.DataFrame, normal_tissue: pd.DataFrame) 
     det_by_gene = detected.groupby("gid")["tl"].apply(lambda s: sorted(set(s)))
     rel_by_gene = nt.groupby("gid")["Reliability"].first()
 
+    cross_reactive = cross_reactive_ihc()
     for idx, row in seed.iterrows():
         gid = str(row["Ensembl_Gene_ID"]).split(".")[0]
-        det = None if gid in CROSS_REACTIVE_IHC else det_by_gene.get(gid)
+        det = None if gid in cross_reactive else det_by_gene.get(gid)
         if not det:  # absent / cross-reactive IHC, or detected nowhere -> no data
             seed.at[idx, "protein_strict_expression"] = "no data"
             seed.at[idx, "protein_reliability"] = "no data"

--- a/cancerdata/cta_tissues.py
+++ b/cancerdata/cta_tissues.py
@@ -78,10 +78,6 @@ HPA_ADAPTIVE_PROTEIN_RNA_THRESHOLDS: dict[str, float] = {
     "Missing": 0.97,
 }
 
-#: Maximum number of tissues with RNA detected (nTPM >= 1) for the strict
-#: marker-based filter.
-HPA_MARKER_STRICT_MAX_RNA_TISSUES: int = 7
-
 #: RNA expression floor (nTPM) for the ``never_expressed`` flag. A gene with no
 #: HPA protein (IHC) data and a maximum RNA nTPM below this value across all
 #: tissues is flagged ``never_expressed`` -- it passes the reproductive-

--- a/cancerdata/data/cta-ihc-unreliable.csv
+++ b/cancerdata/data/cta-ihc-unreliable.csv
@@ -1,0 +1,5 @@
+Ensembl_Gene_ID,Symbol,reason
+ENSG00000176746,MAGEB6,kidney IHC with RNA ~0; Enhanced but RNA-discordant (cross-reactive antibody)
+ENSG00000155622,XAGE2,scattered Low glandular IHC with RNA ~0 (placenta-restricted; cross-reactive)
+ENSG00000278085,CT45A8,heart Low IHC with RNA 0; CT45A1 paralog sharing an antibody
+ENSG00000270946,CT45A9,heart Low IHC with RNA 0; CT45A1 paralog sharing an antibody

--- a/cancerdata/data_manifest.py
+++ b/cancerdata/data_manifest.py
@@ -133,6 +133,7 @@ CANCERDATA_ORIGINATED: dict[str, tuple[str, str]] = {
     "source-matrices": ("expression", "per-cohort raw-matrix registry (code/source/n_samples)"),
     "tissue-burden-map": ("ontology", "primary_tissue -> anatomic burden category"),
     "family-burden-map": ("ontology", "registry family -> burden category (fallback)"),
+    "cta-ihc-unreliable": ("cta", "CTAs whose HPA IHC is cross-reactive (RNA-only fallback)"),
 }
 
 #: pirlygenes data that is NOT cancerdata's domain — target selection / therapy /


### PR DESCRIPTION
Finishes the CTA-curation de-special-casing.

- **`CROSS_REACTIVE_IHC`** — 4 hand-listed paralog/antibody IDs whose HPA IHC is forced to "no data" (so they fall back to RNA-only) → **`data/cta-ihc-unreliable.csv`** (`Ensembl_Gene_ID, Symbol, reason`). This is genuine curation knowledge that needs a human, so it belongs in an auditable, versioned data file with per-gene reasons rather than buried in a regen script. `cta_regen.cross_reactive_ihc()` loads it; the **regeneration parity test confirms the regenerated table is byte-identical** to the shipped one.
- Removed `HPA_MARKER_STRICT_MAX_RNA_TISSUES` (defined but never referenced anywhere).
- Registered the new CSV in `data_manifest` `CANCERDATA_ORIGINATED`.

(Left the 4 "inert" brain tissue names in `SAFETY_TISSUE_GROUPS` — they're documented intentional vocabulary parity, not dead.)

Full suite 271 passed; ruff clean.