### PR TITLE
Per-patient CTA plots: patient-count heatmap, coverage curves, faithful burden (#15)

### DIFF
--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -253,16 +253,30 @@ def _cmd_plot(args: argparse.Namespace) -> int:
         "incidence-vs-mortality": plots.incidence_vs_mortality,
         "cta-expression-heatmap": plots.cta_expression_heatmap,
         "cta-addressable-burden": plots.cta_addressable_burden,
+        "cta-patient-heatmap": plots.cta_patient_count_heatmap,
+        "cta-coverage-curves": plots.cta_coverage_curves,
     }
     try:
         if args.which == "incidence-vs-mortality":
             kwargs = {"region": args.region}
         elif args.which == "cta-expression-heatmap":
             kwargs = {"stat": args.stat}
+        elif args.which == "cta-addressable-burden":
+            kwargs = {"source": args.source, "threshold_tpm": args.threshold_tpm}
+        elif args.which == "cta-patient-heatmap":
+            kwargs = {"threshold_tpm": args.threshold_tpm}
+        elif args.which == "cta-coverage-curves":
+            if not args.codes:
+                print("Error: cta-coverage-curves needs --codes", file=sys.stderr)
+                return 1
+            kwargs = {
+                "cancer_types": [c.strip() for c in args.codes.split(",")],
+                "threshold_tpm": args.threshold_tpm,
+            }
         else:
             kwargs = {}
         fns[args.which](save=args.out, **kwargs)
-    except (ValueError, ModuleNotFoundError, NotImplementedError) as e:
+    except (ValueError, ModuleNotFoundError, NotImplementedError, FileNotFoundError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"Wrote {args.out}")
@@ -439,6 +453,8 @@ def _build_parser() -> argparse.ArgumentParser:
             "incidence-vs-mortality",
             "cta-expression-heatmap",
             "cta-addressable-burden",
+            "cta-patient-heatmap",
+            "cta-coverage-curves",
         ],
         help="Which plot to render",
     )
@@ -451,6 +467,23 @@ def _build_parser() -> argparse.ArgumentParser:
         default="median",
         choices=["q1", "median", "q3"],
         help="Statistic for cta-expression-heatmap",
+    )
+    p_plot.add_argument(
+        "--source",
+        default="within_sample",
+        choices=["within_sample", "per_sample"],
+        help="Prevalence basis for cta-addressable-burden (per_sample needs matrices)",
+    )
+    p_plot.add_argument(
+        "--threshold-tpm",
+        type=float,
+        default=10.0,
+        help="Clean-TPM 'expressed' cut for the per-sample CTA plots",
+    )
+    p_plot.add_argument(
+        "--codes",
+        default=None,
+        help="Comma-separated cancer codes (for cta-coverage-curves)",
     )
     p_plot.set_defaults(func=_cmd_plot)
 

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -320,37 +320,58 @@ def _cta_prevalence_by_cohort(threshold):
     return out
 
 
+def _addressable_prevalence(source, *, threshold, threshold_tpm):
+    """``({code: addressable share}, xlabel)`` for the two prevalence sources."""
+    if source == "per_sample":
+        # Faithful: fraction of a cohort's patients expressing >=1 CTA above
+        # threshold_tpm (the union), from the per-sample matrices.
+        from .coverage import addressable_fraction_by_cohort
+
+        prev = addressable_fraction_by_cohort(threshold_tpm=threshold_tpm).to_dict()
+        return prev, (
+            f"Addressable burden  (incidence share × P(≥1 CTA > {threshold_tpm:g} TPM), per-patient)"
+        )
+    if source == "within_sample":
+        prev = _cta_prevalence_by_cohort(threshold)
+        return prev, f"Addressable burden  (incidence share × top-CTA prevalence, thr={threshold})"
+    raise ValueError("source must be 'within_sample' or 'per_sample'")
+
+
 def cta_addressable_burden(
     *,
+    source="within_sample",
     threshold=0.95,
+    threshold_tpm=10.0,
     metric="us_incidence_pct",
     n=25,
     save=None,
 ):
-    """Bar chart of **CTA-addressable cancer burden** per cancer type.
+    """Bar chart of **CTA-addressable cancer burden** per cancer type — ``incidence
+    share × CTA prevalence``, ranking cancers by how many patients a CTA-directed
+    therapy could address.
 
