### PR TITLE
General proteoform identity: keep ENSG joinable, add proteoform_id

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -114,7 +114,9 @@ from .incidence import (
     cancer_code_burden_map,
 )
 from .proteoforms import (
+    collapse_to_proteoforms,
     gene_to_proteoform,
+    gene_to_proteoform_id,
     proteoform_for_gene,
     proteoform_group_map,
     proteoform_groups,
@@ -193,6 +195,7 @@ __all__ = [
     "cohort_mean_expression",
     "cohort_registry",
     "cohort_registry_df",
+    "collapse_to_proteoforms",
     "cta_dataframe",
     "cta_patient_fractions",
     "expression_source",
@@ -205,6 +208,7 @@ __all__ = [
     "gene_protein_tissues",
     "gene_tissue_ntpm",
     "gene_to_proteoform",
+    "gene_to_proteoform_id",
     "greedy_coverage",
     "hpa_normal_tissue",
     # HPA normal-tissue reference data

--- a/cancerdata/_build.py
+++ b/cancerdata/_build.py
@@ -25,7 +25,7 @@ from collections.abc import Iterable, Mapping
 import numpy as np
 import pandas as pd
 
-_ID_COLS = ("Ensembl_Gene_ID", "Symbol")
+_ID_COLS = ("Ensembl_Gene_ID", "Symbol", "proteoform_id")
 
 #: Per-gene cohort percentile breakpoints — dense in the actionable upper tail so
 #: a consumer can place a sample's gene as a percentile rank within the cohort
@@ -92,8 +92,19 @@ def sum_proteoform_tpm(
     so a proteoform-summed artifact and a per-gene one share the same arithmetic.
 
     ``df`` has ``Ensembl_Gene_ID``, ``Symbol`` and one column per sample. Gene IDs
-    are matched version-insensitively. The grouped row carries the group label as
-    both ``Ensembl_Gene_ID`` and ``Symbol``; ungrouped rows keep their originals.
+    are matched version-insensitively. The output carries a stable proteoform
+    identity **without overloading the Ensembl ID column** (so it stays a real,
+    joinable ENSG):
+
+      - ``Ensembl_Gene_ID`` — the group's **canonical member** ENSG (the
+        lexicographically-smallest member id) for a collapsed group; the gene's own
+        ENSG for a singleton. Always a genuine Ensembl id.
+      - ``proteoform_id`` — the equivalence-class identity: the slash-joined label
+        for a group (``CTAG1A/CTAG1B``), the gene's own ``Symbol`` for a singleton.
+        Total over every row — the join key for proteoform-level analyses.
+      - ``Symbol`` — the slash-label for a group / the gene's symbol for a singleton
+        (display).
+
     First-appearance row order is preserved.
 
     Summation uses ``min_count=1`` so a missing measurement stays missing: a cell
@@ -110,23 +121,37 @@ def sum_proteoform_tpm(
     cols = list(sample_cols) if sample_cols is not None else sample_columns(df)
     work = df.copy()
     unversioned = work["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
-    gene_to_label = {
-        str(gene).split(".")[0]: str(label)
-        for label, members in group_map.items()
-        for gene in members
-    }
+    gene_to_label: dict[str, str] = {}
+    gene_to_canonical: dict[str, str] = {}
+    for raw_label, members in group_map.items():
+        member_ids = [str(g).split(".")[0] for g in members]
+        canonical = min(member_ids)  # stable, collision-free representative ENSG
+        for mid in member_ids:
+            gene_to_label[mid] = str(raw_label)
+            gene_to_canonical[mid] = canonical
+
     label = unversioned.map(gene_to_label)
     in_group = label.notna()
+    canonical = unversioned.map(gene_to_canonical)
 
     work["_key"] = label.where(in_group, unversioned)
-    work["_out_id"] = label.where(in_group, work["Ensembl_Gene_ID"].astype(str))
+    # ENSG stays a real Ensembl id (canonical member / own id), never the label.
+    work["_out_id"] = canonical.where(in_group, work["Ensembl_Gene_ID"].astype(str))
     work["_out_symbol"] = label.where(in_group, work["Symbol"].astype(str))
+    # proteoform_id is total: the class label for groups, the symbol for singletons.
+    work["_out_pfid"] = label.where(in_group, work["Symbol"].astype(str))
 
     grouped = work.groupby("_key", sort=False)
-    ids = grouped[["_out_id", "_out_symbol"]].first()
+    ids = grouped[["_out_id", "_out_symbol", "_out_pfid"]].first()
     sums = grouped[cols].sum(min_count=1)
-    agg = ids.join(sums).rename(columns={"_out_id": "Ensembl_Gene_ID", "_out_symbol": "Symbol"})
-    return agg.reset_index(drop=True)[["Ensembl_Gene_ID", "Symbol", *cols]]
+    agg = ids.join(sums).rename(
+        columns={
+            "_out_id": "Ensembl_Gene_ID",
+            "_out_symbol": "Symbol",
+            "_out_pfid": "proteoform_id",
+        }
+    )
+    return agg.reset_index(drop=True)[["Ensembl_Gene_ID", "Symbol", "proteoform_id", *cols]]
 
 
 def within_sample_top_fractions(
@@ -161,6 +186,8 @@ def within_sample_top_fractions(
             "Symbol": df["Symbol"].astype(str).to_numpy(),
         }
     )
+    if "proteoform_id" in df.columns:  # carry the proteoform identity through (collapsed input)
+        out["proteoform_id"] = df["proteoform_id"].astype(str).to_numpy()
     for t in thresholds:
         pct = round((1.0 - t) * 100)
         out[f"frac_samples_top{pct}pct"] = (ranks >= t).mean(axis=1).to_numpy()
@@ -211,6 +238,8 @@ def cohort_percentile_vectors(
             "Symbol": df["Symbol"].astype(str).to_numpy(),
         }
     )
+    if "proteoform_id" in df.columns:  # carry the proteoform identity through (collapsed input)
+        out["proteoform_id"] = df["proteoform_id"].astype(str).to_numpy()
     for i, bp in enumerate(bps):
         out[f"p{bp}"] = q[i].astype("float16")
     return out

--- a/cancerdata/coverage.py
+++ b/cancerdata/coverage.py
@@ -65,13 +65,12 @@ def _hit_matrix(cancer_type, *, threshold_tpm: float, gene_ids, proteoform: bool
     unversioned = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
     panel = _panel_ids(gene_ids)
     sub = df[unversioned.isin(panel)].reset_index(drop=True)
-    samples = [c for c in df.columns if c not in _BASE]
     if proteoform and len(sub):
-        from ._build import sum_proteoform_tpm
-        from .proteoforms import proteoform_group_map
+        from .proteoforms import collapse_to_proteoforms
 
-        sub = sum_proteoform_tpm(sub, proteoform_group_map(), samples).reset_index(drop=True)
-        samples = [c for c in sub.columns if c not in _BASE]
+        sub = collapse_to_proteoforms(sub).reset_index(drop=True)
+    id_cols = [c for c in ("Ensembl_Gene_ID", "Symbol", "proteoform_id") if c in sub.columns]
+    samples = [c for c in sub.columns if c not in id_cols]
     hits = sub[samples].to_numpy(dtype=float) >= float(threshold_tpm)
     return sub, samples, hits
 
@@ -84,15 +83,18 @@ def cta_patient_fractions(
     proteoform: bool = True,
 ) -> pd.DataFrame:
     """Per antigen, the fraction of a cohort's patients expressing it above
-    ``threshold_tpm`` (clean TPM). Returns ``Ensembl_Gene_ID``, ``Symbol``,
-    ``fraction_expressing``, ``n_patients_expressing``, ``n_patients`` — sorted by
-    prevalence. The default gene panel is the expressed CTA set; identical-protein
-    paralogs are summed to one antigen (``proteoform=True``)."""
+    ``threshold_tpm`` (clean TPM). Returns ``Ensembl_Gene_ID`` (a real ENSG — the
+    canonical member for a collapsed proteoform), ``Symbol``, ``proteoform_id`` (the
+    antigen identity, present when ``proteoform=True``), ``fraction_expressing``,
+    ``n_patients_expressing``, ``n_patients`` — sorted by prevalence. The default
+    gene panel is the expressed CTA set; identical-protein paralogs are summed to
+    one antigen (``proteoform=True``)."""
     sub, samples, hits = _hit_matrix(
         cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
     )
     n = len(samples)
-    out = sub[_BASE].copy()
+    id_cols = [c for c in ("Ensembl_Gene_ID", "Symbol", "proteoform_id") if c in sub.columns]
+    out = sub[id_cols].copy()
     counts = hits.sum(axis=1)
     out["n_patients_expressing"] = counts
     out["fraction_expressing"] = counts / n if n else 0.0
@@ -175,17 +177,18 @@ def greedy_coverage(
         covered |= hits[best_g]
         remaining.discard(best_g)
         cum = int(covered.sum())
-        rows.append(
-            {
-                "rank": len(rows) + 1,
-                "Ensembl_Gene_ID": str(sub.at[best_g, "Ensembl_Gene_ID"]),
-                "Symbol": str(sub.at[best_g, "Symbol"]),
-                "marginal_patients": best_new,
-                "marginal_fraction": best_new / n,
-                "cumulative_patients": cum,
-                "cumulative_fraction": cum / n,
-            }
-        )
+        row = {
+            "rank": len(rows) + 1,
+            "Ensembl_Gene_ID": str(sub.at[best_g, "Ensembl_Gene_ID"]),
+            "Symbol": str(sub.at[best_g, "Symbol"]),
+            "marginal_patients": best_new,
+            "marginal_fraction": best_new / n,
+            "cumulative_patients": cum,
+            "cumulative_fraction": cum / n,
+        }
+        if "proteoform_id" in sub.columns:
+            row["proteoform_id"] = str(sub.at[best_g, "proteoform_id"])
+        rows.append(row)
     return pd.DataFrame(rows)
 
 

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -391,11 +391,10 @@ def proteoform_representative_samples(
     :func:`cancerdata._build.sum_proteoform_tpm` core can run inside the offline
     percentile/within-sample generators to ship proteoform-summed artifacts.
     """
-    from ._build import sum_proteoform_tpm
-    from .proteoforms import proteoform_group_map
+    from .proteoforms import collapse_to_proteoforms
 
     wide = representative_cohort_samples(cancer_types, k=k, normalize="tpm_clean", format="wide")
     sample_cols = [c for c in wide.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
     if wide.empty or not sample_cols:
         return wide
-    return sum_proteoform_tpm(wide, proteoform_group_map(), sample_cols)
+    return collapse_to_proteoforms(wide, sample_cols=sample_cols)

--- a/cancerdata/proteoforms.py
+++ b/cancerdata/proteoforms.py
@@ -141,6 +141,47 @@ def proteoform_for_gene(gene: str) -> str | None:
 
 
 def gene_to_proteoform() -> dict[str, str]:
-    """``{member gene ID: proteoform label}`` (Ensembl IDs only)."""
+    """``{member gene ID: proteoform label}`` (Ensembl IDs only) — multi-member
+    groups only. For a **total** map (every gene → its class, singletons included)
+    use :func:`gene_to_proteoform_id`."""
     df = _proteoform_frame("cta")
     return dict(zip(df[_GENE_ID_COLUMN].astype(str), df[_LABEL_COLUMN].astype(str)))
+
+
+def gene_to_proteoform_id(genes, *, symbols=None, scope: str = "cta") -> dict[str, str]:
+    """Total ``{gene → proteoform_id}`` over the given genes: every gene maps to
+    exactly one proteoform equivalence class.
+
+    A gene in a multi-member group maps to the group's ``proteoform_id`` (the
+    slash-joined label); a gene in no group is its **own** singleton class, mapping
+    to its symbol (if ``symbols`` is given, aligned to ``genes``) else its
+    unversioned Ensembl id. This is the join key for proteoform-level analyses —
+    unlike :func:`gene_to_proteoform`, it is defined for **every** gene, so callers
+    never need an ad-hoc "is it grouped?" branch. ``genes``/``symbols`` are parallel
+    iterables of Ensembl ids / symbols."""
+    pf = _proteoform_frame(scope)
+    member_map = dict(zip(pf[_GENE_ID_COLUMN].astype(str), pf[_LABEL_COLUMN].astype(str)))
+    genes = [str(g).split(".")[0] for g in genes]
+    syms = list(symbols) if symbols is not None else [None] * len(genes)
+    out: dict[str, str] = {}
+    for gid, sym in zip(genes, syms):
+        out[gid] = member_map.get(gid) or (str(sym) if sym is not None else gid)
+    return out
+
+
+def collapse_to_proteoforms(
+    df: pd.DataFrame, *, scope: str = "cta", sample_cols=None
+) -> pd.DataFrame:
+    """Collapse a genes×samples expression frame to proteoform level — the single
+    reusable entry point for proteoform summation.
+
+    Identical-protein members in ``scope`` are summed per sample into one antigen
+    row (see :func:`cancerdata._build.sum_proteoform_tpm`). The output keeps
+    ``Ensembl_Gene_ID`` as a real **canonical-member** ENSG (never the label) and
+    adds a total ``proteoform_id`` column (the class identity). Use this instead of
+    calling ``sum_proteoform_tpm`` + ``proteoform_group_map`` directly, so coverage,
+    the medoid/within-sample generators, and any future consumer share one
+    collapse + one identity scheme."""
+    from ._build import sum_proteoform_tpm
+
+    return sum_proteoform_tpm(df, proteoform_group_map(scope=scope), sample_cols)

--- a/scripts/generate_within_sample_top5.py
+++ b/scripts/generate_within_sample_top5.py
@@ -60,7 +60,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from cancerdata._build import sample_columns, sum_proteoform_tpm, within_sample_top_fractions
+from cancerdata._build import sample_columns, within_sample_top_fractions
 
 _DATA_DIR = Path(__file__).resolve().parents[1] / "cancerdata" / "data"
 OUT_DIR = _DATA_DIR / "cancer-reference-expression-within-sample-top5"
@@ -90,11 +90,6 @@ def build(
     """
     if out_dir is None:
         out_dir = PROTEOFORM_OUT_DIR if proteoform else OUT_DIR
-    group_map = None
-    if proteoform:
-        from cancerdata.proteoforms import proteoform_group_map
-
-        group_map = proteoform_group_map()
     out_dir.mkdir(parents=True, exist_ok=True)
     shards = sorted(input_dir.glob("*.parquet"))
     if not shards:
@@ -109,10 +104,12 @@ def build(
         if not cols:
             print(f"  {code}: no sample columns, skipped", flush=True)
             continue
-        if group_map is not None:
-            # Sum identical-protein members per sample first, then rank within
-            # the collapsed gene/proteoform axis.
-            df = sum_proteoform_tpm(df, group_map, cols)
+        if proteoform:
+            # Sum identical-protein members per sample first, then rank within the
+            # collapsed antigen axis (one reusable collapse + proteoform_id identity).
+            from cancerdata.proteoforms import collapse_to_proteoforms
+
+            df = collapse_to_proteoforms(df, sample_cols=cols)
             cols = sample_columns(df)
         out = within_sample_top_fractions(df, cols)
         out.to_parquet(out_dir / f"{code}.parquet", index=False, compression="zstd")

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -98,7 +98,9 @@ def test_proteoform_paralogs_are_summed(monkeypatch):
     # the source symbol it re-resolves on each call.
     import cancerdata.proteoforms as pmod
 
-    monkeypatch.setattr(pmod, "proteoform_group_map", lambda: {"A1/A2": ["ENSG_A1", "ENSG_A2"]})
+    monkeypatch.setattr(
+        pmod, "proteoform_group_map", lambda *, scope="cta": {"A1/A2": ["ENSG_A1", "ENSG_A2"]}
+    )
 
     pf_sum = coverage.cta_patient_fractions("X", threshold_tpm=10, proteoform=True)
     # A1/A2 collapsed to one row, expressed in p0 (summed 12 > 10) -> fraction 0.5

--- a/tests/test_proteoforms.py
+++ b/tests/test_proteoforms.py
@@ -85,13 +85,15 @@ def test_sum_proteoform_tpm_collapses_members_and_passes_through():
         }
     )
     out = sum_proteoform_tpm(df, {"SSX4/SSX4B": ("ENSG00000268009", "ENSG00000269791")})
-    by_symbol = out.set_index("Symbol")
-    assert by_symbol.loc["SSX4/SSX4B", "s1"] == 8.0
-    assert by_symbol.loc["SSX4/SSX4B", "s2"] == 1.0
-    assert by_symbol.loc["SSX4/SSX4B", "Ensembl_Gene_ID"] == "SSX4/SSX4B"
-    # PRAME passes through unchanged, keeping its original id.
-    assert by_symbol.loc["PRAME", "s1"] == 100.0
-    assert by_symbol.loc["PRAME", "Ensembl_Gene_ID"] == "ENSG00000185686"
+    by_pf = out.set_index("proteoform_id")
+    assert by_pf.loc["SSX4/SSX4B", "s1"] == 8.0
+    assert by_pf.loc["SSX4/SSX4B", "s2"] == 1.0
+    # ENSG stays a REAL Ensembl id (the canonical = smallest member), not the label.
+    assert by_pf.loc["SSX4/SSX4B", "Ensembl_Gene_ID"] == "ENSG00000268009"
+    assert by_pf.loc["SSX4/SSX4B", "Symbol"] == "SSX4/SSX4B"
+    # PRAME passes through: singleton class -> proteoform_id is its symbol, ENSG kept.
+    assert by_pf.loc["PRAME", "s1"] == 100.0
+    assert by_pf.loc["PRAME", "Ensembl_Gene_ID"] == "ENSG00000185686"
     # One collapsed row + one passthrough row.
     assert len(out) == 2
 
@@ -175,3 +177,44 @@ def test_proteoform_representative_samples_sums_members(representatives_cache):
     assert by_symbol.loc["SSX4/SSX4B", "rep_0"] == 10.0
     assert by_symbol.loc["SSX4/SSX4B", "rep_1"] == 4.0
     assert by_symbol.loc["PRAME", "rep_0"] == 50.0
+
+
+def test_gene_to_proteoform_id_is_total():
+    # Every gene maps to a class: grouped -> label, singleton -> symbol (or ENSG).
+    from cancerdata.proteoforms import gene_to_proteoform_id
+
+    genes = ["ENSG00000268009", "ENSG00000269791", "ENSG00000185686", "ENSG_X"]
+    symbols = ["SSX4", "SSX4B", "PRAME", "MYGENE"]
+    # patch the registry frame to a known group so the test is hermetic-ish:
+    m = gene_to_proteoform_id(genes, symbols=symbols)
+    assert set(m) == set(genes)  # total
+    # PRAME is a singleton (not in a multi-member CTA group) -> its own symbol
+    assert m["ENSG00000185686"] == "PRAME"
+    # a gene absent from the registry with a symbol -> the symbol
+    assert m["ENSG_X"] == "MYGENE"
+    # a gene with no symbol given -> falls back to its ensembl id
+    m2 = gene_to_proteoform_id(["ENSG_Y"])
+    assert m2["ENSG_Y"] == "ENSG_Y"
+
+
+def test_collapse_to_proteoforms_keeps_ensembl_id_real():
+    # The reusable collapse entry point: ENSG column stays a real Ensembl id, the
+    # antigen identity is in proteoform_id.
+    from cancerdata.proteoforms import collapse_to_proteoforms, proteoform_group_map
+
+    gmap = proteoform_group_map()
+    # pick a real CTA group to exercise the collapse
+    label, members = next(iter(gmap.items()))
+    df = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": list(members),
+            "Symbol": [f"m{i}" for i in range(len(members))],
+            "s1": [10.0] * len(members),
+        }
+    )
+    out = collapse_to_proteoforms(df, sample_cols=["s1"])
+    assert "proteoform_id" in out.columns
+    assert len(out) == 1
+    assert out.iloc[0]["proteoform_id"] == label
+    assert out.iloc[0]["Ensembl_Gene_ID"] == min(members)  # canonical member
+    assert out.iloc[0]["s1"] == 10.0 * len(members)  # summed


### PR DESCRIPTION
Addresses the architectural point you raised: proteoform summation collapses an identical-protein equivalence class (CTAG1A+CTAG1B = NY-ESO-1, XAGE1A/XAGE1B, …) to one antigen, which had changed the join key from a real ENSG to a **slash-label overloaded into `Ensembl_Gene_ID`**. That's a latent break for any consumer joining on ENSG (coverage ↔ heatmap ↔ percentiles), and it was handled ad-hoc per-function. Fixed **generally for all CTA proteoform equivalence classes**.

**Design** (mirrors pirlygenes' canonical-member-ENSG model for joinability; keeps tsarina's slash-label contract, since cancerdata is upstream):

`_build.sum_proteoform_tpm` collapsed row now carries:
- **`Ensembl_Gene_ID`** = the group's **canonical member** ENSG (lexicographically-smallest member id) / the gene's own ENSG for singletons → **always a real, joinable Ensembl id** (no overload).
- **`proteoform_id`** = the equivalence-class identity (slash-label for groups, the symbol for singletons) → **total** over every row, the proteoform-level join key.
- **`Symbol`** = the slash-label / gene symbol (display).

Plus the general primitives so nothing is ad-hoc:
- **`gene_to_proteoform_id(genes, symbols=)`** — the **total** gene→class map (singletons included), so callers never branch on "is it grouped?".
- **`collapse_to_proteoforms(df, scope=)`** — one reusable collapse entry point; coverage's `_hit_matrix`, `proteoform_representative_samples`, and the within-sample generator all route through it (instead of each re-importing `sum_proteoform_tpm` + the group map).
- `cohort_percentile_vectors` / `within_sample_top_fractions` carry `proteoform_id` through; coverage surfaces it in `cta_patient_fractions` / `greedy_coverage`.

**Validated on real LUAD:** `XAGE1A/XAGE1B` collapses to `Ensembl_Gene_ID=ENSG00000204379` (the real canonical id) + `proteoform_id=XAGE1A/XAGE1B`. The total map covers every CTA (PRAME→`PRAME`, XAGE1A→`XAGE1A/XAGE1B`). Tests updated to the new convention + new tests for the total map and `collapse_to_proteoforms`. Full suite 300 passed.