### PR TITLE
Per-sample expression accessor + per-patient antigen coverage (#13/#15)

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -55,6 +55,12 @@ from .cancer_types import (
     tissue_of_origin,
     viral_status,
 )
+from .coverage import (
+    addressable_fraction,
+    addressable_fraction_by_cohort,
+    cta_patient_fractions,
+    greedy_coverage,
+)
 from .cta import (
     CTA_evidence,
     CTA_excluded_gene_names,
@@ -73,6 +79,7 @@ from .expression import (
     available_representative_cohorts,
     available_within_sample_cohorts,
     cohort_gene_percentiles,
+    per_sample_expression,
     proteoform_representative_samples,
     representative_cohort_samples,
     within_sample_top_fraction,
@@ -139,6 +146,9 @@ __all__ = [
     # expression sources + per-sample curation
     "ExpressionSource",
     "__version__",
+    # expression (read accessors over the downloadable bundle)
+    "addressable_fraction",
+    "addressable_fraction_by_cohort",
     "available_percentile_cohorts",
     "available_representative_cohorts",
     "available_within_sample_cohorts",
@@ -177,12 +187,12 @@ __all__ = [
     # cohort vocabulary
     "cohort_aggregates",
     "cohort_aggregates_df",
-    # expression (read accessors over the downloadable bundle)
     "cohort_gene_percentiles",
     "cohort_kind",
     "cohort_registry",
     "cohort_registry_df",
     "cta_dataframe",
+    "cta_patient_fractions",
     "expression_source",
     "expression_sources",
     "family_display_name",
@@ -193,6 +203,7 @@ __all__ = [
     "gene_protein_tissues",
     "gene_tissue_ntpm",
     "gene_to_proteoform",
+    "greedy_coverage",
     "hpa_normal_tissue",
     # HPA normal-tissue reference data
     "hpa_rna_consensus",
@@ -200,6 +211,7 @@ __all__ = [
     "is_mixture_cohort",
     "known_cohort_ids",
     "mixture_cohort_codes",
+    "per_sample_expression",
     "protein_family",
     "proteoform_for_gene",
     "proteoform_group_map",

--- a/cancerdata/coverage.py
+++ b/cancerdata/coverage.py
@@ -1,0 +1,189 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-patient antigen coverage over the full per-sample matrices.
+
+These answer questions a per-cohort summary cannot, because they need the *joint*
+per-sample matrix — which patient expresses which antigen, not just per-gene
+prevalence:
+
+  - :func:`cta_patient_fractions` — per gene, the fraction of a cohort's patients
+    expressing it above a TPM threshold;
+  - :func:`addressable_fraction` — the fraction of patients expressing **≥1** of a
+    gene panel (the union — "what share of this cohort a CTA-directed therapy could
+    address"), which is NOT the per-gene fractions summed;
+  - :func:`greedy_coverage` — a minimal antigen panel by greedy set cover: at each
+    step add the gene covering the most still-uncovered patients.
+
+All operate on :func:`cancerdata.expression.per_sample_expression` (clean TPM), so
+they need the cohort's per-sample matrix fetched (see :mod:`cancerdata.source_matrices`).
+The default gene panel is the expressed CTA set (:func:`cancerdata.cta.CTA_gene_ids`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import numpy as np
+import pandas as pd
+
+from .cta import CTA_gene_id_to_name, CTA_gene_ids
+from .expression import per_sample_expression
+
+#: Default clean-TPM threshold for "expressed in a patient". 10 TPM is a common
+#: cut for a confidently-expressed transcript.
+DEFAULT_EXPRESSED_TPM: float = 10.0
+
+_BASE = ["Ensembl_Gene_ID", "Symbol"]
+
+
+def _panel_ids(gene_ids: Iterable[str] | None) -> set[str]:
+    ids = set(gene_ids) if gene_ids is not None else set(CTA_gene_ids())
+    return {str(g).split(".")[0] for g in ids}
+
+
+def _hit_matrix(cancer_type, *, threshold_tpm: float, gene_ids):
+    """``(panel rows of the matrix, sample columns, gene×sample boolean hit matrix)``
+    where a hit is clean TPM >= ``threshold_tpm`` for one gene in one patient."""
+    df = per_sample_expression(cancer_type, normalize="tpm_clean")
+    unversioned = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+    panel = _panel_ids(gene_ids)
+    sub = df[unversioned.isin(panel)].reset_index(drop=True)
+    samples = [c for c in df.columns if c not in _BASE]
+    hits = sub[samples].to_numpy(dtype=float) >= float(threshold_tpm)
+    return sub, samples, hits
+
+
+def cta_patient_fractions(
+    cancer_type,
+    *,
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    gene_ids: Iterable[str] | None = None,
+) -> pd.DataFrame:
+    """Per gene, the fraction of a cohort's patients expressing it above
+    ``threshold_tpm`` (clean TPM). Returns ``Ensembl_Gene_ID``, ``Symbol``,
+    ``fraction_expressing``, ``n_patients_expressing``, ``n_patients`` — sorted by
+    prevalence. The default gene panel is the expressed CTA set."""
+    sub, samples, hits = _hit_matrix(cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids)
+    n = len(samples)
+    out = sub[_BASE].copy()
+    counts = hits.sum(axis=1)
+    out["n_patients_expressing"] = counts
+    out["fraction_expressing"] = counts / n if n else 0.0
+    out["n_patients"] = n
+    return out.sort_values("fraction_expressing", ascending=False).reset_index(drop=True)
+
+
+def addressable_fraction(
+    cancer_type,
+    *,
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    gene_ids: Iterable[str] | None = None,
+) -> float:
+    """Fraction of a cohort's patients expressing **at least one** gene in the panel
+    above ``threshold_tpm`` — the faithful "addressable" share (the union across
+    patients, which the per-gene fractions can't be summed into). 0.0 for an empty
+    cohort/panel."""
+    _, samples, hits = _hit_matrix(cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids)
+    if not samples or hits.size == 0:
+        return 0.0
+    return float(hits.any(axis=0).mean())
+
+
+def greedy_coverage(
+    cancer_type,
+    *,
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    gene_ids: Iterable[str] | None = None,
+    max_genes: int | None = None,
+) -> pd.DataFrame:
+    """Greedy set-cover panel: at each step add the gene covering the most patients
+    not yet covered by the chosen panel, until every coverable patient is covered
+    (or ``max_genes`` is reached).
+
+    Returns one row per chosen gene, in selection order: ``rank``,
+    ``Ensembl_Gene_ID``, ``Symbol``, ``marginal_patients`` (newly covered),
+    ``marginal_fraction``, ``cumulative_patients``, ``cumulative_fraction``. The
+    cumulative fraction is the coverage curve; its last value equals
+    :func:`addressable_fraction`. Ties are broken by total prevalence then row order
+    (deterministic)."""
+    sub, samples, hits = _hit_matrix(cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids)
+    n = len(samples)
+    rows: list[dict] = []
+    if n == 0 or hits.size == 0:
+        return pd.DataFrame(
+            columns=[
+                "rank",
+                "Ensembl_Gene_ID",
+                "Symbol",
+                "marginal_patients",
+                "marginal_fraction",
+                "cumulative_patients",
+                "cumulative_fraction",
+            ]
+        )
+
+    covered = np.zeros(n, dtype=bool)
+    remaining = set(range(len(sub)))
+    total_prev = hits.sum(axis=1)  # tie-break: prefer the more broadly expressed gene
+    limit = max_genes if max_genes is not None else len(sub)
+
+    while remaining and len(rows) < limit:
+        best_g, best_new = None, 0
+        for g in remaining:
+            new = int(np.count_nonzero(hits[g] & ~covered))
+            if new > best_new or (
+                new == best_new and best_g is not None and total_prev[g] > total_prev[best_g]
+            ):
+                best_g, best_new = g, new
+        if best_g is None or best_new == 0:
+            break  # no remaining gene covers a new patient
+        covered |= hits[best_g]
+        remaining.discard(best_g)
+        cum = int(covered.sum())
+        rows.append(
+            {
+                "rank": len(rows) + 1,
+                "Ensembl_Gene_ID": str(sub.at[best_g, "Ensembl_Gene_ID"]),
+                "Symbol": str(sub.at[best_g, "Symbol"]),
+                "marginal_patients": best_new,
+                "marginal_fraction": best_new / n,
+                "cumulative_patients": cum,
+                "cumulative_fraction": cum / n,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def addressable_fraction_by_cohort(
+    cohorts: Iterable[str] | None = None,
+    *,
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    gene_ids: Iterable[str] | None = None,
+) -> pd.Series:
+    """``{cohort code -> addressable fraction}`` over the cohorts that have a
+    per-sample matrix (default: all of them). Skips cohorts whose matrix isn't
+    available rather than fetching every one implicitly."""
+    from . import source_matrices
+
+    codes = list(cohorts) if cohorts is not None else source_matrices.available_cohorts()
+    out: dict[str, float] = {}
+    for code in codes:
+        if cohorts is None and not source_matrices.is_cached(code):
+            continue
+        out[str(code)] = addressable_fraction(code, threshold_tpm=threshold_tpm, gene_ids=gene_ids)
+    return pd.Series(out, name="addressable_fraction")
+
+
+def cta_id_to_name() -> dict[str, str]:
+    """``{unversioned CTA gene id -> symbol}`` for labelling coverage outputs."""
+    return CTA_gene_id_to_name()

--- a/cancerdata/coverage.py
+++ b/cancerdata/coverage.py
@@ -114,8 +114,8 @@ def greedy_coverage(
     ``Ensembl_Gene_ID``, ``Symbol``, ``marginal_patients`` (newly covered),
     ``marginal_fraction``, ``cumulative_patients``, ``cumulative_fraction``. The
     cumulative fraction is the coverage curve; its last value equals
-    :func:`addressable_fraction`. Ties are broken by total prevalence then row order
-    (deterministic)."""
+    :func:`addressable_fraction` once the panel is exhausted (unless ``max_genes``
+    truncates it first). Ties are broken by total prevalence (deterministic)."""
     sub, samples, hits = _hit_matrix(cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids)
     n = len(samples)
     rows: list[dict] = []

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -34,10 +34,11 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from . import data_bundle
+from . import data_bundle, source_matrices
 from ._build import WITHIN_SAMPLE_THRESHOLDS as _WITHIN_SAMPLE_THRESHOLD_COLS
 from .cancer_types import cohort_aggregates, resolve_cancer_type
 from .load_dataset import _BUNDLED_DATA_DIR
+from .normalization import clean_tpm
 
 _REPRESENTATIVES_DIR = "cancer-reference-expression-representatives"
 _PERCENTILES_DIR = "cancer-reference-expression-percentiles"
@@ -117,6 +118,56 @@ def available_representative_cohorts() -> list[str]:
 def available_percentile_cohorts() -> list[str]:
     """Cohort codes that ship a per-gene percentile-vector shard (sorted)."""
     return _available_shard_codes(_percentiles_root())
+
+
+_PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p")
+
+
+def per_sample_expression(
+    cancer_type, *, normalize: str = "tpm_clean", auto_fetch: bool = True
+) -> pd.DataFrame:
+    """Full per-sample expression matrix (genes x **every** sample) for a cohort.
+
+    The packaged references are summaries — per-gene percentile vectors, bounded
+    medoid :func:`representative_cohort_samples`, within-sample top fractions. This
+    returns the raw material behind them: one column per individual sample, so a
+    consumer can ask per-patient questions a summary can't answer ("in what
+    fraction of patients is this gene expressed", greedy antigen co-occurrence
+    coverage, …). It fetches the cohort's per-sample matrix via
+    :mod:`cancerdata.source_matrices` (a per-cohort release asset, tens of MB) and
+    normalizes it.
+
+    ``normalize``:
+      - ``"tpm_clean"`` (default) — two-compartment clean TPM (the comparable
+        biological view the summaries are built on);
+      - ``"tpm_clean_log1p"`` — clean TPM, ``log1p``-transformed;
+      - ``"tpm_raw"`` — the matrix as shipped (raw TPM), no normalization.
+
+    ``auto_fetch=False`` raises instead of downloading if the matrix isn't cached.
+    Returns ``Ensembl_Gene_ID``, ``Symbol`` and one column per sample.
+    """
+    if normalize not in _PER_SAMPLE_NORMALIZE:
+        raise ValueError(f"normalize must be one of {_PER_SAMPLE_NORMALIZE}")
+    code = resolve_cancer_type(cancer_type, strict=False) or cancer_type
+    if auto_fetch:
+        path = source_matrices.ensure(code)
+    else:
+        path = source_matrices.local_path(code)
+        if not path.exists():
+            raise FileNotFoundError(
+                f"per-sample matrix for {code!r} not cached at {path}. "
+                f"Run source_matrices.fetch({code!r}) to download it."
+            )
+    raw = pd.read_parquet(path)
+    base = ["Ensembl_Gene_ID", "Symbol"]
+    samples = [c for c in raw.columns if c not in base]
+    if normalize == "tpm_raw":
+        return raw
+    clean = clean_tpm(raw[samples], gene_table=raw[base])
+    out = pd.concat([raw[base].reset_index(drop=True), clean.reset_index(drop=True)], axis=1)
+    if normalize == "tpm_clean_log1p":
+        out[samples] = np.log1p(out[samples].to_numpy(dtype=float))
+    return out
 
 
 def representative_cohort_samples(

--- a/scripts/stage_source_matrices.py
+++ b/scripts/stage_source_matrices.py
@@ -1,0 +1,130 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stage the per-cohort source matrices for ``cancerdata.source_matrices``.
+
+For each cancer code in ``source-matrices.csv``, find its single selected source
+cohort's raw per-sample matrix in a local matrix cache and copy it to:
+
+  - the ``source_matrices`` on-disk cache (``<CODE>.parquet``) so the accessor +
+    per-patient coverage analyses work locally without a release; and
+  - (with ``--release-dir``) an upload staging dir as ``<CODE>_per_sample_tpm.parquet``,
+    the exact asset names ``source_matrices.release_url`` expects on the
+    ``source-v<DATA_VERSION>`` GitHub release.
+
+The matrix cache is laid out ``<cache>/<cohort>/derived/<NAME>_per_sample_tpm.parquet``.
+The cohort directory is matched to the registry's ``source_cohort`` by GSE accession
+or normalized name (the same single-source choice the rebuild driver makes), so a
+multi-source code stages exactly the one matrix the shipped artifacts were built on.
+
+Run:
+    python scripts/stage_source_matrices.py --cache ~/.cache/pirlygenes/expression \
+        [--release-dir ~/cancerdata-source-upload] [--codes LUAD,SKCM] [--limit N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cancerdata import source_matrices as sm
+
+
+def _source_key(name: str) -> str:
+    m = re.search(r"GSE\d+", name.upper())
+    return m.group() if m else re.sub(r"[^A-Z0-9]", "", name.upper())
+
+
+def _matrices_by_source(cache: Path) -> dict[str, list[Path]]:
+    """``{source_key -> [matrix paths]}`` for every per-sample matrix in the cache."""
+    out: dict[str, list[Path]] = defaultdict(list)
+    for p in cache.glob("*/derived/*_per_sample_tpm.parquet"):
+        out[_source_key(p.parent.parent.name)].append(p)
+    return out
+
+
+def stage(cache: Path, *, release_dir: Path | None, codes: list[str] | None, limit: int | None):
+    reg = sm.registry()
+    by_source = _matrices_by_source(cache)
+    rows = reg.to_dict("records")
+    if codes:
+        wanted = {c.upper() for c in codes}
+        rows = [r for r in rows if str(r["cancer_code"]).upper() in wanted]
+    if limit:
+        rows = rows[:limit]
+
+    cache_out = sm.cache_dir()
+    if release_dir is not None:
+        release_dir.mkdir(parents=True, exist_ok=True)
+
+    staged, missing = 0, []
+    for r in rows:
+        code = str(r["cancer_code"])
+        src_key = _source_key(str(r["source_cohort"]))
+        candidates = by_source.get(src_key, [])
+        if not candidates:
+            missing.append((code, r["source_cohort"]))
+            continue
+        # If the source has multiple code-matrices, pick the one whose stem maps to
+        # this code (the rebuild driver's code key); else the sole candidate.
+        chosen = candidates[0] if len(candidates) == 1 else _match_code(code, candidates)
+        if chosen is None:
+            missing.append((code, r["source_cohort"]))
+            continue
+        shutil.copyfile(chosen, cache_out / f"{code}.parquet")
+        if release_dir is not None:
+            shutil.copyfile(chosen, release_dir / f"{code}_per_sample_tpm.parquet")
+        staged += 1
+        print(f"  {code}: <- {chosen.parent.parent.name}/{chosen.name}", flush=True)
+
+    print(f"\nstaged {staged}/{len(rows)} cohorts -> {cache_out}", flush=True)
+    if release_dir is not None:
+        print(f"release assets -> {release_dir}", flush=True)
+    if missing:
+        print(f"MISSING ({len(missing)}): {missing}", flush=True)
+
+
+def _match_code(code: str, candidates: list[Path]) -> Path | None:
+    def code_key(name: str) -> str:
+        n = name[5:] if name.lower().startswith("tcga_") else name
+        return n.replace("_", "").lower()
+
+    want = code_key(code)
+    hits = [
+        p for p in candidates if code_key(p.name.replace("_per_sample_tpm.parquet", "")) == want
+    ]
+    return hits[0] if len(hits) == 1 else (candidates[0] if candidates else None)
+
+
+def main(argv=None) -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--cache", required=True, type=Path, help="Local per-sample matrix cache root")
+    p.add_argument("--release-dir", type=Path, default=None, help="Also write upload-named assets")
+    p.add_argument("--codes", type=str, default=None, help="Comma-separated codes (default all)")
+    p.add_argument("--limit", type=int, default=None, help="Only the first N registry rows")
+    args = p.parse_args(argv)
+    stage(
+        args.cache.expanduser(),
+        release_dir=args.release_dir.expanduser() if args.release_dir else None,
+        codes=args.codes.split(",") if args.codes else None,
+        limit=args.limit,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stage_source_matrices.py
+++ b/scripts/stage_source_matrices.py
@@ -51,9 +51,10 @@ def _source_key(name: str) -> str:
 
 
 def _matrices_by_source(cache: Path) -> dict[str, list[Path]]:
-    """``{source_key -> [matrix paths]}`` for every per-sample matrix in the cache."""
+    """``{source_key -> [matrix paths]}`` for every per-sample matrix in the cache
+    (sorted, so candidate order is deterministic across machines)."""
     out: dict[str, list[Path]] = defaultdict(list)
-    for p in cache.glob("*/derived/*_per_sample_tpm.parquet"):
+    for p in sorted(cache.glob("*/derived/*_per_sample_tpm.parquet")):
         out[_source_key(p.parent.parent.name)].append(p)
     return out
 
@@ -100,6 +101,11 @@ def stage(cache: Path, *, release_dir: Path | None, codes: list[str] | None, lim
 
 
 def _match_code(code: str, candidates: list[Path]) -> Path | None:
+    """The candidate matrix whose filename stem maps to ``code`` (a source dir with
+    several code-matrices, e.g. treehouse). Returns ``None`` if the match isn't
+    unique — the caller reports that as missing rather than staging an arbitrary
+    matrix (silently shipping the wrong cohort would corrupt every analysis)."""
+
     def code_key(name: str) -> str:
         n = name[5:] if name.lower().startswith("tcga_") else name
         return n.replace("_", "").lower()
@@ -108,7 +114,7 @@ def _match_code(code: str, candidates: list[Path]) -> Path | None:
     hits = [
         p for p in candidates if code_key(p.name.replace("_per_sample_tpm.parquet", "")) == want
     ]
-    return hits[0] if len(hits) == 1 else (candidates[0] if candidates else None)
+    return hits[0] if len(hits) == 1 else None
 
 
 def main(argv=None) -> None:

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,98 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from cancerdata import coverage
+
+# A controlled 3-gene × 4-patient fixture (threshold 5):
+#   gA expressed in p0,p1   gB in p2   gC in p1 (redundant with gA)   p3 uncovered
+_GENES = ["ENSG_A", "ENSG_B", "ENSG_C"]
+_FIXTURE = pd.DataFrame(
+    {
+        "Ensembl_Gene_ID": _GENES,
+        "Symbol": ["GA", "GB", "GC"],
+        "p0": [10.0, 0.0, 0.0],
+        "p1": [10.0, 0.0, 10.0],
+        "p2": [0.0, 10.0, 0.0],
+        "p3": [0.0, 0.0, 0.0],
+    }
+)
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    monkeypatch.setattr(coverage, "per_sample_expression", lambda *a, **k: _FIXTURE.copy())
+    return _GENES
+
+
+def test_patient_fractions(patched):
+    pf = coverage.cta_patient_fractions("X", threshold_tpm=5, gene_ids=patched)
+    frac = dict(zip(pf["Ensembl_Gene_ID"], pf["fraction_expressing"]))
+    assert frac["ENSG_A"] == 0.5  # p0, p1
+    assert frac["ENSG_B"] == 0.25  # p2
+    assert frac["ENSG_C"] == 0.25  # p1
+    assert (pf["n_patients"] == 4).all()
+    # sorted by prevalence descending
+    assert next(iter(pf["Ensembl_Gene_ID"])) == "ENSG_A"
+
+
+def test_addressable_fraction_is_the_union(patched):
+    # Covered patients = p0,p1,p2 (p3 expresses nothing) -> 3/4. NOT the 0.5+0.25+0.25
+    # sum of per-gene fractions.
+    af = coverage.addressable_fraction("X", threshold_tpm=5, gene_ids=patched)
+    assert af == 0.75
+    # The union is >= the best single gene and <= the naive sum.
+    assert af >= 0.5
+    assert af < 0.5 + 0.25 + 0.25
+
+
+def test_greedy_coverage_is_set_cover(patched):
+    gc = coverage.greedy_coverage("X", threshold_tpm=5, gene_ids=patched)
+    # gA (covers p0,p1) first, then gB (covers p2); gC adds nothing -> excluded.
+    assert list(gc["Symbol"]) == ["GA", "GB"]
+    assert list(gc["marginal_patients"]) == [2, 1]
+    assert gc["cumulative_fraction"].iloc[-1] == 0.75  # == addressable_fraction
+    # cumulative is monotonic non-decreasing
+    assert (gc["cumulative_fraction"].diff().dropna() > 0).all()
+
+
+def test_greedy_respects_max_genes(patched):
+    gc = coverage.greedy_coverage("X", threshold_tpm=5, gene_ids=patched, max_genes=1)
+    assert len(gc) == 1
+    assert gc["cumulative_fraction"].iloc[0] == 0.5
+
+
+def test_empty_panel_is_zero(monkeypatch):
+    monkeypatch.setattr(coverage, "per_sample_expression", lambda *a, **k: _FIXTURE.copy())
+    assert coverage.addressable_fraction("X", gene_ids=[]) == 0.0
+    assert coverage.greedy_coverage("X", gene_ids=[]).empty
+
+
+def test_high_threshold_covers_nobody(patched):
+    # Nothing clears 1000 TPM -> 0 addressable, empty greedy panel.
+    assert coverage.addressable_fraction("X", threshold_tpm=1000, gene_ids=patched) == 0.0
+    assert coverage.greedy_coverage("X", threshold_tpm=1000, gene_ids=patched).empty
+
+
+# ---- real-data parity (skipped unless the source-matrix cache is staged) ----
+
+from cancerdata import source_matrices as _sm  # noqa: E402
+
+_LUAD_READY = _sm.is_cached("LUAD") if "LUAD" in _sm.available_cohorts() else False
+
+
+@pytest.mark.skipif(not _LUAD_READY, reason="LUAD per-sample matrix not staged")
+def test_real_cohort_coverage_is_consistent():
+    af = coverage.addressable_fraction("LUAD", threshold_tpm=10)
+    pf = coverage.cta_patient_fractions("LUAD", threshold_tpm=10)
+    gc = coverage.greedy_coverage("LUAD", threshold_tpm=10)
+    # union >= best single CTA, <= 1, and the greedy curve converges to it.
+    assert pf["fraction_expressing"].max() <= af <= 1.0
+    assert abs(gc["cumulative_fraction"].iloc[-1] - af) < 1e-9
+    assert (np.diff(gc["cumulative_fraction"].to_numpy()) > 0).all()

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -65,3 +65,50 @@ def test_representatives_provenance_requires_long_format():
     # a no-op, so it must fail loudly rather than silently dropping the request.
     with pytest.raises(ValueError, match="include_provenance=True requires format='long'"):
         expression.representative_cohort_samples("PRAD", include_provenance=True)
+
+
+def _raw_matrix(tmp_path):
+    # A tiny raw-TPM per-sample matrix (genes x samples) whose columns sum near 1e6.
+    df = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG1", "ENSG2", "ENSG3"],
+            "Symbol": ["A", "B", "C"],
+            "s1": [500000.0, 300000.0, 200000.0],
+            "s2": [100000.0, 600000.0, 300000.0],
+        }
+    )
+    path = tmp_path / "PRAD.parquet"
+    df.to_parquet(path, index=False)
+    return path
+
+
+def test_per_sample_expression_normalize_modes(tmp_path, monkeypatch):
+    path = _raw_matrix(tmp_path)
+    monkeypatch.setattr(expression.source_matrices, "ensure", lambda code: path)
+
+    raw = expression.per_sample_expression("PRAD", normalize="tpm_raw")
+    assert list(raw.columns) == ["Ensembl_Gene_ID", "Symbol", "s1", "s2"]
+    assert raw["s1"].sum() == pytest.approx(1e6)
+
+    clean = expression.per_sample_expression("PRAD", normalize="tpm_clean")
+    # No technical/censored genes in this fixture -> the technical compartment is
+    # empty and the biological compartment fills its 750k budget (clean_tpm's
+    # two-compartment contract). A real matrix with technical genes sums to ~1e6.
+    assert clean["s1"].sum() == pytest.approx(750000.0, rel=1e-6)
+    assert list(clean.columns) == ["Ensembl_Gene_ID", "Symbol", "s1", "s2"]
+
+    logged = expression.per_sample_expression("PRAD", normalize="tpm_clean_log1p")
+    assert np.allclose(logged["s1"].to_numpy(), np.log1p(clean["s1"].to_numpy()))
+
+
+def test_per_sample_expression_bad_normalize(tmp_path, monkeypatch):
+    monkeypatch.setattr(expression.source_matrices, "ensure", lambda code: _raw_matrix(tmp_path))
+    with pytest.raises(ValueError, match="normalize must be one of"):
+        expression.per_sample_expression("PRAD", normalize="zscore")
+
+
+def test_per_sample_expression_no_autofetch_raises(monkeypatch, tmp_path):
+    missing = tmp_path / "nope.parquet"
+    monkeypatch.setattr(expression.source_matrices, "local_path", lambda code: missing)
+    with pytest.raises(FileNotFoundError, match="not cached"):
+        expression.per_sample_expression("PRAD", auto_fetch=False)


### PR DESCRIPTION
The first half of unblocking the per-patient pirlygenes plots: cancerdata couldn't answer per-patient questions because it ships only per-cohort summaries (percentiles, n=5 medoids, within-sample fractions). This adds the per-sample layer.

### `expression.per_sample_expression(code, normalize=)`
Full **genes × every-sample** matrix for a cohort, fetched via `source_matrices` (the per-cohort release asset) and normalized (`tpm_clean` default / `tpm_clean_log1p` / `tpm_raw`). Complements `representative_cohort_samples` (n=5 medoids) — same clean-TPM basis, all samples.

### `cancerdata/coverage.py` — per-patient primitives over the joint matrix
- `cta_patient_fractions(code, threshold_tpm=)` — per gene, the fraction of patients expressing it above a TPM cut.
- `addressable_fraction(code, …)` — fraction of patients expressing **≥1** of a panel (the **union** — the faithful "addressable" share that the per-gene fractions can't be summed into).
- `greedy_coverage(code, …)` — minimal antigen panel by greedy set cover; the cumulative curve converges to `addressable_fraction` (the coverage curve).
- `addressable_fraction_by_cohort(…)` — the across-cohort series.

### `scripts/stage_source_matrices.py`
Populates the `source_matrices` cache (and an upload dir of `<CODE>_per_sample_tpm.parquet` release assets) from a local matrix cache, using the registry's single-source selection — i.e. it prepares the exact assets the `source-v<DATA_VERSION>` release needs.

### Validation
End-to-end on real cohorts: **LUAD addressable = 0.95** (XAGE1B → CT83 → EGFL6 lead the greedy panel), SKCM 0.99, MM 0.66 — biologically sensible. **10 tests**: synthetic set-cover/union semantics + a real-data parity test gated on a staged cohort. Full suite 284 passed.

**Remaining for non-local use:** the per-sample matrices must be uploaded to the `source-v<DATA_VERSION>` GitHub release (the accessor fetches from there); the staging script produces exactly those assets. The plots + CLI that consume this layer are the follow-up PR.