-    Combines two things cancerdata owns: the incidence share of each cancer
-    (:func:`cancerdata.incidence.cancer_burden`) and the within-sample prevalence of
-    the most-expressed CTA in that cohort (:func:`_cta_prevalence_by_cohort`). The
-    bar is ``incidence_share × CTA_prevalence`` — a relative measure of how many
-    patients a CTA-directed therapy could address, ranking cancers by opportunity.
+    ``source`` selects the prevalence basis:
+      - ``"within_sample"`` (default, portable) — the single-best-CTA within-sample
+        prevalence from the shipped within-sample bundle (a *proxy*; ``threshold`` is
+        the within-sample rank cut 0.99/0.95/0.90);
+      - ``"per_sample"`` — the **faithful** fraction of patients expressing ≥1 CTA
+        above ``threshold_tpm`` (the per-patient union), from the per-sample matrices
+        (:func:`cancerdata.coverage.addressable_fraction_by_cohort`); needs the
+        cohorts' per-sample matrices cached.
 
-    ``threshold`` is the within-sample rank cut (0.99/0.95/0.90 → top 1/5/10%);
-    ``metric`` selects the incidence basis; ``n`` caps the bars shown. Bars are
-    coloured by registry family. Needs the within-sample bundle present.
-
-    Scope note: incidence is at burden-category granularity (several subtypes share
-    a category), and the prevalence is the single-best-CTA proxy — an exact "fraction
-    expressing ≥1 CTA" union needs the per-sample matrices (#13). So read this as a
-    relative prioritization, not an absolute patient count."""
+    ``metric`` selects the incidence basis; ``n`` caps the bars; bars are coloured by
+    registry family. Incidence is at burden-category granularity (several subtypes
+    share a category), so read the bar as a relative prioritization."""
     import numpy as np
 
     plt = _plt()
-    prevalence = _cta_prevalence_by_cohort(threshold)
+    prevalence, xlabel = _addressable_prevalence(
+        source, threshold=threshold, threshold_tpm=threshold_tpm
+    )
     if not prevalence:
         raise ValueError(
-            "no within-sample CTA prevalence available — is the within-sample bundle present? "
-            "(see available_within_sample_cohorts())"
+            f"no CTA prevalence available for source={source!r} — is the required data "
+            "present? (within-sample bundle, or cached per-sample matrices)"
         )
     burden = cancer_burden(metric=metric)  # {burden category: share}
 
