### PR TITLE
Make pyensembl a core dependency (drop the [genome] extra)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,14 @@ cd.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
   `hpa_single_cell`, and per-gene lookups (`gene_tissue_ntpm`,
   `gene_protein_tissues`, `gene_cell_type_ntpm`) over HPA v23, fetched on demand
   (`cancerdata sources fetch`).
+- **Genome reference** — `canonical_gene_id_and_name`, `find_gene_id_by_name`,
+  `find_gene_name_from_ensembl_{gene,transcript}_id`, `aggregate_gene_expression`
+  (pyensembl-backed symbol ↔ Ensembl-ID resolution). pyensembl ships with the
+  package, but resolution needs a downloaded human release once:
+  `pyensembl install --release 111 --species homo_sapiens` (the accessors return
+  `None` until then).
 - **Plots** (`pip install cancerdata[plots]`) — `cancerdata.plots.apd1_vs_tmb`,
-  `apd1_orr_bars`, `incidence_vs_mortality`.
+  `apd1_orr_bars`, `incidence_vs_mortality`, and the CTA/coverage figures.
 
 ## CLI
 

--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -101,6 +101,15 @@ from .fusions import (
     protein_family,
 )
 from .gene_qc import GeneQcClass, classify_gene_qc, is_rescue_feature
+from .genome import (
+    aggregate_gene_expression,
+    canonical_gene_id_and_name,
+    canonical_gene_ids_and_names,
+    find_gene_id_by_name,
+    find_gene_name_from_ensembl_gene_id,
+    find_gene_name_from_ensembl_transcript_id,
+    genomes,
+)
 from .hpa import (
     gene_cell_type_ntpm,
     gene_protein_tissues,
@@ -171,6 +180,7 @@ __all__ = [
     # expression (read accessors over the downloadable bundle)
     "addressable_fraction",
     "addressable_fraction_by_cohort",
+    "aggregate_gene_expression",
     "aggregate_transcripts_to_genes",
     "available_percentile_cohorts",
     "available_representative_cohorts",
@@ -206,6 +216,8 @@ __all__ = [
     "cancer_types_in_family",
     "cancer_types_with_fusion",
     "canonical_cancer_code",
+    "canonical_gene_id_and_name",
+    "canonical_gene_ids_and_names",
     "classify_gene_qc",
     "clean_tpm",
     "cohort_aggregate_members",
@@ -223,6 +235,9 @@ __all__ = [
     "expression_source",
     "expression_sources",
     "family_display_name",
+    "find_gene_id_by_name",
+    "find_gene_name_from_ensembl_gene_id",
+    "find_gene_name_from_ensembl_transcript_id",
     "format_cancer_code_label",
     "fpkm_to_tpm",
     "fusion_partners",
@@ -232,6 +247,7 @@ __all__ = [
     "gene_tissue_ntpm",
     "gene_to_proteoform",
     "gene_to_proteoform_id",
+    "genomes",
     "greedy_coverage",
     "hpa_normal_tissue",
     # HPA normal-tissue reference data

--- a/cancerdata/genome.py
+++ b/cancerdata/genome.py
@@ -12,16 +12,15 @@
 
 """Ensembl-reference gene/transcript resolution (the ``pyensembl``-backed layer).
 
-This is the genome-reference resolver that the pandas-only ID layer
+This is the genome-reference resolver that the curated pandas ID layer
 (:mod:`cancerdata.gene_ids`, curated CSV aliases) can't do: mapping an *arbitrary*
 Ensembl transcript or gene ID to a gene, and a symbol to its canonical Ensembl gene
 ID, against the installed Ensembl release(s).
 
-It needs ``pyensembl`` and a downloaded human Ensembl release, so it is an **optional
-extra** (``pip install cancerdata[genome]`` + ``pyensembl install --release N
---species homo_sapiens``) — importing this module without pyensembl raises a clear
-error. The base package stays pandas-only; only this module and the full
-:func:`aggregate_gene_expression` need the genome.
+``pyensembl`` is a core dependency, but it still needs a **downloaded** human Ensembl
+release at runtime (``pyensembl install --release N --species homo_sapiens``); with no
+release installed, :func:`genomes` is empty and the resolvers return ``None`` rather
+than raising.
 
 Resolution order for a symbol mirrors pirlygenes: each installed release (newest
 first) by name + curated display aliases, then the bundled NCBI symbol-synonym
@@ -33,13 +32,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-try:
-    from pyensembl.shell import collect_all_installed_ensembl_releases
-except ImportError as e:  # pragma: no cover - exercised only without the extra
-    raise ImportError(
-        "cancerdata.genome needs pyensembl — install with `pip install cancerdata[genome]` "
-        "and download a release: `pyensembl install --release 111 --species homo_sapiens`"
-    ) from e
+from pyensembl.shell import collect_all_installed_ensembl_releases
 
 from .gene_ids import resolve_symbol
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,12 @@ dependencies = [
     "numpy",
     "pyarrow",
     "PyYAML",
+    "pyensembl",
 ]
 
 [project.optional-dependencies]
 plots = [
     "matplotlib",
-]
-genome = [
-    "pyensembl",
 ]
 dev = [
     "pytest",

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -4,22 +4,15 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-import importlib.util
-
 import pandas as pd
 import pytest
 
-# Gated on the optional [genome] extra + an installed human Ensembl release.
-_HAS_PYENSEMBL = importlib.util.find_spec("pyensembl") is not None
-if _HAS_PYENSEMBL:
-    from cancerdata import genome as gx
+from cancerdata import genome as gx
 
-    _HAS_RELEASE = bool(gx.genomes())
-else:
-    _HAS_RELEASE = False
-
+# pyensembl is a core dependency, but resolution still needs a downloaded human
+# Ensembl release; skip when none is installed.
 pytestmark = pytest.mark.skipif(
-    not _HAS_RELEASE, reason="pyensembl + a human Ensembl release not installed"
+    not gx.genomes(), reason="no human Ensembl release installed (pyensembl install ...)"
 )
 
 


### PR DESCRIPTION
## What

Per request — no more extras to install: pyensembl moves from the optional
`[genome]` extra into the base dependencies, so the Ensembl-reference resolver
(`cancerdata.genome`) is always importable.

## Changes

- `pyproject.toml`: `pyensembl` → core `dependencies`; remove the `[genome]` extra.
- `genome.py`: drop the `ImportError` guard — plain `from pyensembl.shell import ...`.
- `__init__.py`: export the genome accessors from the package root —
  `canonical_gene_id_and_name`, `canonical_gene_ids_and_names`,
  `find_gene_id_by_name`, `find_gene_name_from_ensembl_gene_id`,
  `find_gene_name_from_ensembl_transcript_id`, `aggregate_gene_expression`,
  `genomes`.
- `test_genome.py`: gate on an installed Ensembl release (still a runtime
  download), not on import availability.
- `README.md`: add a Genome-reference domain bullet noting the one-time
  `pyensembl install --release N --species homo_sapiens`.

## Runtime note

pyensembl needs a **downloaded** human release to resolve anything. With none
installed, `genomes()` is empty and the resolvers return `None` (no raise).

## Tests

324 passed; `cancerdata.find_gene_id_by_name("CTAG1B") -> ENSG00000184033`.