### PR TITLE
Curated aPD1 response signatures + mechanism plot (#72 PR5)

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -133,6 +133,13 @@ from .proteoforms import (
     proteoform_groups,
     proteoform_symbol_map,
 )
+from .response_signatures import (
+    response_signature_direction,
+    response_signature_genes,
+    response_signature_names,
+    response_signatures_df,
+    signature_score,
+)
 from .samples import (
     sample_counts_by_cancer_code,
     sample_manifest,
@@ -248,11 +255,16 @@ __all__ = [
     "renormalize_to_million",
     "representative_cohort_samples",
     "resolve_cancer_type",
+    "response_signature_direction",
+    "response_signature_genes",
+    "response_signature_names",
+    "response_signatures_df",
     "sample_counts_by_cancer_code",
     "sample_manifest",
     "samples_for_cancer_code",
     "samples_for_cohort",
     "sarcoma_lineage_codes",
+    "signature_score",
     "sources_for_cancer_code",
     "tissue_of_origin",
     "tpm_to_housekeeping_normalized",

--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -255,10 +255,13 @@ def _cmd_plot(args: argparse.Namespace) -> int:
         "cta-addressable-burden": plots.cta_addressable_burden,
         "cta-patient-heatmap": plots.cta_patient_count_heatmap,
         "cta-coverage-curves": plots.cta_coverage_curves,
+        "apd1-response-signature": plots.apd1_response_signature_scatter,
     }
     try:
         if args.which == "incidence-vs-mortality":
             kwargs = {"region": args.region}
+        elif args.which == "apd1-response-signature":
+            kwargs = {"signature": args.signature}
         elif args.which == "cta-expression-heatmap":
             kwargs = {"stat": args.stat}
         elif args.which == "cta-addressable-burden":
@@ -455,10 +458,16 @@ def _build_parser() -> argparse.ArgumentParser:
             "cta-addressable-burden",
             "cta-patient-heatmap",
             "cta-coverage-curves",
+            "apd1-response-signature",
         ],
         help="Which plot to render",
     )
     p_plot.add_argument("--out", required=True, help="Output PNG path")
+    p_plot.add_argument(
+        "--signature",
+        default="t_cell_inflamed",
+        help="Response signature for apd1-response-signature (e.g. t_cell_inflamed, tgfb_exclusion)",
+    )
     p_plot.add_argument(
         "--region", default="us", choices=["us", "world"], help="Region for incidence-vs-mortality"
     )

--- a/cancerdata/data/cancer-response-signatures.csv
+++ b/cancerdata/data/cancer-response-signatures.csv
@@ -1,0 +1,25 @@
+signature,gene_symbol,direction,description,source
+t_cell_inflamed,IFNG,positive,IFN-gamma / T-cell-inflamed GEP (response-associated),Ayers 2017 PMID:28650338
+t_cell_inflamed,STAT1,positive,IFN-gamma / T-cell-inflamed GEP (response-associated),Ayers 2017 PMID:28650338
+t_cell_inflamed,CXCL9,positive,IFN-gamma / T-cell-inflamed GEP (response-associated),Ayers 2017 PMID:28650338
+t_cell_inflamed,CXCL10,positive,IFN-gamma / T-cell-inflamed GEP (response-associated),Ayers 2017 PMID:28650338
+t_cell_inflamed,CXCL11,positive,IFN-gamma / T-cell-inflamed GEP (response-associated),Ayers 2017 PMID:28650338
+t_cell_inflamed,IDO1,positive,IFN-gamma / T-cell-inflamed GEP (response-associated),Ayers 2017 PMID:28650338
+t_cell_inflamed,HLA-DRA,positive,IFN-gamma / T-cell-inflamed GEP (response-associated),Ayers 2017 PMID:28650338
+t_cell_inflamed,CD8A,positive,IFN-gamma / T-cell-inflamed GEP (response-associated),Ayers 2017 PMID:28650338
+cytotoxic,GZMA,positive,Cytotoxic T/NK effector activity (response-associated),Rooney 2015 PMID:25594174
+cytotoxic,GZMB,positive,Cytotoxic T/NK effector activity (response-associated),Rooney 2015 PMID:25594174
+cytotoxic,PRF1,positive,Cytotoxic T/NK effector activity (response-associated),Rooney 2015 PMID:25594174
+cytotoxic,NKG7,positive,Cytotoxic T/NK effector activity (response-associated),Rooney 2015 PMID:25594174
+cytotoxic,GNLY,positive,Cytotoxic T/NK effector activity (response-associated),Rooney 2015 PMID:25594174
+antigen_presentation,B2M,positive,MHC-I antigen presentation machinery (response-associated),Chowell 2018 PMID:29217585
+antigen_presentation,HLA-A,positive,MHC-I antigen presentation machinery (response-associated),Chowell 2018 PMID:29217585
+antigen_presentation,HLA-B,positive,MHC-I antigen presentation machinery (response-associated),Chowell 2018 PMID:29217585
+antigen_presentation,HLA-C,positive,MHC-I antigen presentation machinery (response-associated),Chowell 2018 PMID:29217585
+antigen_presentation,TAP1,positive,MHC-I antigen presentation machinery (response-associated),Chowell 2018 PMID:29217585
+antigen_presentation,NLRC5,positive,MHC-I antigen presentation machinery (response-associated),Chowell 2018 PMID:29217585
+tgfb_exclusion,TGFB1,negative,TGF-beta / immune-exclusion (resistance-associated),Mariathasan 2018 PMID:29443960
+tgfb_exclusion,TGFBR2,negative,TGF-beta / immune-exclusion (resistance-associated),Mariathasan 2018 PMID:29443960
+tgfb_exclusion,ACTA2,negative,TGF-beta / immune-exclusion (resistance-associated),Mariathasan 2018 PMID:29443960
+tgfb_exclusion,COL1A1,negative,TGF-beta / immune-exclusion (resistance-associated),Mariathasan 2018 PMID:29443960
+tgfb_exclusion,FAP,negative,TGF-beta / immune-exclusion (resistance-associated),Mariathasan 2018 PMID:29443960

