### PR TITLE
Port CTA-coverage / burden figures onto the plot primitives

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -60,6 +60,8 @@ from .coverage import (
     addressable_fraction_by_cohort,
     cta_patient_fractions,
     greedy_coverage,
+    mean_antigens_per_patient,
+    mean_antigens_per_patient_by_cohort,
 )
 from .cta import (
     CTA_evidence,
@@ -256,6 +258,8 @@ __all__ = [
     "is_mixture_cohort",
     "is_rescue_feature",
     "known_cohort_ids",
+    "mean_antigens_per_patient",
+    "mean_antigens_per_patient_by_cohort",
     "mixture_cohort_codes",
     "normalize_expression",
     "normalize_technical_rna_columns",

--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -255,10 +255,13 @@ def _cmd_plot(args: argparse.Namespace) -> int:
         "cta-addressable-burden": plots.cta_addressable_burden,
         "cta-patient-heatmap": plots.cta_patient_count_heatmap,
         "cta-coverage-curves": plots.cta_coverage_curves,
+        "cta-coverage-stacked": plots.cta_coverage_stacked_bars,
+        "cta-burden-vs-response": plots.cta_burden_vs_response,
+        "burden-category-bars": plots.burden_category_bars,
         "apd1-response-signature": plots.apd1_response_signature_scatter,
     }
     try:
-        if args.which == "incidence-vs-mortality":
+        if args.which in ("incidence-vs-mortality", "burden-category-bars"):
             kwargs = {"region": args.region}
         elif args.which == "apd1-response-signature":
             kwargs = {"signature": args.signature}
@@ -268,9 +271,11 @@ def _cmd_plot(args: argparse.Namespace) -> int:
             kwargs = {"source": args.source, "threshold_tpm": args.threshold_tpm}
         elif args.which == "cta-patient-heatmap":
             kwargs = {"threshold_tpm": args.threshold_tpm}
-        elif args.which == "cta-coverage-curves":
+        elif args.which == "cta-burden-vs-response":
+            kwargs = {"against": args.against, "threshold_tpm": args.threshold_tpm}
+        elif args.which in ("cta-coverage-curves", "cta-coverage-stacked"):
             if not args.codes:
-                print("Error: cta-coverage-curves needs --codes", file=sys.stderr)
+                print(f"Error: {args.which} needs --codes", file=sys.stderr)
                 return 1
             kwargs = {
                 "cancer_types": [c.strip() for c in args.codes.split(",")],
@@ -458,6 +463,9 @@ def _build_parser() -> argparse.ArgumentParser:
             "cta-addressable-burden",
             "cta-patient-heatmap",
             "cta-coverage-curves",
+            "cta-coverage-stacked",
+            "cta-burden-vs-response",
+            "burden-category-bars",
             "apd1-response-signature",
         ],
         help="Which plot to render",
@@ -482,6 +490,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default="within_sample",
         choices=["within_sample", "per_sample"],
         help="Prevalence basis for cta-addressable-burden (per_sample needs matrices)",
+    )
+    p_plot.add_argument(
+        "--against",
+        default="apd1",
+        choices=["apd1", "tmb"],
+        help="Response metric for cta-burden-vs-response",
     )
     p_plot.add_argument(
         "--threshold-tpm",

--- a/cancerdata/coverage.py
+++ b/cancerdata/coverage.py
@@ -192,6 +192,50 @@ def greedy_coverage(
     return pd.DataFrame(rows)
 
 
+def mean_antigens_per_patient(
+    cancer_type,
+    *,
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    gene_ids: Iterable[str] | None = None,
+    proteoform: bool = True,
+) -> float:
+    """Mean number of panel antigens a patient in the cohort expresses above
+    ``threshold_tpm`` — the per-patient antigen *load* (how many CTAs the average
+    patient presents, not just whether ≥1). Equals the sum over antigens of their
+    per-patient prevalence; identical-protein paralogs count once
+    (``proteoform=True``). 0.0 for an empty cohort/panel."""
+    _, samples, hits = _hit_matrix(
+        cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
+    )
+    if not samples or hits.size == 0:
+        return 0.0
+    return float(hits.sum(axis=0).mean())
+
+
+def mean_antigens_per_patient_by_cohort(
+    cohorts: Iterable[str] | None = None,
+    *,
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    gene_ids: Iterable[str] | None = None,
+    proteoform: bool = True,
+) -> pd.Series:
+    """``{cohort code -> mean antigens per patient}`` over the cohorts that have a
+    per-sample matrix (default: all cached ones). Mirrors
+    :func:`addressable_fraction_by_cohort`: skips uncached cohorts rather than
+    fetching every one implicitly."""
+    from . import source_matrices
+
+    codes = list(cohorts) if cohorts is not None else source_matrices.available_cohorts()
+    out: dict[str, float] = {}
+    for code in codes:
+        if cohorts is None and not source_matrices.is_cached(code):
+            continue
+        out[str(code)] = mean_antigens_per_patient(
+            code, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
+        )
+    return pd.Series(out, name="mean_antigens_per_patient")
+
+
 def addressable_fraction_by_cohort(
     cohorts: Iterable[str] | None = None,
     *,

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -198,6 +198,110 @@ def _cohort_gene_heatmap(grid, *, title, cbar_label, cmap, lognorm=False, floor=
     return _save(fig, save)
 
 
+# CTA antigen families, by symbol prefix (longest match wins). cancerdata has no
+# curated antigen-family table; this presentational heuristic mirrors pirlygenes and
+# only drives colour grouping in the gene-level CTA plots — never analysis.
+_ANTIGEN_FAMILY_PREFIXES = (
+    ("MAGEA", "MAGE-A"),
+    ("MAGEB", "MAGE-B"),
+    ("MAGEC", "MAGE-C"),
+    ("CSAG", "CSAG"),
+    ("GAGE", "GAGE"),
+    ("XAGE", "XAGE"),
+    ("PAGE", "PAGE"),
+    ("SSX", "SSX"),
+    ("CT45", "CT45"),
+    ("CTAG", "CTAG/NY-ESO"),
+    ("LAGE", "CTAG/NY-ESO"),
+    ("SPANX", "SPANX"),
+    ("PRAME", "PRAME"),
+    ("DPPA2", "DPPA"),
+    ("TFDP3", "TFDP3"),
+)
+
+
+def _antigen_family(symbol) -> str:
+    """CTA antigen family for a gene symbol via longest matching prefix; ``"other"``
+    when nothing matches (e.g. CT83, CTCFL)."""
+    s = str(symbol).upper()
+    best = None
+    for prefix, fam in _ANTIGEN_FAMILY_PREFIXES:
+        if s.startswith(prefix) and (best is None or len(prefix) > len(best[0])):
+            best = (prefix, fam)
+    return best[1] if best else "other"
+
+
+def _antigen_family_colors(symbols):
+    """``({symbol -> color}, {family -> color})`` keyed by antigen family (tab20)."""
+    plt = _plt()
+    fam_by_sym = {s: _antigen_family(s) for s in symbols}
+    families = sorted(set(fam_by_sym.values()))
+    cmap = plt.get_cmap("tab20")
+    fam_color = {f: cmap(i % 20) for i, f in enumerate(families)}
+    return {s: fam_color[f] for s, f in fam_by_sym.items()}, fam_color
+
+
+def _stacked_barh(rows, *, xlabel, title, legend=None, annotate=True, save=None):
+    """Horizontal stacked bars. ``rows`` is ``[(row_label, [(seg_label, value,
+    color), ...]), ...]`` in top-to-bottom order; each row's segments stack along x.
+    ``legend`` is an optional ``{label: color}`` shown as a colour key. Segments wide
+    enough are annotated with their ``seg_label``. The shared stacked-bar scaffold."""
+    plt = _plt()
+    fig, ax = plt.subplots(figsize=(10, max(4, 0.42 * len(rows))))
+    total = max((sum(v for _, v, _ in segs) for _, segs in rows), default=1.0) or 1.0
+    for i, (_, segs) in enumerate(rows):
+        left = 0.0
+        for seg_label, value, color in segs:
+            ax.barh(i, value, left=left, color=color, edgecolor="white", linewidth=0.4)
+            if annotate and value > 0.06 * total:
+                ax.text(
+                    left + value / 2,
+                    i,
+                    seg_label,
+                    ha="center",
+                    va="center",
+                    fontsize=5,
+                    color="white",
+                )
+            left += value
+    ax.set_yticks(range(len(rows)))
+    ax.set_yticklabels([r[0] for r in rows], fontsize=7)
+    ax.invert_yaxis()  # first row at the top
+    ax.set_xlabel(xlabel)
+    ax.set_title(title)
+    ax.grid(True, axis="x", alpha=0.3)
+    if legend:
+        handles = [plt.Rectangle((0, 0), 1, 1, color=c) for c in legend.values()]
+        ax.legend(handles, list(legend), fontsize=6, title="antigen family", loc="lower right")
+    fig.tight_layout()
+    return _save(fig, save)
+
+
+def _grouped_barh(categories, series, *, xlabel, title, save=None):
+    """Grouped (paired) horizontal bars. ``categories`` are the row labels (top-to-
+    bottom); ``series`` is ``[(name, [value per category], color), ...]`` — one bar
+    per series within each category group. The shared grouped-bar scaffold."""
+    import numpy as np
+
+    plt = _plt()
+    n_series = max(1, len(series))
+    base = np.arange(len(categories))
+    height = 0.8 / n_series
+    fig, ax = plt.subplots(figsize=(9, max(4, 0.5 * len(categories))))
+    for k, (name, values, color) in enumerate(series):
+        offset = (k - (n_series - 1) / 2) * height
+        ax.barh(base + offset, values, height=height, label=name, color=color)
+    ax.set_yticks(base)
+    ax.set_yticklabels(categories, fontsize=7)
+    ax.invert_yaxis()
+    ax.set_xlabel(xlabel)
+    ax.set_title(title)
+    ax.grid(True, axis="x", alpha=0.3)
+    ax.legend(fontsize=7, loc="lower right")
+    fig.tight_layout()
+    return _save(fig, save)
+
+
 def apd1_vs_tmb(*, save=None, annotate=True):
     """Scatter of anti-PD-1 ORR (%) vs median TMB (log x), one point per cancer
     type with a curated value for both, colored by lineage family. The classic
@@ -577,6 +681,124 @@ def cta_coverage_curves(
     ax.legend(fontsize=7, loc="lower right")
     fig.tight_layout()
     return _save(fig, save)
+
+
+def cta_coverage_stacked_bars(
+    cancer_types,
+    *,
+    threshold_tpm=10.0,
+    max_genes=12,
+    save=None,
+):
+    """Greedy **coverage plateau** as a stacked bar per cohort — one horizontal bar
+    per cancer type, split into the marginal new-patient fraction each CTA adds in
+    greedy set-cover order (:func:`cancerdata.coverage.greedy_coverage`). The bar's
+    total length is the cohort's addressable share (≥1 CTA panel); each segment shows
+    how much a single antigen contributes, coloured by antigen family.
+
+    Complements :func:`cta_coverage_curves` (cumulative step curve) by showing *which*
+    antigens carry the coverage. ``cancer_types`` is a code or iterable; each needs a
+    cached per-sample matrix. ``max_genes`` caps the segments per cohort."""
+    from .coverage import greedy_coverage
+
+    codes = [cancer_types] if isinstance(cancer_types, str) else list(cancer_types)
+    coverage_by_code = {}
+    for code in codes:
+        gc = greedy_coverage(code, threshold_tpm=threshold_tpm, max_genes=max_genes)
+        if not gc.empty:
+            coverage_by_code[code] = gc
+    if not coverage_by_code:
+        raise ValueError(
+            "no coverage to plot — are the cohorts' per-sample matrices cached, and "
+            "does any CTA clear the threshold?"
+        )
+    all_syms = {str(s) for gc in coverage_by_code.values() for s in gc["Symbol"]}
+    sym_color, fam_color = _antigen_family_colors(all_syms)
+
+    rows = []
+    for code, gc in coverage_by_code.items():
+        covered = float(gc["cumulative_fraction"].iloc[-1])
+        segs = [
+            (str(r.Symbol), float(r.marginal_fraction), sym_color[str(r.Symbol)])
+            for r in gc.itertuples()
+        ]
+        rows.append((f"{format_cancer_code_label(code)}  ({covered:.0%})", segs))
+    return _stacked_barh(
+        rows,
+        xlabel=f"fraction of patients covered (≥1 CTA > {threshold_tpm:g} TPM)",
+        title=f"CTA greedy coverage by antigen — {len(rows)} cohorts",
+        legend=fam_color,
+        save=save,
+    )
+
+
+def burden_category_bars(*, region="us", n=None, save=None):
+    """Grouped horizontal bars of cancer **incidence vs mortality** share per burden
+    category for a region (``"us"``/``"world"``), categories ordered by incidence. The
+    reference view behind :func:`incidence_vs_mortality` — read the gap between a
+    category's two bars as its lethality."""
+    if region not in ("us", "world"):
+        raise ValueError("region must be 'us' or 'world'")
+    plt = _plt()
+    inc = cancer_burden(metric=f"{region}_incidence_pct")
+    mort = cancer_burden(metric=f"{region}_mortality_pct")
+    cats = sorted(set(inc) & set(mort), key=lambda c: inc.get(c, 0.0), reverse=True)
+    if not cats:
+        raise ValueError("no burden category with both an incidence and a mortality share")
+    if n is not None:
+        cats = cats[:n]
+    cmap = plt.get_cmap("tab10")
+    return _grouped_barh(
+        cats,
+        [
+            ("incidence", [inc[c] for c in cats], cmap(0)),
+            ("mortality", [mort[c] for c in cats], cmap(3)),
+        ],
+        xlabel=f"{region.upper()} share of cancer cases / deaths (%)",
+        title=f"Cancer burden by category ({region.upper()}) — incidence vs mortality",
+        save=save,
+    )
+
+
+def cta_burden_vs_response(*, against="apd1", threshold_tpm=10.0, cohorts=None, save=None):
+    """Scatter of a cohort's **mean CTA antigen load** (mean number of CTAs a patient
+    expresses above ``threshold_tpm``, from
+    :func:`cancerdata.coverage.mean_antigens_per_patient`) vs its anti-PD-1 ORR
+    (``against="apd1"``) or median TMB (``against="tmb"``), one point per cancer type,
+    coloured by lineage family.
+
+    The per-patient counterpart to :func:`apd1_response_signature_scatter`: does a
+    cohort's CTA antigen load track checkpoint response / mutational burden? Points are
+    cohorts with BOTH a cached per-sample matrix and the chosen response metric. Needs
+    the per-sample matrices cached."""
+    from .coverage import mean_antigens_per_patient
+
+    if against == "apd1":
+        ymap, ylabel = cancer_apd1_response(), "Anti-PD-1 monotherapy ORR (%)"
+    elif against == "tmb":
+        ymap, ylabel = cancer_tmb(), "Median tumor mutational burden (mut/Mb)"
+    else:
+        raise ValueError("against must be 'apd1' or 'tmb'")
+
+    cohorts = list(cohorts) if cohorts is not None else _cached_per_sample_cohorts()
+    points = []
+    for code in cohorts:
+        if code not in ymap:
+            continue
+        load = mean_antigens_per_patient(code, threshold_tpm=threshold_tpm)
+        points.append((code, load, float(ymap[code])))
+    if not points:
+        raise ValueError(
+            f"no cohort with both a cached per-sample matrix and a {against} value — "
+            "fetch the matrices (source_matrices.fetch) for those cohorts first."
+        )
+    return _family_scatter(
+        points,
+        xlabel=f"mean CTAs expressed per patient (> {threshold_tpm:g} TPM)",
+        ylabel=ylabel,
+        title=f"CTA antigen load vs {against} — {len(points)} cancers",
+        save=save,
+    )
 
 
 def apd1_response_signature_scatter(signature="t_cell_inflamed", *, cohorts=None, save=None):

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -62,6 +62,19 @@ def test_greedy_coverage_is_set_cover(patched):
     assert (gc["cumulative_fraction"].diff().dropna() > 0).all()
 
 
+def test_mean_antigens_per_patient(patched):
+    # hits: gA in p0,p1 (2) + gB in p2 (1) + gC in p1 (1) = 4 over 4 patients -> 1.0.
+    # Equals the sum of per-gene prevalences (0.5 + 0.25 + 0.25).
+    load = coverage.mean_antigens_per_patient("X", threshold_tpm=5, gene_ids=patched)
+    assert load == 1.0
+    pf = coverage.cta_patient_fractions("X", threshold_tpm=5, gene_ids=patched)
+    assert load == pytest.approx(pf["fraction_expressing"].sum())
+
+
+def test_mean_antigens_per_patient_empty_panel(patched):
+    assert coverage.mean_antigens_per_patient("X", gene_ids=[]) == 0.0
+
+
 def test_greedy_respects_max_genes(patched):
     gc = coverage.greedy_coverage("X", threshold_tpm=5, gene_ids=patched, max_genes=1)
     assert len(gc) == 1

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -41,6 +41,17 @@ def test_cli_plot(tmp_path):
     assert out.exists()
 
 
+def test_cli_plot_burden_category_bars(tmp_path):
+    out = tmp_path / "cats.png"
+    assert cli.main(["plot", "burden-category-bars", "--region", "world", "--out", str(out)]) == 0
+    assert out.exists()
+
+
+def test_cli_plot_coverage_stacked_needs_codes(capsys):
+    # The coverage plots require --codes; missing it is a clean error, not a crash.
+    assert cli.main(["plot", "cta-coverage-stacked", "--out", "x.png"]) == 1
+
+
 # ---- CTA expression heatmap (needs the expression bundle / percentile data) ----
 
 _HAS_PERCENTILES = bool(__import__("cancerdata").available_percentile_cohorts())
@@ -230,6 +241,90 @@ def test_cta_coverage_curves_empty_raises(monkeypatch):
     monkeypatch.setattr(coverage, "greedy_coverage", lambda *a, **k: pd.DataFrame())
     with pytest.raises(ValueError, match="no coverage curve"):
         plots.cta_coverage_curves(["LUAD"])
+
+
+def test_antigen_family_grouping():
+    assert plots._antigen_family("MAGEA4") == "MAGE-A"
+    assert plots._antigen_family("MAGEB2") == "MAGE-B"
+    assert plots._antigen_family("CTAG1B") == "CTAG/NY-ESO"
+    assert plots._antigen_family("LAGE1") == "CTAG/NY-ESO"  # same family as CTAG
+    assert plots._antigen_family("SSX2") == "SSX"
+    assert plots._antigen_family("CT83") == "other"
+
+
+def test_cta_coverage_stacked_bars_renders(tmp_path, monkeypatch):
+    import pandas as pd
+
+    from cancerdata import coverage
+
+    def fake_greedy(code, *, threshold_tpm, max_genes):
+        return pd.DataFrame(
+            {
+                "rank": [1, 2, 3],
+                "Ensembl_Gene_ID": ["E1", "E2", "E3"],
+                "Symbol": ["MAGEA4", "CTAG1B", "SSX2"],
+                "marginal_patients": [60, 20, 10],
+                "marginal_fraction": [0.6, 0.2, 0.1],
+                "cumulative_patients": [60, 80, 90],
+                "cumulative_fraction": [0.6, 0.8, 0.9],
+            }
+        )
+
+    monkeypatch.setattr(coverage, "greedy_coverage", fake_greedy)
+    out = tmp_path / "stacked.png"
+    fig = plots.cta_coverage_stacked_bars(["LUAD", "SKCM"], save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+    assert fig is not None
+
+
+def test_cta_coverage_stacked_bars_empty_raises(monkeypatch):
+    import pandas as pd
+
+    from cancerdata import coverage
+
+    monkeypatch.setattr(coverage, "greedy_coverage", lambda *a, **k: pd.DataFrame())
+    with pytest.raises(ValueError, match="no coverage to plot"):
+        plots.cta_coverage_stacked_bars(["LUAD"])
+
+
+def test_burden_category_bars_renders(tmp_path):
+    out = tmp_path / "cats.png"
+    fig = plots.burden_category_bars(region="us", n=8, save=str(out))
+    assert out.exists() and out.stat().st_size > 0
+    assert fig is not None
+
+
+def test_burden_category_bars_bad_region():
+    with pytest.raises(ValueError, match="region must be"):
+        plots.burden_category_bars(region="moon")
+
+
+def test_cta_burden_vs_response_renders(tmp_path, monkeypatch):
+    from cancerdata import coverage
+
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: ["LUAD", "SKCM", "MM"])
+    monkeypatch.setattr(
+        plots, "cancer_apd1_response", lambda: {"LUAD": 19.0, "SKCM": 42.0, "MM": 3.0}
+    )
+    monkeypatch.setattr(
+        coverage,
+        "mean_antigens_per_patient",
+        lambda code, **k: {"LUAD": 1.5, "SKCM": 4.0, "MM": 8.0}[code],
+    )
+    out = tmp_path / "load.png"
+    fig = plots.cta_burden_vs_response(against="apd1", save=str(out))
+    assert out.exists() and fig is not None
+
+
+def test_cta_burden_vs_response_bad_against():
+    with pytest.raises(ValueError, match="against must be"):
+        plots.cta_burden_vs_response(against="nonsense")
+
+
+def test_cta_burden_vs_response_no_data(monkeypatch):
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: [])
+    with pytest.raises(ValueError, match="no cohort with both"):
+        plots.cta_burden_vs_response()
 
 
 def test_apd1_response_signature_scatter_renders(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Ports the genuinely-distinct pirlygenes CTA/burden figures onto the centralized
plot primitives (#82). Each plot is a thin assembler: shape the data → hand it to
one primitive.

### New figures
- **`cta_coverage_stacked_bars`** — greedy coverage plateau per cohort as a
  horizontal stacked bar, split into each CTA's *marginal* new-patient fraction
  (from `greedy_coverage`), coloured by antigen family. Complements the existing
  cumulative `cta_coverage_curves` by showing *which* antigens carry the coverage.
- **`burden_category_bars`** — incidence vs mortality share per burden category as
  grouped bars; the bar view behind `incidence_vs_mortality`.
- **`cta_burden_vs_response`** — per-cohort mean CTA antigen load vs aPD1 ORR
  (`against="apd1"`) or median TMB (`against="tmb"`), family-coloured. The
  per-patient counterpart to `apd1_response_signature_scatter`.

### New primitives / helpers
- `_stacked_barh(rows, ...)` — generic ragged horizontal stacked bars + legend.
- `_grouped_barh(categories, series, ...)` — generic paired horizontal bars.
- `_antigen_family` / `_antigen_family_colors` — CTA antigen family by symbol
  prefix (mirrors pirlygenes; **presentational only**, drives colour grouping).

### New accessor
- `coverage.mean_antigens_per_patient[_by_cohort]` — mean number of CTAs a patient
  expresses above threshold (equals the sum of per-gene prevalences),
  proteoform-summed. Exported from the package root.

### Wiring
All three plots added to the CLI: `cancerdata plot cta-coverage-stacked` /
`burden-category-bars` / `cta-burden-vs-response` (with `--against`).

## Deliberately out of scope

The pirlygenes multi-factor **aPD1 causal-regression** 3-panel is analysis-layer
(trufflepig), not base-layer reference — left out per the "base layer, not
analysis layer" guidance. The 9-mer counts plot is the next PR (proteome wiring).

## Tests

336 passed (12 new: antigen-family grouping, the three figures + error paths,
the new coverage accessor, CLI dispatch).