### PR TITLE
Expression engine: FPKM→TPM + renormalize-to-million (#72 PR2a)

### DIFF
--- a/cancerdata/normalization.py
+++ b/cancerdata/normalization.py
@@ -157,3 +157,77 @@ def percentile_rank(df: pd.DataFrame, value_cols=None) -> pd.DataFrame:
     out = df.copy()
     out[cols] = df[cols].rank(axis=0, pct=True) * 100.0
     return out
+
+
+# ---------- TPM-scale rescaling (FPKM->TPM, renormalize to 1e6) ----------
+
+#: Column-name conventions for "an expression value column" — TPM/nTPM/FPKM named
+#: (mirrors the pirlygenes expression schema), excluding the ``_raw`` provenance
+#: copies that must never be rescaled.
+_VALUE_COL_PREFIXES = ("TPM", "nTPM_", "FPKM_")
+_VALUE_COL_SUFFIXES = (
+    "_TPM",
+    "_nTPM",
+    "_FPKM",
+    "_TPM_log1p",
+    "_nTPM_log1p",
+    "_TPM_clean",
+    "_nTPM_clean",
+    "_TPM_clean_log1p",
+    "_nTPM_clean_log1p",
+    "_TPM_hk",
+    "_nTPM_hk",
+    "_TPM_percentile",
+    "_nTPM_percentile",
+)
+_RAW_VALUE_COL_PREFIXES = ("TPM_raw_", "nTPM_raw_")
+_RAW_VALUE_COL_SUFFIXES = ("_TPM_raw", "_nTPM_raw")
+
+
+def is_expression_value_col(col: object) -> bool:
+    """True if ``col`` names an expression value column (TPM/nTPM/FPKM-named),
+    excluding the ``_raw`` provenance copies."""
+    name = str(col)
+    return (name.startswith(_VALUE_COL_PREFIXES) or name.endswith(_VALUE_COL_SUFFIXES)) and not (
+        name.startswith(_RAW_VALUE_COL_PREFIXES) or name.endswith(_RAW_VALUE_COL_SUFFIXES)
+    )
+
+
+def renormalize_to_million(df: pd.DataFrame, *, value_cols=None) -> tuple[pd.DataFrame, dict]:
+    """Rescale each expression column so its finite sum is exactly 1e6 (the TPM
+    convention). Drops nothing — a bare utility, e.g. after :func:`clean_tpm` /
+    technical-gene removal if you also want the post-filter total pinned at 1e6.
+
+    Returns ``(rescaled_df, stats)`` where ``stats`` records, per column, the input
+    sum and applied scale (a column whose sum is ≤ 0 is left untouched, scale 1.0).
+    ``value_cols`` defaults to the TPM/nTPM/FPKM-named columns
+    (:func:`is_expression_value_col`)."""
+    out = df.copy()
+    if value_cols is None:
+        value_cols = [c for c in out.columns if is_expression_value_col(c)]
+    value_cols = [str(c) for c in value_cols if str(c) in out.columns]
+    columns: dict[str, dict] = {}
+    any_applied = False
+    for col in value_cols:
+        vals = pd.to_numeric(out[col], errors="coerce")
+        col_sum = float(vals.sum())
+        columns[col] = {"input_sum": col_sum}
+        if col_sum <= 0:
+            columns[col]["scale"] = 1.0
+            continue
+        scale = 1e6 / col_sum
+        out[col] = vals * scale
+        columns[col]["scale"] = scale
+        columns[col]["output_sum"] = 1e6
+        any_applied = True
+    stats = {"applied": any_applied, "columns": columns, "value_cols": value_cols}
+    return out, stats
+
+
+def fpkm_to_tpm(df: pd.DataFrame, *, value_cols=None) -> tuple[pd.DataFrame, dict]:
+    """Convert FPKM-scale expression columns to TPM by per-column rescaling:
+    ``TPM_i = FPKM_i / sum(FPKM_j) * 1e6`` over finite rows. Mathematically the same
+    as :func:`renormalize_to_million` (FPKM and TPM share the same per-sample
+    normalization), but a self-documenting entry point for the quantifier→TPM step.
+    Returns ``(df, stats)``."""
+    return renormalize_to_million(df, value_cols=value_cols)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -82,3 +82,53 @@ def test_normalize_to_housekeeping():
     df = gt.assign(s1=[10.0, 30.0, 100.0])  # hk median = 20
     out = norm.normalize_to_housekeeping(df)
     assert np.allclose(out["s1"], [0.5, 1.5, 5.0])
+
+
+# ---- FPKM->TPM / renormalize-to-million ----
+
+
+def test_renormalize_to_million_rescales_each_column():
+    df = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1", "E2"],
+            "Symbol": ["A", "B"],
+            "s1_TPM": [1.0, 3.0],  # sum 4 -> scale 250000
+            "s2_TPM": [10.0, 10.0],  # sum 20 -> scale 50000
+        }
+    )
+    out, stats = norm.renormalize_to_million(df)
+    assert out["s1_TPM"].sum() == pytest.approx(1e6)
+    assert out["s2_TPM"].sum() == pytest.approx(1e6)
+    assert stats["applied"] is True
+    assert stats["columns"]["s1_TPM"]["scale"] == pytest.approx(250000.0)
+    # id columns untouched
+    assert list(out["Symbol"]) == ["A", "B"]
+
+
+def test_renormalize_ignores_raw_and_zero_columns():
+    df = pd.DataFrame(
+        {
+            "s1_TPM": [1.0, 1.0],
+            "s2_TPM_raw": [5.0, 5.0],  # _raw provenance -> never rescaled
+            "s3_TPM": [0.0, 0.0],  # zero sum -> left untouched, scale 1.0
+        }
+    )
+    out, stats = norm.renormalize_to_million(df)
+    assert list(out["s2_TPM_raw"]) == [5.0, 5.0]  # untouched
+    assert "s2_TPM_raw" not in stats["columns"]
+    assert stats["columns"]["s3_TPM"]["scale"] == 1.0
+    assert out["s1_TPM"].sum() == pytest.approx(1e6)
+
+
+def test_fpkm_to_tpm_equals_renormalize():
+    df = pd.DataFrame({"x_FPKM": [2.0, 6.0, 2.0]})
+    out, _ = norm.fpkm_to_tpm(df, value_cols=["x_FPKM"])
+    assert out["x_FPKM"].sum() == pytest.approx(1e6)
+    assert out["x_FPKM"].to_numpy() == pytest.approx([2e5, 6e5, 2e5])
+
+
+def test_is_expression_value_col():
+    assert norm.is_expression_value_col("LUAD_TPM_clean")
+    assert norm.is_expression_value_col("TPM")
+    assert not norm.is_expression_value_col("LUAD_TPM_raw")
+    assert not norm.is_expression_value_col("Ensembl_Gene_ID")


### PR DESCRIPTION
First PR of #72 (completing the cancerdata expression engine). Ports the self-contained TPM-scale rescaling primitives trufflepig imports from `pirlygenes.expression.normalize`:

- **`renormalize_to_million(df)`** — rescale each TPM/nTPM/FPKM value column so its finite sum is exactly 1e6 (the TPM convention); drops nothing. Returns `(df, stats)` with per-column `input_sum` + `scale`, drop-in compatible with pirlygenes.
- **`fpkm_to_tpm(df)`** — the FPKM→TPM entry point (same math — FPKM and TPM share the per-sample normalization — but a self-documenting quantifier→TPM step).
- **`is_expression_value_col`** + the TPM/nTPM/FPKM column-name convention, excluding the `_raw` provenance copies that must never be rescaled.

Pandas/numpy only — fits cancerdata's base-layer dependency contract. 4 tests (per-column rescale, `_raw`/zero-column handling, `fpkm == renormalize`, column detection). Full suite 296 passed.

Next in the series: `normalize_expression` + technical-RNA wrappers (PR2b), gene-QC (PR3), cohort-mean accessor (PR4).