### PR TITLE
Wire derived get_data caches into the clear hook (post-merge review fix)

### DIFF
--- a/cancerdata/cancer_types.py
+++ b/cancerdata/cancer_types.py
@@ -214,13 +214,17 @@ CANCER_TYPE_NAMES = _CancerTypeNamesView()
 
 
 def _clear_caches():
-    """Reset every registry-backed cache in this module.
+    """Reset every registry-backed cache in this module, plus the load_dataset
+    frame cache and all derived caches (incidence/cta lookups).
 
     Test hook for swapping the registry CSV via a monkey-patched ``get_data``;
     not part of the public surface.
     """
+    from .load_dataset import _clear_cache
+
     CANCER_TYPE_NAMES.clear_cache()
     _registry_frame.cache_clear()
+    _clear_cache()  # frame cache + registered derived caches (burden maps, CTA, …)
 
 
 def resolve_cancer_type(cancer_type, *, strict=True):

--- a/cancerdata/cta.py
+++ b/cancerdata/cta.py
@@ -34,7 +34,7 @@ from functools import lru_cache
 import pandas as pd
 
 from .cta_tissues import HPA_EXPRESSION_FLOOR_NTPM
-from .load_dataset import get_data
+from .load_dataset import _register_derived_cache, get_data
 
 
 def _never_expressed_rescue_mask(df: pd.DataFrame) -> pd.Series:
@@ -86,8 +86,11 @@ def _non_cta_excluded_gene_ids() -> frozenset[str]:
     return frozenset(unversioned[histones | tubulins])
 
 
-#: Backwards-compatible alias: the family-derived exclusion set (see
-#: :func:`_non_cta_excluded_gene_ids`). Computed once at import.
+_register_derived_cache(_non_cta_excluded_gene_ids.cache_clear)
+
+#: Backwards-compatible snapshot of the family-derived exclusion set (see
+#: :func:`_non_cta_excluded_gene_ids`). Computed once at import; the live filter in
+#: :func:`_cta_frame` calls the cached function so a fixture swap stays correct.
 NON_CTA_EXCLUDED_GENE_IDS: frozenset[str] = _non_cta_excluded_gene_ids()
 
 _PASSES_FILTERS_COLUMN = "passes_filters"
@@ -157,10 +160,14 @@ def _cta_frame() -> pd.DataFrame:
     """Cached CTA table with the non-CTA excluded genes dropped. Internal,
     read-only — do not mutate; public callers get a copy via cta_dataframe()."""
     df = get_data("cancer-testis-antigens", copy=False)
-    if "Ensembl_Gene_ID" in df.columns and NON_CTA_EXCLUDED_GENE_IDS:
+    excluded = _non_cta_excluded_gene_ids()
+    if "Ensembl_Gene_ID" in df.columns and excluded:
         unversioned = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
-        df = df[~unversioned.isin(NON_CTA_EXCLUDED_GENE_IDS)].reset_index(drop=True)
+        df = df[~unversioned.isin(excluded)].reset_index(drop=True)
     return df
+
+
+_register_derived_cache(_cta_frame.cache_clear)
 
 
 def cta_dataframe() -> pd.DataFrame:

--- a/cancerdata/cta_regen.py
+++ b/cancerdata/cta_regen.py
@@ -52,7 +52,7 @@ from .cta_tissues import (
     SAFETY_NTPM_THRESHOLD,
     SAFETY_TISSUE_GROUPS,
 )
-from .load_dataset import get_data
+from .load_dataset import _register_derived_cache, get_data
 
 # ── Curated overrides ──────────────────────────────────────────────────────
 
@@ -71,6 +71,9 @@ def cross_reactive_ihc() -> frozenset[str]:
     """
     df = get_data("cta-ihc-unreliable", copy=False)
     return frozenset(df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0])
+
+
+_register_derived_cache(cross_reactive_ihc.cache_clear)
 
 
 #: Reproductive (+thymus) tissues, lowercased, for the protein restriction call.

--- a/cancerdata/incidence.py
+++ b/cancerdata/incidence.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from functools import lru_cache
 
 from .cancer_types import cancer_type_registry, resolve_cancer_type