--- a/cancerdata/data_manifest.py
+++ b/cancerdata/data_manifest.py
@@ -136,6 +136,10 @@ CANCERDATA_ORIGINATED: dict[str, tuple[str, str]] = {
     "tissue-burden-map": ("ontology", "primary_tissue -> anatomic burden category"),
     "family-burden-map": ("ontology", "registry family -> burden category (fallback)"),
     "cta-ihc-unreliable": ("cta", "CTAs whose HPA IHC is cross-reactive (RNA-only fallback)"),
+    "cancer-response-signatures": (
+        "response",
+        "curated aPD1 response/resistance expression signatures (T-cell-inflamed, TGF-β, …)",
+    ),
 }
 
 #: pirlygenes data that is NOT cancerdata's domain — target selection / therapy /

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -522,6 +522,60 @@ def cta_coverage_curves(
     return _save(fig, save)
 
 
+def apd1_response_signature_scatter(signature="t_cell_inflamed", *, cohorts=None, save=None):
+    """Scatter of a cohort's **aPD1 response-signature score** vs its anti-PD-1 ORR,
+    one point per cancer type — the mechanism view of *why* response varies.
+
+    The signature score is the cohort-mean log clean-TPM of the signature's genes
+    (:func:`cancerdata.response_signatures.signature_score`); ``signature`` is one of
+    :func:`cancerdata.response_signatures.response_signature_names` (e.g.
+    ``"t_cell_inflamed"`` / ``"cytotoxic"`` / ``"antigen_presentation"`` →
+    response-associated, ``"tgfb_exclusion"`` → resistance-associated). Points are
+    cohorts that have BOTH a cached per-sample matrix and a curated aPD1 ORR,
+    coloured by lineage family. Needs the per-sample matrices cached."""
+    from .response_signatures import response_signature_direction, signature_score
+
+    plt = _plt()
+    direction = response_signature_direction(signature)  # validates the name
+    orr = cancer_apd1_response()
+    cohorts = list(cohorts) if cohorts is not None else _cached_per_sample_cohorts()
+    rows = []
+    for code in cohorts:
+        if code not in orr:
+            continue
+        score = signature_score(code, signature)
+        if score == score:  # not NaN
+            rows.append((code, score, float(orr[code])))
+    if not rows:
+        raise ValueError(
+            "no cohort with both a cached per-sample matrix and an aPD1 ORR — fetch "
+            "the matrices (source_matrices.fetch) for aPD1 cohorts first."
+        )
+    codes = [r[0] for r in rows]
+    colors, fam_color = _family_colors(codes)
+    fig, ax = plt.subplots(figsize=(9, 7))
+    for code, x, y in rows:
+        ax.scatter(x, y, color=colors[code], s=70, edgecolor="white", linewidth=0.6, zorder=3)
+        ax.annotate(
+            format_cancer_code_label(code),
+            (x, y),
+            fontsize=6,
+            xytext=(3, 3),
+            textcoords="offset points",
+        )
+    ax.set_xlabel(f"{signature} signature score (cohort-mean log clean TPM)")
+    ax.set_ylabel("Anti-PD-1 monotherapy ORR (%)")
+    ax.set_title(f"aPD1 response vs {signature} ({direction}-associated) — {len(rows)} cancers")
+    ax.grid(True, alpha=0.3)
+    handles = [
+        plt.Line2D([], [], marker="o", linestyle="", color=col, label=fam)
+        for fam, col in sorted(fam_color.items())
+    ]
+    ax.legend(handles=handles, fontsize=6, ncol=2, loc="best", framealpha=0.9)
+    fig.tight_layout()
+    return _save(fig, save)
+
+
 def cta_specific_9mer_counts(*, save=None, **kwargs):
     """**Scaffold** — CTA-specific 9-mer (peptide) counts per cancer type.
 

--- a/cancerdata/response_signatures.py
+++ b/cancerdata/response_signatures.py
@@ -1,0 +1,92 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A small curated set of anti-PD-1 response/resistance expression signatures.
+
+Cancer-type-level reference describing the *biology* of checkpoint response — the
+companion to the aPD1 ORR table cancerdata already owns. Deliberately a **few**
+foundational, well-cited signatures (T-cell-inflamed / IFN-γ, cytotoxic effector,
+MHC-I antigen presentation, TGF-β immune exclusion), not pirlygenes' full
+therapy-signature catalog: cancerdata stays the base layer, not the analysis layer.
+
+``cancer-response-signatures.csv``: ``signature, gene_symbol, direction``
+(``positive`` = response-associated, ``negative`` = resistance-associated),
+``description``, ``source``. :func:`signature_score` scores a cohort by averaging
+its member genes' (log) clean-TPM expression over the cohort's patients.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import pandas as pd
+
+from .load_dataset import get_data
+
+
+@lru_cache(maxsize=1)
+def _frame() -> pd.DataFrame:
+    return get_data("cancer-response-signatures", copy=False)
+
+
+def response_signatures_df() -> pd.DataFrame:
+    """The full curated signature table (one row per signature gene). Copy."""
+    return _frame().copy()
+
+
+def response_signature_names() -> list[str]:
+    """The available signature names (sorted)."""
+    return sorted(_frame()["signature"].astype(str).unique())
+
+
+def response_signature_genes(name: str) -> set[str]:
+    """Member gene symbols of a signature. Raises if ``name`` is unknown."""
+    df = _frame()
+    sub = df[df["signature"].astype(str) == name]
+    if sub.empty:
+        raise ValueError(f"unknown signature {name!r}; one of {response_signature_names()}")
+    return set(sub["gene_symbol"].astype(str))
+
+
+def response_signature_direction(name: str) -> str:
+    """``"positive"`` (response-associated) or ``"negative"`` (resistance) for a
+    signature."""
+    df = _frame()
+    sub = df[df["signature"].astype(str) == name]
+    if sub.empty:
+        raise ValueError(f"unknown signature {name!r}; one of {response_signature_names()}")
+    return str(sub["direction"].iloc[0])
+
+
+def signature_score(cancer_type, name: str, *, statistic: str = "mean") -> float:
+    """Score a cohort for a signature: the average (``statistic``) of its member
+    genes' **log clean-TPM** cohort expression across the cohort's patients.
+
+    Built on :func:`cancerdata.expression.cohort_mean_expression` (so it needs the
+    cohort's per-sample matrix). Genes absent from the cohort are skipped; ``nan`` if
+    none of the signature's genes are present. Higher = more of that program; pair
+    with :func:`response_signature_direction` for the response interpretation."""
+    from .expression import cohort_mean_expression
+
+    genes = response_signature_genes(name)
+    mean = cohort_mean_expression(cancer_type, normalize="tpm_clean_log1p", statistic=statistic)
+    vals = mean.loc[mean["Symbol"].astype(str).isin(genes), "expression"]
+    return float(vals.mean()) if len(vals) else float("nan")
+
+
+__all__ = [
+    "response_signature_direction",
+    "response_signature_genes",
+    "response_signature_names",
+    "response_signatures_df",
+    "signature_score",
+]

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -230,3 +230,29 @@ def test_cta_coverage_curves_empty_raises(monkeypatch):
     monkeypatch.setattr(coverage, "greedy_coverage", lambda *a, **k: pd.DataFrame())
     with pytest.raises(ValueError, match="no coverage curve"):
         plots.cta_coverage_curves(["LUAD"])
+
+
+def test_apd1_response_signature_scatter_renders(tmp_path, monkeypatch):
+    from cancerdata import response_signatures as rs
+
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: ["LUAD", "SKCM", "MM"])
+    monkeypatch.setattr(
+        plots, "cancer_apd1_response", lambda: {"LUAD": 19.0, "SKCM": 42.0, "MM": 3.0}
+    )
+    monkeypatch.setattr(
+        rs, "signature_score", lambda code, sig, **k: {"LUAD": 3.1, "SKCM": 2.9, "MM": 1.0}[code]
+    )
+    out = tmp_path / "sig.png"
+    fig = plots.apd1_response_signature_scatter("t_cell_inflamed", save=str(out))
+    assert out.exists() and fig is not None
+
+
+def test_apd1_response_signature_scatter_no_data(monkeypatch):
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: [])
+    with pytest.raises(ValueError, match="no cohort with both"):
+        plots.apd1_response_signature_scatter("t_cell_inflamed")
+
+
+def test_apd1_response_signature_bad_name():
+    with pytest.raises(ValueError, match="unknown signature"):
+        plots.apd1_response_signature_scatter("not_a_signature")

--- a/tests/test_response_signatures.py
+++ b/tests/test_response_signatures.py
@@ -1,0 +1,48 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import pandas as pd
+import pytest
+
+from cancerdata import response_signatures as rs
+
+
+def test_signature_catalog():
+    names = rs.response_signature_names()
+    assert {"t_cell_inflamed", "cytotoxic", "antigen_presentation", "tgfb_exclusion"} <= set(names)
+    assert "IFNG" in rs.response_signature_genes("t_cell_inflamed")
+    assert rs.response_signature_direction("t_cell_inflamed") == "positive"
+    assert rs.response_signature_direction("tgfb_exclusion") == "negative"
+
+
+def test_unknown_signature_raises():
+    with pytest.raises(ValueError, match="unknown signature"):
+        rs.response_signature_genes("not_a_signature")
+
+
+def test_signature_score(monkeypatch):
+    # Stub cohort_mean_expression so the score is hermetic.
+    import cancerdata.expression as ex
+
+    fixture = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1", "E2", "E3"],
+            "Symbol": ["IFNG", "STAT1", "OTHER"],
+            "expression": [2.0, 4.0, 100.0],
+        }
+    )
+    monkeypatch.setattr(ex, "cohort_mean_expression", lambda *a, **k: fixture)
+    # mean over the signature's genes present (IFNG=2, STAT1=4) -> 3.0; OTHER ignored
+    score = rs.signature_score("X", "t_cell_inflamed")
+    assert score == 3.0
+
+
+def test_signature_score_nan_when_no_genes(monkeypatch):
+    import cancerdata.expression as ex
+
+    empty = pd.DataFrame({"Ensembl_Gene_ID": [], "Symbol": [], "expression": []})
+    monkeypatch.setattr(ex, "cohort_mean_expression", lambda *a, **k: empty)
+    assert rs.signature_score("X", "cytotoxic") != rs.signature_score("X", "cytotoxic")  # NaN


### PR DESCRIPTION
The final #72 item, scoped per your guidance — **curate a few signatures, don't take over all of pirlygenes**.

A *small* curated set of well-cited aPD1 response/resistance expression signatures (not pirlygenes' full `therapy-response-signatures` catalog), as base-layer reference describing the biology behind the aPD1 ORR table cancerdata already owns:

- **`data/cancer-response-signatures.csv`** — 4 foundational signatures (24 genes), each with `direction` (response- vs resistance-associated) + PMID:
  - `t_cell_inflamed` (IFN-γ GEP, Ayers 2017), `cytotoxic` (Rooney 2015), `antigen_presentation` (Chowell 2018) → positive; `tgfb_exclusion` (Mariathasan 2018) → negative. cancerdata-originated (registered in the manifest).
- **`response_signatures.py`** — `response_signatures_df` / `_names` / `_genes` / `_direction` + `signature_score(cohort, name)` (cohort-mean log clean-TPM over the signature's genes, on `cohort_mean_expression`).
- **`plots.apd1_response_signature_scatter`** — signature score vs aPD1 ORR per cancer type (the mechanism view), CLI-wired (`cancerdata plot apd1-response-signature --signature tgfb_exclusion`).

Validated on staged cohorts: SKCM/LUAD `t_cell_inflamed` > MM (immune-inflamed melanoma/lung vs myeloma), as expected.

**Scope honored:** this is the base-layer signature *data* + one mechanism plot. The full aPD1-causal analysis suite (OLS models, exclusion screens, mechanism heatmaps) stays in the analysis layer — not imported. 8 tests. Full suite 324 passed.

This completes #72 — every expression-engine primitive trufflepig needs is cancerdata-native, and the aPD1-mechanism gap is closed with a curated, scoped signature set.