@@ -376,10 +397,125 @@ def cta_addressable_burden(
     ax.set_yticks(y)
     ax.set_yticklabels([format_cancer_code_label(c) for c in codes], fontsize=7)
     ax.invert_yaxis()
-    ax.set_xlabel(f"Addressable burden  (incidence share × top-CTA prevalence, thr={threshold})")
+    ax.set_xlabel(xlabel)
     ax.set_title(f"CTA-addressable cancer burden — top {len(codes)} cancers")
     handles = [plt.Rectangle((0, 0), 1, 1, color=c) for c in fam_color.values()]
     ax.legend(handles, list(fam_color), fontsize=6, title="family", loc="lower right")
+    fig.tight_layout()
+    return _save(fig, save)
+
+
+def _cached_per_sample_cohorts():
+    """Cohort codes whose per-sample matrix is cached locally (sorted)."""
+    from . import source_matrices
+
+    return sorted(c for c in source_matrices.available_cohorts() if source_matrices.is_cached(c))
+
+
+def cta_patient_count_heatmap(
+    *,
+    threshold_tpm=10.0,
+    cohorts=None,
+    n_cohorts=30,
+    n_ctas=30,
+    value="fraction",
+    save=None,
+):
+    """Heatmap of **per-patient CTA prevalence** — rows are cohorts, columns are
+    CTAs, each cell is the fraction (or count) of that cohort's patients expressing
+    the CTA above ``threshold_tpm`` clean TPM.
+
+    Unlike :func:`cta_expression_heatmap` (cohort summary TPM), this is computed from
+    the full per-sample matrices, so it answers "in what fraction of *patients* is
+    this antigen expressed". ``cohorts`` defaults to every cohort whose per-sample
+    matrix is cached; ``value`` is ``"fraction"`` (0–1) or ``"count"`` (patients).
+    Rows/cols are the top ``n_cohorts``/``n_ctas`` by prevalence."""
+    import pandas as pd
+
+    from .coverage import cta_patient_fractions
+
+    if value not in ("fraction", "count"):
+        raise ValueError("value must be 'fraction' or 'count'")
+    plt = _plt()
+    cohorts = list(cohorts) if cohorts is not None else _cached_per_sample_cohorts()
+    if not cohorts:
+        raise ValueError(
+            "no cohorts with a cached per-sample matrix — fetch them via "
+            "source_matrices.fetch(code) (or stage them) first."
+        )
+    col = "fraction_expressing" if value == "fraction" else "n_patients_expressing"
+    rows = {}
+    for code in cohorts:
+        pf = cta_patient_fractions(code, threshold_tpm=threshold_tpm)
+        rows[code] = pd.Series(pf[col].to_numpy(), index=pf["Symbol"])
+    matrix = pd.DataFrame(rows).T  # cohorts × CTA symbols
+    matrix = matrix.loc[:, ~matrix.columns.duplicated()]
+    if matrix.empty or matrix.shape[1] == 0:
+        raise ValueError("no CTA expressed above the threshold in the selected cohorts")
+
+    top_ctas = matrix.max(axis=0).sort_values(ascending=False).head(n_ctas).index
+    row_score = matrix[top_ctas].max(axis=1)
+    top_cohorts = row_score.sort_values(ascending=False).head(n_cohorts).index
+    grid = matrix.loc[top_cohorts, top_ctas].fillna(0.0)
+
+    fig, ax = plt.subplots(figsize=(max(8, 0.42 * len(top_ctas)), max(6, 0.34 * len(top_cohorts))))
+    im = ax.imshow(grid.to_numpy(dtype=float), aspect="auto", cmap="viridis")
+    ax.set_xticks(range(len(top_ctas)))
+    ax.set_xticklabels(list(top_ctas), rotation=90, fontsize=6)
+    ax.set_yticks(range(len(top_cohorts)))
+    ax.set_yticklabels([format_cancer_code_label(c) for c in top_cohorts], fontsize=6)
+    unit = "fraction of patients" if value == "fraction" else "patients"
+    ax.set_title(
+        f"CTA per-patient prevalence (> {threshold_tpm:g} TPM) — "
+        f"{len(top_cohorts)} cohorts × {len(top_ctas)} CTAs"
+    )
+    cbar = fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01)
+    cbar.set_label(unit)
+    fig.tight_layout()
+    return _save(fig, save)
+
+
+def cta_coverage_curves(
+    cancer_types,
+    *,
+    threshold_tpm=10.0,
+    max_genes=20,
+    save=None,
+):
+    """Greedy **antigen-coverage curves** — for each cohort, the cumulative fraction
+    of patients covered as CTAs are added to the panel in greedy set-cover order
+    (:func:`cancerdata.coverage.greedy_coverage`). Answers "how many antigens does a
+    panel need to reach most patients of this cancer".
+
+    ``cancer_types`` is a code or iterable of codes (each needs a cached per-sample
+    matrix); the curve starts at 0 antigens / 0 coverage and steps up per added CTA,
+    truncated at ``max_genes``."""
+    import numpy as np
+
+    from .coverage import greedy_coverage
+
+    codes = [cancer_types] if isinstance(cancer_types, str) else list(cancer_types)
+    plt = _plt()
+    fig, ax = plt.subplots(figsize=(8, 5))
+    plotted = 0
+    for code in codes:
+        gc = greedy_coverage(code, threshold_tpm=threshold_tpm, max_genes=max_genes)
+        if gc.empty:
+            continue
+        x = np.concatenate([[0], gc["rank"].to_numpy()])
+        y = np.concatenate([[0.0], gc["cumulative_fraction"].to_numpy()])
+        ax.step(x, y, where="post", marker="o", markersize=3, label=format_cancer_code_label(code))
+        plotted += 1
+    if not plotted:
+        raise ValueError(
+            "no coverage curve could be drawn — are the cohorts' per-sample matrices "
+            "cached, and does any CTA clear the threshold?"
+        )
+    ax.set_xlabel("number of CTAs in panel (greedy set cover)")
+    ax.set_ylabel(f"fraction of patients covered (≥1 CTA > {threshold_tpm:g} TPM)")
+    ax.set_ylim(0, 1)
+    ax.set_title("CTA antigen-coverage curves")
+    ax.legend(fontsize=7, loc="lower right")
     fig.tight_layout()
     return _save(fig, save)
 

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -447,9 +447,11 @@ def cta_patient_count_heatmap(
     rows = {}
     for code in cohorts:
         pf = cta_patient_fractions(code, threshold_tpm=threshold_tpm)
-        rows[code] = pd.Series(pf[col].to_numpy(), index=pf["Symbol"])
+        # Collapse identical-protein paralogs sharing a Symbol to one column (max
+        # prevalence) so the per-cohort index is unique — pd.DataFrame can't align
+        # Series on a duplicated index.
+        rows[code] = pf.groupby("Symbol")[col].max()
     matrix = pd.DataFrame(rows).T  # cohorts × CTA symbols
-    matrix = matrix.loc[:, ~matrix.columns.duplicated()]
     if matrix.empty or matrix.shape[1] == 0:
         raise ValueError("no CTA expressed above the threshold in the selected cohorts")
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -102,7 +102,7 @@ def test_cta_addressable_burden_renders(tmp_path, monkeypatch):
 
 def test_cta_addressable_burden_no_within_sample(monkeypatch):
     monkeypatch.setattr(plots, "_cta_prevalence_by_cohort", lambda threshold: {})
-    with pytest.raises(ValueError, match="no within-sample CTA prevalence"):
+    with pytest.raises(ValueError, match="no CTA prevalence available"):
         plots.cta_addressable_burden()
 
 
@@ -116,3 +116,93 @@ def test_cta_addressable_burden_no_mapped_cohorts(monkeypatch):
 def test_cta_specific_9mer_counts_not_implemented():
     with pytest.raises(NotImplementedError, match="#15"):
         plots.cta_specific_9mer_counts()
+
+
+# ---- per-patient plots (consume the per-sample matrices via coverage.py) ----
+
+
+def test_cta_addressable_burden_per_sample_source(tmp_path, monkeypatch):
+    # source="per_sample" pulls the faithful union from coverage; stub it hermetically.
+    from cancerdata import coverage
+
+    monkeypatch.setattr(
+        coverage,
+        "addressable_fraction_by_cohort",
+        lambda **k: __import__("pandas").Series({"LUAD": 0.95, "SKCM": 0.99, "BRCA": 0.5}),
+    )
+    out = tmp_path / "burden_faithful.png"
+    fig = plots.cta_addressable_burden(source="per_sample", n=10, save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+    assert fig is not None
+
+
+def test_cta_addressable_burden_bad_source():
+    with pytest.raises(ValueError, match="source must be"):
+        plots.cta_addressable_burden(source="nonsense")
+
+
+def test_cta_patient_count_heatmap_renders(tmp_path, monkeypatch):
+    import pandas as pd
+
+    from cancerdata import coverage
+
+    def fake_fractions(code, *, threshold_tpm):
+        # two cohorts, three CTAs with different per-patient prevalences
+        base = {"LUAD": [0.7, 0.3, 0.1], "SKCM": [0.9, 0.2, 0.5]}[code]
+        return pd.DataFrame(
+            {
+                "Ensembl_Gene_ID": ["E1", "E2", "E3"],
+                "Symbol": ["GA", "GB", "GC"],
+                "fraction_expressing": base,
+                "n_patients_expressing": [int(x * 100) for x in base],
+                "n_patients": [100, 100, 100],
+            }
+        )
+
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: ["LUAD", "SKCM"])
+    monkeypatch.setattr(coverage, "cta_patient_fractions", fake_fractions)
+    out = tmp_path / "patient_heatmap.png"
+    fig = plots.cta_patient_count_heatmap(n_ctas=3, save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+    assert fig is not None
+
+
+def test_cta_patient_count_heatmap_no_cohorts(monkeypatch):
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: [])
+    with pytest.raises(ValueError, match="no cohorts with a cached per-sample matrix"):
+        plots.cta_patient_count_heatmap()
+
+
+def test_cta_coverage_curves_renders(tmp_path, monkeypatch):
+    import pandas as pd
+
+    from cancerdata import coverage
+
+    def fake_greedy(code, *, threshold_tpm, max_genes):
+        return pd.DataFrame(
+            {
+                "rank": [1, 2, 3],
+                "Ensembl_Gene_ID": ["E1", "E2", "E3"],
+                "Symbol": ["GA", "GB", "GC"],
+                "marginal_patients": [60, 20, 10],
+                "marginal_fraction": [0.6, 0.2, 0.1],
+                "cumulative_patients": [60, 80, 90],
+                "cumulative_fraction": [0.6, 0.8, 0.9],
+            }
+        )
+
+    monkeypatch.setattr(coverage, "greedy_coverage", fake_greedy)
+    out = tmp_path / "curves.png"
+    fig = plots.cta_coverage_curves(["LUAD", "SKCM"], save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+    assert fig is not None
+
+
+def test_cta_coverage_curves_empty_raises(monkeypatch):
+    import pandas as pd
+
+    from cancerdata import coverage
+
+    monkeypatch.setattr(coverage, "greedy_coverage", lambda *a, **k: pd.DataFrame())
+    with pytest.raises(ValueError, match="no coverage curve"):
+        plots.cta_coverage_curves(["LUAD"])

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -173,6 +173,30 @@ def test_cta_patient_count_heatmap_no_cohorts(monkeypatch):
         plots.cta_patient_count_heatmap()
 
 
+def test_cta_patient_count_heatmap_duplicate_symbols(tmp_path, monkeypatch):
+    # Paralog CTAs sharing a Symbol must not crash the cohort×CTA frame alignment.
+    import pandas as pd
+
+    from cancerdata import coverage
+
+    def fake_fractions(code, *, threshold_tpm):
+        return pd.DataFrame(
+            {
+                "Ensembl_Gene_ID": ["E1", "E2", "E3"],
+                "Symbol": ["GA", "GA", "GB"],  # GA duplicated (two paralogs)
+                "fraction_expressing": [0.7, 0.3, 0.1],
+                "n_patients_expressing": [70, 30, 10],
+                "n_patients": [100, 100, 100],
+            }
+        )
+
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: ["LUAD", "SKCM"])
+    monkeypatch.setattr(coverage, "cta_patient_fractions", fake_fractions)
+    out = tmp_path / "dup.png"
+    fig = plots.cta_patient_count_heatmap(save=str(out))  # must not raise
+    assert out.exists() and fig is not None
+
+
 def test_cta_coverage_curves_renders(tmp_path, monkeypatch):
     import pandas as pd
 


### PR DESCRIPTION
The second half of unblocking the per-patient pirlygenes plots — built on the coverage layer from #70.

### New plots
- **`cta_patient_count_heatmap`** — cohorts × CTAs grid where each cell is the **fraction (or count) of patients** expressing that CTA above a clean-TPM cut, computed from the full per-sample matrices. The per-patient analogue of `cta_expression_heatmap` (which uses cohort-summary TPM).
- **`cta_coverage_curves`** — greedy **antigen-coverage curves**: cumulative fraction of patients covered as CTAs are added to the panel in set-cover order. Answers "how many antigens does a panel need to reach most patients". Validated on real cohorts — SKCM ~96% with **one** antigen, LUAD ~95% by 6, MM (CTA-poor) plateaus ~63%.
- **`cta_addressable_burden`** gains **`source="per_sample"`** — the **faithful** union (`P(≥1 CTA > threshold_tpm) × incidence`) from the per-sample matrices, alongside the default portable `"within_sample"` proxy. One plot, an honest knob.

### CLI
`cancerdata plot cta-patient-heatmap` and `cta-coverage-curves`, with `--source` / `--threshold-tpm` / `--codes`.

### Tests
8 hermetic tests (the `coverage` primitives stubbed, so no matrices needed) covering renders, the source knob, and the empty/no-cohort error paths; renders also verified on staged real cohorts. Full suite **290 green**.

These plots need the target cohorts' per-sample matrices cached (the #13 accessor + the `source-v<DATA_VERSION>` release the staging script prepares). With those present, every per-patient pirlygenes plot the earlier audit flagged as blocked is now reproducible from cancerdata.