### PR TITLE
Expression engine: pyensembl genome resolution + full aggregate_gene_expression (#72)

### DIFF
--- a/cancerdata/genome.py
+++ b/cancerdata/genome.py
@@ -1,0 +1,253 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ensembl-reference gene/transcript resolution (the ``pyensembl``-backed layer).
+
+This is the genome-reference resolver that the pandas-only ID layer
+(:mod:`cancerdata.gene_ids`, curated CSV aliases) can't do: mapping an *arbitrary*
+Ensembl transcript or gene ID to a gene, and a symbol to its canonical Ensembl gene
+ID, against the installed Ensembl release(s).
+
+It needs ``pyensembl`` and a downloaded human Ensembl release, so it is an **optional
+extra** (``pip install cancerdata[genome]`` + ``pyensembl install --release N
+--species homo_sapiens``) — importing this module without pyensembl raises a clear
+error. The base package stays pandas-only; only this module and the full
+:func:`aggregate_gene_expression` need the genome.
+
+Resolution order for a symbol mirrors pirlygenes: each installed release (newest
+first) by name + curated display aliases, then the bundled NCBI symbol-synonym
+snapshot (:func:`cancerdata.gene_ids.resolve_symbol`). Gene/transcript IDs resolve
+against the newest release first, falling back to older installed releases.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+try:
+    from pyensembl.shell import collect_all_installed_ensembl_releases
+except ImportError as e:  # pragma: no cover - exercised only without the extra
+    raise ImportError(
+        "cancerdata.genome needs pyensembl — install with `pip install cancerdata[genome]` "
+        "and download a release: `pyensembl install --release 111 --species homo_sapiens`"
+    ) from e
+
+from .gene_ids import resolve_symbol
+
+#: Curated literary display aliases used as extra symbol candidates (NY-ESO-1 ↔
+#: CTAG1B, gp100 ↔ PMEL, …). Small, base-layer reference — not a full alias table.
+_DISPLAY_ALIASES = {
+    "CTAG1B": "NY-ESO-1",
+    "PMEL": "gp100",
+    "CD274": "PD-L1",
+    "PDCD1LG2": "PD-L2",
+    "PDCD1": "PD-1",
+    "FOLH1": "PSMA",
+    "TNFRSF17": "BCMA",
+    "TACSTD2": "TROP2",
+    "MS4A1": "CD20",
+    "HAVCR2": "TIM-3",
+    "VSIR": "VISTA",
+}
+_REVERSE_ALIASES: dict[str, list[str]] = {}
+for _k, _v in _DISPLAY_ALIASES.items():
+    _REVERSE_ALIASES.setdefault(_v, []).append(_k)
+
+
+@lru_cache(maxsize=1)
+def genomes():
+    """Installed human Ensembl releases, newest first. Empty if none installed."""
+    return sorted(
+        (
+            g
+            for g in collect_all_installed_ensembl_releases()
+            if g.species.latin_name == "homo_sapiens"
+        ),
+        key=lambda g: g.release,
+        reverse=True,
+    )
+
+
+def strip_version(gene_id: str) -> str:
+    """``ENSG00000251562.5`` → ``ENSG00000251562`` (idempotent on bare ids)."""
+    return str(gene_id).split(".", 1)[0].strip()
+
+
+def gene_for_ensembl_id(genome, gene_id: str):
+    """Resolve an Ensembl gene id to a pyensembl ``Gene`` against one release, or
+    ``None`` (version-tolerant, exception-swallowing)."""
+    try:
+        return genome.gene_by_id(strip_version(gene_id))
+    except Exception:
+        return None
+
+
+@lru_cache(maxsize=1)
+def _newest_indexes():
+    """``(gene_id->name, transcript_id->gene_name)`` from the newest installed
+    release, built once in memory (pyensembl persists its own SQLite cache)."""
+    gid_to_name: dict[str, str] = {}
+    tid_to_gene: dict[str, str] = {}
+    gs = genomes()
+    if gs:
+        g = gs[0]
+        try:
+            for gene in g.genes():
+                gid_to_name[strip_version(gene.id)] = gene.name
+        except Exception:
+            pass
+        try:
+            for t in g.transcripts():
+                tid_to_gene[strip_version(t.id)] = t.gene_name
+        except Exception:
+            pass
+    return gid_to_name, tid_to_gene
+
+
+def find_gene_name_from_ensembl_gene_id(gene_id: str) -> str | None:
+    """Gene symbol for an Ensembl gene id — newest release, then older releases."""
+    gid = strip_version(gene_id)
+    name = _newest_indexes()[0].get(gid)
+    if name:
+        return name
+    for genome in genomes()[1:]:
+        gene = gene_for_ensembl_id(genome, gid)
+        if gene and gene.gene_name:
+            return gene.gene_name
+    return None
+
+
+def find_gene_name_from_ensembl_transcript_id(transcript_id: str) -> str | None:
+    """Gene symbol for an Ensembl transcript id — newest release, then older."""
+    tid = strip_version(transcript_id)
+    name = _newest_indexes()[1].get(tid)
+    if name:
+        return name
+    for genome in genomes()[1:]:
+        try:
+            t = genome.transcript_by_id(tid)
+        except Exception:
+            t = None
+        if t and t.gene_name:
+            return t.gene_name
+    return None
+
+
+def _best_canonical_cds_length(gene) -> int:
+    lengths = [
+        len(t.coding_sequence)
+        for t in gene.transcripts
+        if t.is_protein_coding and t.contains_start_codon
+    ]
+    return max(lengths, default=0)
+
+
+def pick_best_gene(genes):
+    """Choose one gene when a symbol maps to several: prefer protein-coding, then
+    longer canonical CDS, more coding transcripts, then a stable name tie-break."""
+    if not genes:
+        raise ValueError("expected at least one gene")
+    if len(genes) == 1:
+        return genes[0]
+
+    def sort_key(g):
+        coding = 1 if getattr(g, "biotype", "") == "protein_coding" else 0
+        num_coding = sum(t.is_protein_coding for t in g.transcripts)
+        return (coding, _best_canonical_cds_length(g), num_coding, len(g.name), g.name)
+
+    return sorted(genes, key=sort_key, reverse=True)[0]
+
+
+def _name_candidates(name: str) -> set[str]:
+    cands = {name, *(_DISPLAY_ALIASES.get(name, name),), *_REVERSE_ALIASES.get(name, [])}
+    return {c for n in list(cands) for c in (n, n.lower(), n.upper())}
+
+
+def find_gene_and_release_by_name(name: str):
+    """``(genome, Gene)`` for a symbol — each release (newest first) by name +
+    curated aliases, then the NCBI synonym fallback. ``None`` if unresolved."""
+    for genome in genomes():
+        for n in _name_candidates(name):
+            try:
+                genes = genome.genes_by_name(n)
+            except Exception:
+                genes = []
+            if genes:
+                return genome, pick_best_gene(genes)
+    official = resolve_symbol(name)  # bundled NCBI symbol-synonym snapshot
+    if official and official != name:
+        for genome in genomes():
+            try:
+                genes = genome.genes_by_name(official)
+            except Exception:
+                genes = []
+            if genes:
+                return genome, pick_best_gene(genes)
+    return None
+
+
+def find_gene_id_by_name(name: str) -> str | None:
+    """Canonical Ensembl gene id for a symbol, or ``None``."""
+    res = find_gene_and_release_by_name(name)
+    return res[1].id if res else None
+
+
+def canonical_gene_id_and_name(name: str) -> tuple[str | None, str | None]:
+    """``(Ensembl gene id, canonical symbol)`` for a symbol, or ``(None, None)``."""
+    res = find_gene_and_release_by_name(name)
+    return (res[1].id, res[1].name) if res else (None, None)
+
+
+def canonical_gene_ids_and_names(names):
+    """Batch :func:`canonical_gene_id_and_name` → ``([ids], [names])``."""
+    ids, syms = [], []
+    for name in names:
+        gid, sym = canonical_gene_id_and_name(name)
+        ids.append(gid)
+        syms.append(sym)
+    return ids, syms
+
+
+def aggregate_gene_expression(df, tx_to_gene_name=None, **kwargs):
+    """Full transcript→gene aggregation with Ensembl-reference resolution.
+
+    Like :func:`cancerdata.expression_engine.aggregate_transcripts_to_genes`, but
+    resolves transcripts NOT in ``tx_to_gene_name`` against the installed Ensembl
+    release(s) (via :func:`find_gene_name_from_ensembl_transcript_id`) instead of
+    bucketing them as ``unresolved`` — the faithful drop-in for pirlygenes'
+    ``aggregate_gene_expression``. Adds ``gene_id`` (canonical Ensembl id) per gene.
+    Requires the genome extra; pass extra ``aggregate_transcripts_to_genes`` kwargs
+    through (column candidates, etc.)."""
+    from .expression_engine import aggregate_transcripts_to_genes, expanded_tx_map, find_column
+
+    tx_col = find_column(
+        df,
+        kwargs.get(
+            "transcript_id_column_candidates", ("transcript", "transcript_id", "target_id", "name")
+        ),
+        "transcript ID",
+    )
+    base_map = dict(tx_to_gene_name) if tx_to_gene_name is not None else {}
+    expanded = expanded_tx_map(base_map)
+    # Resolve the transcripts the base map doesn't cover, via the genome.
+    tx0 = df[tx_col].astype(str).str.split(".", n=1).str[0]
+    resolved = dict(base_map)
+    for tx in tx0[~tx0.isin(expanded)].unique():
+        name = find_gene_name_from_ensembl_transcript_id(tx)
+        if name:
+            resolved[tx] = name
+    agg = aggregate_transcripts_to_genes(df, resolved, **kwargs)
+    # Attach canonical Ensembl gene ids for the resolved genes.
+    real = agg["gene"] != "unresolved"
+    id_map = {g: find_gene_id_by_name(g) for g in agg.loc[real, "gene"].unique()}
+    agg["gene_id"] = agg["gene"].map(lambda g: id_map.get(g))
+    return agg

--- a/cancerdata/genome.py
+++ b/cancerdata/genome.py
@@ -151,9 +151,23 @@ def _best_canonical_cds_length(gene) -> int:
     return max(lengths, default=0)
 
 
+def _best_transcript_support(gene) -> int:
+    """Quality of the gene's best transcript as a sortable score (higher better):
+    Ensembl TSL is 1 (best)..5 (worst), inverted to -min(TSL); 0 if no TSL."""
+    levels = []
+    for t in gene.transcripts:
+        try:
+            levels.append(int(getattr(t, "support_level", None)))
+        except (TypeError, ValueError):
+            continue
+    return -min(levels) if levels else 0
+
+
 def pick_best_gene(genes):
-    """Choose one gene when a symbol maps to several: prefer protein-coding, then
-    longer canonical CDS, more coding transcripts, then a stable name tie-break."""
+    """Choose one gene when a symbol maps to several (pirlygenes order): prefer
+    protein-coding, then higher-quality best transcript (lowest TSL), then longer
+    canonical CDS, more coding transcripts, then a stable name tie-break. A symbol
+    resolves to ONE Ensembl gene id — the only key used for joins downstream."""
     if not genes:
         raise ValueError("expected at least one gene")
     if len(genes) == 1:
@@ -162,7 +176,15 @@ def pick_best_gene(genes):
     def sort_key(g):
         coding = 1 if getattr(g, "biotype", "") == "protein_coding" else 0
         num_coding = sum(t.is_protein_coding for t in g.transcripts)
-        return (coding, _best_canonical_cds_length(g), num_coding, len(g.name), g.name)
+        return (
+            coding,
+            _best_transcript_support(g),
+            _best_canonical_cds_length(g),
+            num_coding,
+            -g.name.count("."),
+            len(g.name),
+            g.name,
+        )
 
     return sorted(genes, key=sort_key, reverse=True)[0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
 plots = [
     "matplotlib",
 ]
+genome = [
+    "pyensembl",
+]
 dev = [
     "pytest",
     "pytest-cov",

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -1,0 +1,55 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import importlib.util
+
+import pandas as pd
+import pytest
+
+# Gated on the optional [genome] extra + an installed human Ensembl release.
+_HAS_PYENSEMBL = importlib.util.find_spec("pyensembl") is not None
+if _HAS_PYENSEMBL:
+    from cancerdata import genome as gx
+
+    _HAS_RELEASE = bool(gx.genomes())
+else:
+    _HAS_RELEASE = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_RELEASE, reason="pyensembl + a human Ensembl release not installed"
+)
+
+
+def test_symbol_to_canonical_id():
+    gid, sym = gx.canonical_gene_id_and_name("TP53")
+    assert gid == "ENSG00000141510"
+    assert sym == "TP53"
+
+
+def test_alias_resolution():
+    # NY-ESO-1 is a curated display alias for CTAG1B.
+    assert gx.find_gene_id_by_name("NY-ESO-1") == gx.find_gene_id_by_name("CTAG1B")
+
+
+def test_transcript_id_to_gene_name():
+    assert gx.find_gene_name_from_ensembl_transcript_id("ENST00000269305") == "TP53"
+    assert gx.find_gene_name_from_ensembl_transcript_id("ENST_FAKE") is None
+
+
+def test_full_aggregate_resolves_and_assigns_ids():
+    df = pd.DataFrame(
+        {
+            "transcript_id": ["ENST00000269305", "ENST00000288602", "ENST_FAKE"],
+            "tpm": [40.0, 60.0, 5.0],
+        }
+    )
+    out = gx.aggregate_gene_expression(df)
+    by = dict(zip(out["gene"], out["TPM"]))
+    assert by["TP53"] == 40.0 and by["BRAF"] == 60.0
+    assert by["unresolved"] == 5.0  # unknown transcript bucketed, not dropped
+    ids = dict(zip(out["gene"], out["gene_id"]))
+    assert ids["TP53"] == "ENSG00000141510"
+    assert out.attrs["aggregation_stats"]["n_genes"] == 2


### PR DESCRIPTION
With pyensembl now an allowed dependency, this adds `cancerdata/genome.py` — the **Ensembl-reference resolver** the pandas-only `gene_ids` layer can't do: map an *arbitrary* transcript/gene ID to a gene, and a symbol to its canonical Ensembl gene ID, against the installed release(s). It upgrades PR1′ from "pandas-only grouping (unknowns bucketed)" to the **faithful full** `aggregate_gene_expression`.

Ported from `pirlygenes.gene_ids` (resolution + `pick_best_gene` + NCBI-synonym + display-alias fallback), simplified to **in-memory indexes** (pyensembl persists its own SQLite cache, so the disk-index-cache layer is dropped).

- **`genome.aggregate_gene_expression`** — resolves transcripts not in the supplied map via the genome, assigns a canonical `gene_id` per gene → the drop-in for pirlygenes' function.
- `genome.{canonical_gene_id_and_name, canonical_gene_ids_and_names, find_gene_id_by_name, find_gene_name_from_ensembl_gene_id, find_gene_name_from_ensembl_transcript_id, find_gene_and_release_by_name, pick_best_gene, genomes}`.

**Optional `[genome]` extra** (`pip install cancerdata[genome]` + `pyensembl install`), exactly like `[plots]` for matplotlib: `import cancerdata` still works without pyensembl (verified) — only `cancerdata.genome` needs it, raising a clear install hint otherwise. The base dependency contract is unchanged; the genome layer is opt-in.

Validated on the installed release: `TP53→ENSG00000141510`, `ENST00000269305→TP53`, `ENST00000288602→BRAF`, `NY-ESO-1` alias→`CTAG1B`, unknown transcript bucketed. 4 tests gated on a release being installed. Full suite 317 passed.

This closes the last trufflepig code-dependency gap — `aggregate_gene_expression` + the gene/transcript resolution are now cancerdata-native (in the genome extra).