-from .load_dataset import get_data
+from .load_dataset import _register_derived_cache, get_data
 
 _BURDEN_METRICS = (
     "us_incidence_pct",
@@ -94,6 +94,10 @@ def _family_burden_map() -> dict[str, str]:
     the cns-* families, carcinoma-skin)."""
     df = get_data("family-burden-map")
     return dict(zip(df["family"].astype(str), df["burden_category"].astype(str)))
+
+
+_register_derived_cache(_tissue_burden_map.cache_clear)
+_register_derived_cache(_family_burden_map.cache_clear)
 
 
 def burden_category(cancer_type):

--- a/cancerdata/load_dataset.py
+++ b/cancerdata/load_dataset.py
@@ -41,11 +41,26 @@ _CACHED_DATAFRAMES: dict = {}
 # Back-compat alias.
 _DATA_DIR = _BUNDLED_DATA_DIR
 
+#: Clear callbacks for caches DERIVED from get_data results (e.g. processed
+#: lookups in incidence / cta). Each cache-holder registers its ``cache_clear`` via
+#: :func:`_register_derived_cache`; :func:`_clear_cache` drives them so swapping a
+#: bundled fixture invalidates the derived views too — no module needs to know
+#: about another's caches.
+_DERIVED_CACHE_CLEARERS: list = []
+
+
+def _register_derived_cache(clear_fn) -> None:
+    """Register a ``cache_clear``-style callback to run on :func:`_clear_cache`."""
+    _DERIVED_CACHE_CLEARERS.append(clear_fn)
+
 
 def _clear_cache() -> None:
-    """Drop cached frames + dataset-path map. Test hook for swapping fixtures."""
+    """Drop cached frames + dataset-path map + every derived cache. Test hook for
+    swapping fixtures."""
     _CACHED_DATAFRAMES.clear()
     _invalidate_dataset_paths()
+    for clear_fn in _DERIVED_CACHE_CLEARERS:
+        clear_fn()
 
 
 def _data_roots() -> list[Path]:

--- a/tests/test_incidence.py
+++ b/tests/test_incidence.py
@@ -4,9 +4,33 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import pandas as pd
 import pytest
 
 from cancerdata import incidence
+from cancerdata import load_dataset as ld
+
+
+def test_derived_burden_cache_invalidates_on_clear(monkeypatch):
+    # The lru_cached burden maps must be cleared by load_dataset._clear_cache(),
+    # so swapping a bundled fixture is reflected (test-isolation guard).
+    incidence._tissue_burden_map()  # populate the cache
+    real = incidence.get_data
+
+    def fake(name, *a, **k):
+        if name == "tissue-burden-map":
+            return pd.DataFrame(
+                {"primary_tissue": ["unobtanium"], "burden_category": ["xyzzy"], "scope": ["solid"]}
+            )
+        return real(name, *a, **k)
+
+    monkeypatch.setattr(incidence, "get_data", fake)
+    ld._clear_cache()
+    try:
+        assert incidence._tissue_burden_map() == {"unobtanium": "xyzzy"}
+    finally:
+        monkeypatch.undo()
+        ld._clear_cache()  # restore real data for other tests
 
 
 def test_burden_map_nonempty_floats():


### PR DESCRIPTION
Addresses the one finding from the adversarial cross-PR review of the reconciliation batch (#56–#63): four new `@lru_cache` views over `get_data` results weren't cleared by the cache hooks — `incidence._tissue_burden_map`/`_family_burden_map`, `cta._non_cta_excluded_gene_ids`/`_cta_frame`, `cta_regen.cross_reactive_ihc`. Harmless today (no test swaps that bundled data via `get_data`), but a test-isolation footgun: a future fixture-swap test would read stale burden/CTA results.

**Fix — a small self-registration mechanism** (generalize rather than make `cancer_types` know every sibling's caches):
- `load_dataset._register_derived_cache(clear_fn)` + `_clear_cache()` drives all registered clearers.
- Each cache-holder registers its `cache_clear` at import.
- `cancer_types._clear_caches()` now delegates to `load_dataset._clear_cache()` so the existing registry-swap test hook clears everything.
- `_cta_frame` now reads the cached `_non_cta_excluded_gene_ids()` (live) instead of the frozen module-level snapshot, so a swap stays correct; `NON_CTA_EXCLUDED_GENE_IDS` stays as a documented import-time snapshot.

A new test swaps the `tissue-burden-map` fixture, clears, and asserts the new value is reflected (then restores real data). Full suite 274 passed; ruff clean.