### PR TITLE
Expression engine: gene-QC classifier (#72 PR3)

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -99,6 +99,7 @@ from .fusions import (
     fusion_partners,
     protein_family,
 )
+from .gene_qc import GeneQcClass, classify_gene_qc, is_rescue_feature
 from .hpa import (
     gene_cell_type_ntpm,
     gene_protein_tissues,
@@ -148,6 +149,7 @@ __all__ = [
     "CTA_unfiltered_gene_names",
     # expression sources + per-sample curation
     "ExpressionSource",
+    "GeneQcClass",
     "__version__",
     # expression (read accessors over the downloadable bundle)
     "addressable_fraction",
@@ -186,6 +188,7 @@ __all__ = [
     "cancer_types_in_family",
     "cancer_types_with_fusion",
     "canonical_cancer_code",
+    "classify_gene_qc",
     "cohort_aggregate_members",
     # cohort vocabulary
     "cohort_aggregates",
@@ -215,6 +218,7 @@ __all__ = [
     "hpa_rna_consensus",
     "hpa_single_cell",
     "is_mixture_cohort",
+    "is_rescue_feature",
     "known_cohort_ids",
     "mixture_cohort_codes",
     "per_sample_expression",

--- a/cancerdata/gene_qc.py
+++ b/cancerdata/gene_qc.py
@@ -1,0 +1,225 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gene QC classification for expression matrices.
+
+Answers *which gene-level features are usable* for downstream rescaling: which
+rows are technical RNA (mitochondrial / rRNA-like / NUMT-like / the polyA-bias
+nuclear-retained lncRNAs) that consume a large, pipeline-variable fraction of TPM
+and distort absolute expression. The companion :func:`cancerdata.normalization`
+helpers consume the classification to censor those rows.
+
+The classifier is ENSG-first (against cancerdata's curated gene-family panels,
+stable across symbol renames) then symbol-regex (the self-contained source of
+truth). Ported from ``pirlygenes.expression.qc`` with the family lookup rebound to
+cancerdata's :mod:`cancerdata.gene_families` panels — pandas/numpy only, no
+pyensembl.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+
+
+@dataclass(frozen=True)
+class GeneQcClass:
+    """A gene's QC classification: a human-readable ``label`` and a coarse
+    ``group`` (the drop-by-default ``group`` drives technical-RNA censoring)."""
+
+    label: str
+    group: str
+
+
+_GENE_NA = {"", "NAN", "NONE", "NULL", "-"}
+
+#: Nuclear-retained, ENE-stabilized lncRNAs that survive degradation
+#: disproportionately and creep up as a fraction of bulk TPM (MALAT1, NEAT1).
+_POLYA_BIAS_LNCRNA_SYMBOLS = frozenset({"MALAT1", "NEAT1"})
+
+#: QC groups that count as "technical RNA" — the drop-by-default set.
+_TECHNICAL_RNA_GROUPS = frozenset(
+    {"mt_dna", "mt_like_pseudogene", "rrna_like", "polyadenylation_bias_lncrna"}
+)
+
+#: cancerdata gene-family name -> (qc_label, qc_group). The family naming is
+#: biological; the QC grouping is the downstream drop-by-default view. (cancerdata
+#: has no immune-receptor panel — the symbol regex covers IG/TR segments.)
+_FAMILY_TO_QC = {
+    "mitochondrial": ("mitochondrial transcript", "mt_dna"),
+    "numt_pseudogene": ("mitochondrial pseudogene / NUMT-like", "mt_like_pseudogene"),
+    "nuclear_retained_lncrna": (
+        "nuclear-retained ENE-stabilized lncRNA",
+        "polyadenylation_bias_lncrna",
+    ),
+    "rrna": ("rRNA / rRNA-pseudogene", "rrna_like"),
+    "ribosomal_protein": ("ribosomal protein", "ribosomal_protein"),
+    "ribosomal_protein_pseudogene": (
+        "ribosomal protein pseudogene",
+        "ribosomal_protein_pseudogene",
+    ),
+    "small_noncoding_rna": ("small noncoding RNA", "small_ncrna"),
+    "histone": ("histone transcript", "histone"),
+    "hemoglobin": ("hemoglobin transcript", "hemoglobin"),
+}
+
+
+@lru_cache(maxsize=1)
+def _ensembl_id_to_family() -> dict[str, str]:
+    """``{unversioned ENSG -> cancerdata gene-family name}`` over the QC families.
+    ENSG-first lookup is stable across HGNC symbol renames / version drift."""
+    from . import gene_families
+
+    out: dict[str, str] = {}
+    for family in _FAMILY_TO_QC:
+        if family in gene_families.gene_families():
+            for gid in gene_families.gene_family_ids(family):
+                out.setdefault(gid, family)
+    return out
+
+
+def _family_to_qc_class(family: str, symbol: str | None = None) -> GeneQcClass:
+    """Map a cancerdata gene-family name to its QC class, refining the label with a
+    symbol-specific sub-classifier when a symbol is given (the QC *group* always
+    comes from the family; refinement only affects the human-readable label)."""
+    label, group = _FAMILY_TO_QC.get(family, ("protein-coding/other", "other"))
+    if symbol:
+        refined = _refine_family_label(family, str(symbol).strip().upper())
+        if refined is not None:
+            label = refined
+    return GeneQcClass(label, group)
+
+
+def _refine_family_label(family: str, upper: str) -> str | None:
+    """A more specific human label for ``(family, symbol)`` if available, else None."""
+    if family == "mitochondrial":
+        if upper in {"MT-RNR1", "MT-RNR2"}:
+            return "mitochondrial rRNA"
+        if re.fullmatch(r"MT-T[A-Z]\d?", upper):
+            return "mitochondrial tRNA"
+        return "mitochondrial transcript"
+    if family == "rrna":
+        if re.fullmatch(r"RNA5SP\d+", upper):
+            return "5S rRNA pseudogene"
+        if re.fullmatch(r"RNA5-8SP\d+", upper):
+            return "5.8S rRNA pseudogene"
+        for stem, label in (
+            ("RNA18S", "18S rRNA-like"),
+            ("RNA28S", "28S rRNA-like"),
+            ("RNA45S", "45S pre-rRNA-like"),
+            ("RNA5S", "5S rRNA-like"),
+        ):
+            if upper.startswith(stem):
+                return label
+    if family == "ribosomal_protein_pseudogene":
+        return "ribosomal protein pseudogene"
+    if family == "small_noncoding_rna":
+        if upper.startswith("SNORD"):
+            return "small nucleolar RNA (C/D box)"
+        if upper.startswith("SNORA"):
+            return "small nucleolar RNA (H/ACA box)"
+        if upper.startswith("RNU"):
+            return "spliceosomal snRNA"
+        if upper.startswith("MIR"):
+            return "microRNA"
+        if "Y_RNA" in upper or upper.startswith("YR"):
+            return "Y RNA"
+        if upper.startswith("VTRNA"):
+            return "vault RNA"
+        if upper.startswith("RN7SK") or upper.startswith("RN7SL"):
+            return "signal recognition particle RNA"
+    return None
+
+
+def classify_gene_qc(symbol: str | None = None, *, ensembl_id: str | None = None) -> GeneQcClass:
+    """Coarse QC class for a gene by symbol and/or Ensembl ID.
+
+    Lookup order: (1) ENSG against cancerdata's curated gene-family panels
+    (stable across symbol renames), (2) the symbol regex below (the source of
+    truth for the family CSVs). Returns a :class:`GeneQcClass` whose ``group`` is
+    one of ``mt_dna``, ``mt_like_pseudogene``, ``rrna_like``, ``ribosomal_protein``,
+    ``ribosomal_protein_pseudogene``, ``small_ncrna``, ``histone``,
+    ``immune_receptor``, ``hemoglobin``, ``polyadenylation_bias_lncrna``, ``other``.
+    """
+    family = None
+    if ensembl_id:
+        family = _ensembl_id_to_family().get(str(ensembl_id).split(".")[0])
+
+    raw = str(symbol or "").strip()
+    upper = raw.upper()
+
+    if family is not None:
+        return _family_to_qc_class(family, symbol=upper or None)
+
+    if upper in _GENE_NA:
+        return GeneQcClass("unlabeled feature", "other")
+
+    if upper in _POLYA_BIAS_LNCRNA_SYMBOLS:
+        return GeneQcClass("nuclear-retained ENE-stabilized lncRNA", "polyadenylation_bias_lncrna")
+
+    if upper in {"MT-RNR1", "MT-RNR2"}:
+        return GeneQcClass("mitochondrial rRNA", "mt_dna")
+    if upper.startswith("MT-"):
+        return GeneQcClass("mitochondrial transcript", "mt_dna")
+    if re.fullmatch(r"MT(RNR[12]|ATP[68]|CO[123]|CYB|ND[1-6]|ND4L)P\d+", upper):
+        return GeneQcClass("mitochondrial pseudogene / NUMT-like", "mt_like_pseudogene")
+
+    if re.fullmatch(r"RNA5SP\d+", upper):
+        return GeneQcClass("5S rRNA pseudogene", "rrna_like")
+    if re.fullmatch(r"RNA5-8SP\d+", upper):
+        return GeneQcClass("5.8S rRNA pseudogene", "rrna_like")
+    if re.fullmatch(r"RNA(18S|28S|45S|5S)(P\d+|\d+|[_-].*)?", upper):
+        label = {
+            "RNA18S": "18S rRNA-like",
+            "RNA28S": "28S rRNA-like",
+            "RNA45S": "45S pre-rRNA-like",
+            "RNA5S": "5S rRNA-like",
+        }
+        prefix = next((p for p in label if upper.startswith(p)), "RNA5S")
+        return GeneQcClass(label[prefix], "rrna_like")
+    if upper.startswith(("RNR", "MTRNR")):
+        return GeneQcClass("rRNA-like", "rrna_like")
+
+    if re.fullmatch(r"RP[SL]\d+[A-Z]?(P\d+|P)$", upper):
+        return GeneQcClass("ribosomal protein pseudogene", "ribosomal_protein_pseudogene")
+    if re.fullmatch(r"RP[SL]\d+[A-Z]?", upper) or upper.startswith("RPLP"):
+        return GeneQcClass("ribosomal protein", "ribosomal_protein")
+
+    if upper.startswith(("SNORD", "SNORA", "RNU", "Y_RNA", "MIR")):
+        return GeneQcClass("small noncoding RNA", "small_ncrna")
+
+    if upper.startswith(
+        ("H1-", "H2AC", "H2BC", "H3C", "H4C", "HIST1H", "HIST2H", "HIST3H", "HIST4H")
+    ):
+        return GeneQcClass("histone transcript", "histone")
+
+    if re.fullmatch(r"HB(A\d?|B|D|E\d?|G\d?|M|Q\d?|Z|ZP\d?|BP\d?)", upper):
+        return GeneQcClass("hemoglobin transcript", "hemoglobin")
+
+    if re.fullmatch(r"(IGH[ADGME]\d*|IG[HKL][CVJ][A-Z0-9-]*|TR[ABDG][CVJ][A-Z0-9-]*)", upper):
+        return GeneQcClass("immune receptor segment", "immune_receptor")
+
+    return GeneQcClass("protein-coding/other", "other")
+
+
+def is_rescue_feature(symbol: str | None = None, *, ensembl_id: str | None = None) -> bool:
+    """True when a feature is technical RNA (removed by mtDNA/rRNA censoring) — i.e.
+    its QC group is in the drop-by-default technical-RNA set."""
+    return classify_gene_qc(symbol, ensembl_id=ensembl_id).group in _TECHNICAL_RNA_GROUPS
+
+
+__all__ = [
+    "GeneQcClass",
+    "classify_gene_qc",
+    "is_rescue_feature",
+]

--- a/tests/test_gene_qc.py
+++ b/tests/test_gene_qc.py
@@ -1,0 +1,69 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from cancerdata import gene_qc as qc
+
+
+def test_symbol_regex_classification():
+    cases = {
+        "MT-CO1": "mt_dna",
+        "MT-RNR1": "mt_dna",
+        "MTCO1P12": "mt_like_pseudogene",
+        "RNA5SP1": "rrna_like",
+        "RPL13": "ribosomal_protein",
+        "RPL13AP5": "ribosomal_protein_pseudogene",
+        "MALAT1": "polyadenylation_bias_lncrna",
+        "NEAT1": "polyadenylation_bias_lncrna",
+        "SNORD3A": "small_ncrna",
+        "H2BC1": "histone",
+        "HBA1": "hemoglobin",
+        "IGHV1-2": "immune_receptor",
+        "IGKC": "immune_receptor",
+        "TRBV2": "immune_receptor",
+        "PRAME": "other",
+        "": "other",
+    }
+    for symbol, group in cases.items():
+        assert qc.classify_gene_qc(symbol).group == group, symbol
+
+
+def test_is_rescue_feature_is_technical_only():
+    # technical RNA -> rescued; ribosomal proteins / real genes -> not.
+    assert qc.is_rescue_feature("MT-CO1")
+    assert qc.is_rescue_feature("MALAT1")
+    assert qc.is_rescue_feature("RNA5SP1")
+    assert not qc.is_rescue_feature("RPL13")  # ribosomal protein is kept, not technical
+    assert not qc.is_rescue_feature("PRAME")
+
+
+def test_ensembl_id_first_lookup():
+    # A real mitochondrial gene id (from cancerdata's panel) classifies via ENSG
+    # even with a mismatched/absent symbol — ENSG-first is rename-stable.
+    from cancerdata import gene_families
+
+    mt_ids = list(gene_families.gene_family_ids("mitochondrial"))
+    assert mt_ids
+    cls = qc.classify_gene_qc(symbol="WRONGSYMBOL", ensembl_id=mt_ids[0])
+    assert cls.group == "mt_dna"
+    assert qc.is_rescue_feature(ensembl_id=mt_ids[0])
+
+
+def test_symbol_path_returns_coarse_labels():
+    # The bare symbol-regex path returns the coarse family label for mt/snoRNA
+    # (refinement of those applies only via the family/ENSG path) — faithful to
+    # pirlygenes. (rRNA refinement IS inline in the symbol regex.)
+    assert qc.classify_gene_qc("MT-TA").label == "mitochondrial transcript"
+    assert qc.classify_gene_qc("SNORD3A").label == "small noncoding RNA"
+    assert qc.classify_gene_qc("RNA18S5").label == "18S rRNA-like"
+
+
+def test_family_path_refines_label():
+    # Through the family classifier (ENSG-first path), the label is refined.
+    assert qc._family_to_qc_class("mitochondrial", "MT-TA").label == "mitochondrial tRNA"
+    assert (
+        qc._family_to_qc_class("small_noncoding_rna", "SNORD3A").label
+        == "small nucleolar RNA (C/D box)"
+    )


### PR DESCRIPTION
#72 PR3. Adds `cancerdata/gene_qc.py` — `classify_gene_qc` / `GeneQcClass` / `is_rescue_feature`, ported from `pirlygenes.expression.qc`.

Classifies a gene into a coarse QC group (`mt_dna`, `mt_like_pseudogene`, `rrna_like`, `ribosomal_protein`, `histone`, `hemoglobin`, `immune_receptor`, `polyadenylation_bias_lncrna`, …) so downstream normalization can censor the technical-RNA rows that consume a large, pipeline-variable fraction of TPM and distort absolute expression.

- **ENSG-first** (against cancerdata's own gene-family panels — stable across HGNC symbol renames) then the **self-contained symbol regex** (the source of truth for the family CSVs).
- **Pandas/numpy + stdlib only** — the pyensembl-backed family lookup in pirlygenes is rebound to `cancerdata.gene_families`, so this stays in the base-layer dependency contract.
- Verified **zero group mismatches vs pirlygenes' classifier across 24 symbols** (MT-*, rRNA/RP pseudogenes, MALAT1/NEAT1, snoRNA/snRNA/miRNA, histone, hemoglobin, IG/TR, real genes).

5 tests (symbol regex, ENSG-first lookup, `is_rescue_feature` = technical-only so ribosomal proteins are kept, family-path label refinement). Full suite 305 passed.

Remaining: PR2b (`normalize_expression`), PR1′ (aggregation `[genome]` extra), PR5 (aPD1 mechanism — pending your `therapy-response-signatures` scope call).