### PR TITLE
Proteome-backed CTA-specific 9-mer enumeration + load plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ cd.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
   package, but resolution needs a downloaded human release once:
   `pyensembl install --release 111 --species homo_sapiens` (the accessors return
   `None` until then).
+- **Peptides** — `cta_specific_9mer_counts`, `cta_specific_9mer_load` (per-cohort
+  mean per-patient CTA-specific 9-mer load): 9-mers found in a CTA protein but in no
+  non-CTA protein, enumerated from the reference proteome and cached per release.
 - **Plots** (`pip install cancerdata[plots]`) — `cancerdata.plots.apd1_vs_tmb`,
   `apd1_orr_bars`, `incidence_vs_mortality`, and the CTA/coverage figures.
 

--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -135,6 +135,11 @@ from .normalization import (
     renormalize_to_million,
     tpm_to_housekeeping_normalized,
 )
+from .peptides import (
+    cta_specific_9mer_counts,
+    cta_specific_9mer_load,
+    cta_specific_9mer_weights,
+)
 from .proteoforms import (
     collapse_to_proteoforms,
     gene_to_proteoform,
@@ -234,6 +239,9 @@ __all__ = [
     "collapse_to_proteoforms",
     "cta_dataframe",
     "cta_patient_fractions",
+    "cta_specific_9mer_counts",
+    "cta_specific_9mer_load",
+    "cta_specific_9mer_weights",
     "expression_source",
     "expression_sources",
     "family_display_name",

--- a/cancerdata/cli.py
+++ b/cancerdata/cli.py
@@ -257,6 +257,7 @@ def _cmd_plot(args: argparse.Namespace) -> int:
         "cta-coverage-curves": plots.cta_coverage_curves,
         "cta-coverage-stacked": plots.cta_coverage_stacked_bars,
         "cta-burden-vs-response": plots.cta_burden_vs_response,
+        "cta-specific-9mer-load": plots.cta_specific_9mer_load,
         "burden-category-bars": plots.burden_category_bars,
         "apd1-response-signature": plots.apd1_response_signature_scatter,
     }
@@ -271,7 +272,7 @@ def _cmd_plot(args: argparse.Namespace) -> int:
             kwargs = {"source": args.source, "threshold_tpm": args.threshold_tpm}
         elif args.which == "cta-patient-heatmap":
             kwargs = {"threshold_tpm": args.threshold_tpm}
-        elif args.which == "cta-burden-vs-response":
+        elif args.which in ("cta-burden-vs-response", "cta-specific-9mer-load"):
             kwargs = {"against": args.against, "threshold_tpm": args.threshold_tpm}
         elif args.which in ("cta-coverage-curves", "cta-coverage-stacked"):
             if not args.codes:
@@ -465,6 +466,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "cta-coverage-curves",
             "cta-coverage-stacked",
             "cta-burden-vs-response",
+            "cta-specific-9mer-load",
             "burden-category-bars",
             "apd1-response-signature",
         ],

--- a/cancerdata/peptides.py
+++ b/cancerdata/peptides.py
@@ -160,14 +160,23 @@ def cta_specific_9mer_load(
     By linearity this equals ``Σ over antigens (fraction_expressing ×
     n_specific_9mers)``, so it is built directly on
     :func:`cancerdata.coverage.cta_patient_fractions` (proteoform-summed) — no second
-    pass over the per-sample matrix. Needs the cohort's per-sample matrix cached."""
+    pass over the per-sample matrix. Needs the cohort's per-sample matrix cached.
+
+    The join is on the **canonical-member Ensembl gene id**, not ``Symbol``: a
+    collapsed proteoform's ``Symbol`` is the slash-joined label (``CTAG1A/CTAG1B``),
+    which would never match the per-gene weight table — but identical-protein members
+    share a sequence (hence one specific-9-mer count), so the canonical member's id
+    carries the proteoform's weight."""
     from .coverage import cta_patient_fractions
 
     pf = cta_patient_fractions(cancer_type, threshold_tpm=threshold_tpm)
     if pf.empty:
         return 0.0
-    weights = cta_specific_9mer_weights(k=k)
-    w = pf["Symbol"].astype(str).map(lambda s: weights.get(s, 0))
+    df = cta_specific_9mer_counts(k=k)
+    weight_by_id = {
+        strip_version(g): int(n) for g, n in zip(df["Ensembl_Gene_ID"], df["n_specific_9mers"])
+    }
+    w = pf["Ensembl_Gene_ID"].astype(str).map(lambda g: weight_by_id.get(strip_version(g), 0))
     return float((pf["fraction_expressing"] * w).sum())
 
 

--- a/cancerdata/peptides.py
+++ b/cancerdata/peptides.py
@@ -1,0 +1,179 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CTA-specific 9-mer (peptide) enumeration from the reference proteome.
+
+A 9-mer is **CTA-specific** when it appears in a CTA protein but in *no* non-CTA
+protein anywhere in the proteome — a measure of how much truly tumor-restricted
+neoepitope source a CTA provides (a shared 9-mer would risk central tolerance /
+off-target reactivity). This mirrors pirlygenes' definition exactly:
+
+  - protein sequences come from the installed Ensembl release (pyensembl), the
+    **longest** protein-coding transcript per gene (stop codon stripped);
+  - 9-mers are the distinct sliding-window (stride 1) substrings of a protein;
+  - the **background** is the union of 9-mers over every non-CTA protein (the full
+    CTA *universe* — :func:`cancerdata.cta.CTA_unfiltered_gene_ids` — is excluded so
+    borderline CTAs don't poison the background);
+  - a CTA's ``n_specific_9mers`` is how many of its 9-mers miss that background.
+
+Building the background scans the whole proteome (~20k genes, a minute or two), so
+:func:`cta_specific_9mer_counts` caches its per-CTA table to a CSV under the
+cancerdata cache, keyed by Ensembl release. Needs a downloaded human release with
+protein sequences (``pyensembl install --release N --species homo_sapiens``).
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+import pandas as pd
+
+from .cta import CTA_gene_id_to_name, CTA_gene_ids, CTA_unfiltered_gene_ids
+from .genome import find_gene_id_by_name, genomes, strip_version
+
+#: 9 = the canonical MHC-I epitope length.
+DEFAULT_K: int = 9
+
+
+def _derived_cache_dir() -> Path:
+    from .data_bundle import cache_root
+
+    d = cache_root() / "derived"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _usable_genome():
+    """Newest installed release whose protein sequences are available (GTF + protein
+    FASTA), probed cheaply via TP53. ``None`` if none is usable."""
+    probe = strip_version(find_gene_id_by_name("TP53") or "")
+    for g in genomes():
+        try:
+            gene = g.gene_by_id(probe)
+            if any(t.biotype == "protein_coding" and t.protein_sequence for t in gene.transcripts):
+                return g
+        except Exception:
+            continue
+    return None
+
+
+def _kmers(seq: str, k: int) -> set[str]:
+    """Distinct length-``k`` sliding-window substrings of ``seq``."""
+    return {seq[i : i + k] for i in range(len(seq) - k + 1)}
+
+
+def _longest_protein_per_gene(genome, k: int) -> dict[str, str]:
+    """``{unversioned gene id -> longest protein-coding protein sequence}`` (≥ ``k``
+    aa, trailing stop codon stripped) for one Ensembl release."""
+    longest: dict[str, str] = {}
+    for tr in genome.transcripts():
+        if tr.biotype != "protein_coding":
+            continue
+        try:
+            seq = tr.protein_sequence
+        except Exception:
+            seq = None
+        if not seq or len(seq) < k:
+            continue
+        seq = seq.rstrip("*")
+        if len(seq) < k:
+            continue
+        gid = strip_version(tr.gene_id)
+        if gid not in longest or len(seq) > len(longest[gid]):
+            longest[gid] = seq
+    return longest
+
+
+@lru_cache(maxsize=4)
+def cta_specific_9mer_counts(*, k: int = DEFAULT_K, refresh: bool = False) -> pd.DataFrame:
+    """Per filtered CTA, its distinct-9-mer count and how many are CTA-specific.
+
+    Columns: ``Ensembl_Gene_ID`` (unversioned), ``Symbol``, ``n_9mers`` (distinct
+    9-mers in its longest protein), ``n_specific_9mers`` (those absent from every
+    non-CTA protein). Cached to a per-release CSV under the cancerdata cache; pass
+    ``refresh=True`` to rebuild. Raises if no usable Ensembl release is installed."""
+    genome = _usable_genome()
+    if genome is None:
+        raise RuntimeError(
+            "no usable human Ensembl release with protein sequences installed — run "
+            "`pyensembl install --release 111 --species homo_sapiens`"
+        )
+    cache = _derived_cache_dir() / f"cta_specific_{k}mers_r{genome.release}.csv"
+    if cache.exists() and not refresh:
+        return pd.read_csv(cache)
+
+    longest = _longest_protein_per_gene(genome, k)
+    cta_filtered = {strip_version(g) for g in CTA_gene_ids()}
+    cta_universe = {strip_version(g) for g in CTA_unfiltered_gene_ids()}
+
+    background: set[str] = set()
+    for gid, seq in longest.items():
+        if gid in cta_universe:
+            continue  # exclude the whole CTA universe so borderline CTAs don't mask specificity
+        background |= _kmers(seq, k)
+
+    id2name = CTA_gene_id_to_name()
+    rows = []
+    for gid in sorted(cta_filtered):
+        seq = longest.get(gid)
+        km = _kmers(seq, k) if seq else set()
+        rows.append(
+            {
+                "Ensembl_Gene_ID": gid,
+                "Symbol": id2name.get(gid, gid),
+                "n_9mers": len(km),
+                "n_specific_9mers": sum(1 for x in km if x not in background),
+            }
+        )
+    df = pd.DataFrame(rows, columns=["Ensembl_Gene_ID", "Symbol", "n_9mers", "n_specific_9mers"])
+    df.to_csv(cache, index=False)
+    return df
+
+
+@lru_cache(maxsize=1)
+def cta_specific_9mer_weights(*, k: int = DEFAULT_K) -> dict[str, int]:
+    """``{CTA symbol -> n_specific_9mers}`` from :func:`cta_specific_9mer_counts`.
+
+    Identical-protein paralogs (proteoforms) share a sequence, hence an identical
+    specific-9-mer count, so the per-symbol weight is the proteoform's weight."""
+    df = cta_specific_9mer_counts(k=k)
+    return {str(s): int(n) for s, n in zip(df["Symbol"], df["n_specific_9mers"])}
+
+
+def cta_specific_9mer_load(
+    cancer_type, *, threshold_tpm: float = 10.0, k: int = DEFAULT_K
+) -> float:
+    """Mean per-patient CTA-specific 9-mer **load** for a cohort: for the average
+    patient, the total CTA-specific 9-mers summed over the CTAs they express above
+    ``threshold_tpm``.
+
+    By linearity this equals ``Σ over antigens (fraction_expressing ×
+    n_specific_9mers)``, so it is built directly on
+    :func:`cancerdata.coverage.cta_patient_fractions` (proteoform-summed) — no second
+    pass over the per-sample matrix. Needs the cohort's per-sample matrix cached."""
+    from .coverage import cta_patient_fractions
+
+    pf = cta_patient_fractions(cancer_type, threshold_tpm=threshold_tpm)
+    if pf.empty:
+        return 0.0
+    weights = cta_specific_9mer_weights(k=k)
+    w = pf["Symbol"].astype(str).map(lambda s: weights.get(s, 0))
+    return float((pf["fraction_expressing"] * w).sum())
+
+
+__all__ = [
+    "DEFAULT_K",
+    "cta_specific_9mer_counts",
+    "cta_specific_9mer_load",
+    "cta_specific_9mer_weights",
+]

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -838,25 +838,46 @@ def apd1_response_signature_scatter(signature="t_cell_inflamed", *, cohorts=None
     )
 
 
-def cta_specific_9mer_counts(*, save=None, **kwargs):
-    """**Scaffold** — CTA-specific 9-mer (peptide) counts per cancer type.
+def cta_specific_9mer_load(*, against="tmb", threshold_tpm=10.0, cohorts=None, save=None):
+    """Scatter of a cohort's **mean per-patient CTA-specific 9-mer load**
+    (:func:`cancerdata.peptides.cta_specific_9mer_load`) vs its median TMB
+    (``against="tmb"``) or anti-PD-1 ORR (``against="apd1"``), one point per cancer
+    type, coloured by lineage family.
 
-    The faithful plot counts, per cancer type, the unique 9-mer peptides derived
-    from CTAs expressed in that cohort — a measure of the CTA-specific neoepitope
-    source breadth. It needs two inputs cancerdata does not ship:
+    The 9-mer load is, for the average patient, the total CTA-specific 9-mers across
+    the CTAs they express above ``threshold_tpm`` — a per-patient measure of
+    tumor-restricted neoepitope source breadth. CTA-specific 9-mers come from the
+    reference proteome (the longest protein per gene, background-subtracted against
+    all non-CTA proteins); see :mod:`cancerdata.peptides`.
 
-    1. the **proteome** (translated CTA protein sequences) to enumerate 9-mers —
-       a ``pyensembl``/reference-proteome dependency that is out of cancerdata's
-       pandas-only base-layer scope, and
-    2. the **per-sample expression matrices** to decide which CTAs are expressed
-       per patient (the shipped percentile/within-sample summaries can't recover
-       per-sample peptide sets).
+    Points are cohorts with BOTH a cached per-sample matrix and the chosen metric.
+    Needs the per-sample matrices cached and a downloaded Ensembl release with protein
+    sequences (the first call builds + caches the per-CTA 9-mer table)."""
+    from .peptides import cta_specific_9mer_load as _load
 
-    This is intentionally the heaviest plot and is tracked as its own follow-up
-    (#15); it is not wired to shipped data. Raising keeps the API surface explicit
-    rather than returning a misleading partial figure."""
-    raise NotImplementedError(
-        "cta_specific_9mer_counts needs a reference proteome (9-mer enumeration, e.g. "
-        "via pyensembl) and the per-sample expression matrices — neither is in "
-        "cancerdata's shipped, pandas-only base layer. Tracked as a follow-up in #15."
+    if against == "tmb":
+        xmap, ylabel2 = cancer_tmb(), "Median tumor mutational burden (mut/Mb)"
+    elif against == "apd1":
+        xmap, ylabel2 = cancer_apd1_response(), "Anti-PD-1 monotherapy ORR (%)"
+    else:
+        raise ValueError("against must be 'tmb' or 'apd1'")
+
+    cohorts = list(cohorts) if cohorts is not None else _cached_per_sample_cohorts()
+    points = []
+    for code in cohorts:
+        if code not in xmap:
+            continue
+        load = _load(code, threshold_tpm=threshold_tpm)
+        points.append((code, load, float(xmap[code])))
+    if not points:
+        raise ValueError(
+            f"no cohort with both a cached per-sample matrix and a {against} value — "
+            "fetch the matrices (source_matrices.fetch) for those cohorts first."
+        )
+    return _family_scatter(
+        points,
+        xlabel=f"mean CTA-specific 9-mers per patient (> {threshold_tpm:g} TPM)",
+        ylabel=ylabel2,
+        title=f"CTA-specific 9-mer load vs {against} — {len(points)} cancers",
+        save=save,
     )

--- a/tests/test_peptides.py
+++ b/tests/test_peptides.py
@@ -1,0 +1,111 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import pandas as pd
+import pytest
+
+from cancerdata import peptides
+
+
+class _FakeTr:
+    def __init__(self, gene_id, biotype, protein_sequence):
+        self.gene_id = gene_id
+        self.biotype = biotype
+        self.protein_sequence = protein_sequence
+
+
+class _FakeGenome:
+    release = 999
+
+    def __init__(self, transcripts):
+        self._trs = transcripts
+
+    def transcripts(self):
+        return self._trs
+
+
+def test_kmers():
+    assert peptides._kmers("AAACCC", 3) == {"AAA", "AAC", "ACC", "CCC"}
+    assert peptides._kmers("AB", 3) == set()  # shorter than k
+
+
+def test_longest_protein_per_gene_keeps_longest():
+    genome = _FakeGenome(
+        [
+            _FakeTr("G1", "protein_coding", "AAAA"),
+            _FakeTr("G1", "protein_coding", "AAAAAA"),  # longer -> wins
+            _FakeTr("G1", "lncRNA", "ZZZZZZZZ"),  # non-coding -> ignored
+            _FakeTr("G2", "protein_coding", "CC"),  # shorter than k -> dropped
+            _FakeTr("G3", "protein_coding", "MKLP*"),  # stop codon stripped
+        ]
+    )
+    longest = peptides._longest_protein_per_gene(genome, 3)
+    assert longest["G1"] == "AAAAAA"
+    assert "G2" not in longest
+    assert longest["G3"] == "MKLP"
+
+
+@pytest.fixture
+def fake_proteome(monkeypatch, tmp_path):
+    # CTA protein "AAACCC" (3-mers: AAA,AAC,ACC,CCC); background "CCCDDD" shares CCC.
+    genome = _FakeGenome(
+        [
+            _FakeTr("ENSG_CTA", "protein_coding", "AAACCC"),
+            _FakeTr("ENSG_BG", "protein_coding", "CCCDDD"),
+            _FakeTr("ENSG_NC", "lncRNA", "EEEEEE"),
+        ]
+    )
+    monkeypatch.setattr(peptides, "_usable_genome", lambda: genome)
+    monkeypatch.setattr(peptides, "_derived_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(peptides, "CTA_gene_ids", lambda: ["ENSG_CTA"])
+    monkeypatch.setattr(peptides, "CTA_unfiltered_gene_ids", lambda: ["ENSG_CTA"])
+    monkeypatch.setattr(peptides, "CTA_gene_id_to_name", lambda: {"ENSG_CTA": "CTAX"})
+    peptides.cta_specific_9mer_counts.cache_clear()
+    peptides.cta_specific_9mer_weights.cache_clear()
+    yield
+    peptides.cta_specific_9mer_counts.cache_clear()
+    peptides.cta_specific_9mer_weights.cache_clear()
+
+
+def test_specific_9mer_counts_subtracts_background(fake_proteome):
+    df = peptides.cta_specific_9mer_counts(k=3)
+    assert list(df["Symbol"]) == ["CTAX"]
+    row = df.iloc[0]
+    assert row["n_9mers"] == 4  # AAA, AAC, ACC, CCC
+    assert row["n_specific_9mers"] == 3  # CCC also in background -> excluded
+
+
+def test_specific_9mer_counts_caches(fake_proteome, tmp_path):
+    peptides.cta_specific_9mer_counts(k=3)
+    assert (tmp_path / "cta_specific_3mers_r999.csv").exists()
+
+
+def test_specific_9mer_weights(fake_proteome):
+    assert peptides.cta_specific_9mer_weights(k=3) == {"CTAX": 3}
+
+
+def test_specific_9mer_load_is_weighted_prevalence(fake_proteome, monkeypatch):
+    from cancerdata import coverage
+
+    def fake_fractions(code, *, threshold_tpm):
+        return pd.DataFrame(
+            {
+                "Ensembl_Gene_ID": ["ENSG_CTA"],
+                "Symbol": ["CTAX"],
+                "fraction_expressing": [0.5],
+            }
+        )
+
+    monkeypatch.setattr(coverage, "cta_patient_fractions", fake_fractions)
+    # load = fraction (0.5) * n_specific_9mers (3) = 1.5
+    assert peptides.cta_specific_9mer_load("X", threshold_tpm=5, k=3) == pytest.approx(1.5)
+
+
+def test_specific_9mer_load_empty_cohort(fake_proteome, monkeypatch):
+    from cancerdata import coverage
+
+    monkeypatch.setattr(coverage, "cta_patient_fractions", lambda code, **k: pd.DataFrame())
+    assert peptides.cta_specific_9mer_load("X", k=3) == 0.0

--- a/tests/test_peptides.py
+++ b/tests/test_peptides.py
@@ -87,20 +87,22 @@ def test_specific_9mer_weights(fake_proteome):
     assert peptides.cta_specific_9mer_weights(k=3) == {"CTAX": 3}
 
 
-def test_specific_9mer_load_is_weighted_prevalence(fake_proteome, monkeypatch):
+def test_specific_9mer_load_joins_on_ensembl_id_not_symbol(fake_proteome, monkeypatch):
+    # A collapsed proteoform's Symbol is the slash-joined label, which never matches
+    # the per-gene weight table — the load must join on the canonical-member ENSG.
     from cancerdata import coverage
 
     def fake_fractions(code, *, threshold_tpm):
         return pd.DataFrame(
             {
-                "Ensembl_Gene_ID": ["ENSG_CTA"],
-                "Symbol": ["CTAX"],
+                "Ensembl_Gene_ID": ["ENSG_CTA"],  # canonical member id
+                "Symbol": ["CTAX/CTAY"],  # slash-joined proteoform label
                 "fraction_expressing": [0.5],
             }
         )
 
     monkeypatch.setattr(coverage, "cta_patient_fractions", fake_fractions)
-    # load = fraction (0.5) * n_specific_9mers (3) = 1.5
+    # load = fraction (0.5) * n_specific_9mers (3) = 1.5; would be 0.0 on a Symbol join.
     assert peptides.cta_specific_9mer_load("X", threshold_tpm=5, k=3) == pytest.approx(1.5)
 
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -124,9 +124,30 @@ def test_cta_addressable_burden_no_mapped_cohorts(monkeypatch):
         plots.cta_addressable_burden()
 
 
-def test_cta_specific_9mer_counts_not_implemented():
-    with pytest.raises(NotImplementedError, match="#15"):
-        plots.cta_specific_9mer_counts()
+def test_cta_specific_9mer_load_renders(tmp_path, monkeypatch):
+    from cancerdata import peptides
+
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: ["LUAD", "SKCM", "MM"])
+    monkeypatch.setattr(plots, "cancer_tmb", lambda: {"LUAD": 6.9, "SKCM": 13.0, "MM": 1.5})
+    monkeypatch.setattr(
+        peptides,
+        "cta_specific_9mer_load",
+        lambda code, **k: {"LUAD": 120.0, "SKCM": 540.0, "MM": 60.0}[code],
+    )
+    out = tmp_path / "9mer.png"
+    fig = plots.cta_specific_9mer_load(against="tmb", save=str(out))
+    assert out.exists() and fig is not None
+
+
+def test_cta_specific_9mer_load_bad_against():
+    with pytest.raises(ValueError, match="against must be"):
+        plots.cta_specific_9mer_load(against="nonsense")
+
+
+def test_cta_specific_9mer_load_no_data(monkeypatch):
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: [])
+    with pytest.raises(ValueError, match="no cohort with both"):
+        plots.cta_specific_9mer_load()
 
 
 # ---- per-patient plots (consume the per-sample matrices via coverage.py) ----


### PR DESCRIPTION
## What

The last unported pirlygenes figure — now data-unblocked by pyensembl being core.
Replaces the `cta_specific_9mer_counts` NotImplementedError scaffold with a real
proteome-backed implementation.

### New `cancerdata.peptides` module
A 9-mer is **CTA-specific** when it appears in a CTA protein but in *no* non-CTA
protein. Faithful to pirlygenes:
- protein sequences = the **longest** protein-coding transcript per gene from the
  installed Ensembl release (stop codon stripped);
- distinct sliding-window (stride 1) 9-mers per protein;
- **background** = union of 9-mers over every non-CTA protein, excluding the whole
  CTA *universe* (`CTA_unfiltered_gene_ids`) so borderline CTAs don't mask specificity;
- `cta_specific_9mer_counts()` → per-CTA `n_9mers` / `n_specific_9mers`, **cached** to
  a per-release CSV under the cancerdata cache (whole-proteome scan ~13s, then cached);
- `cta_specific_9mer_weights()` → `{symbol: n_specific_9mers}`.

### Per-cohort load
`cta_specific_9mer_load(cohort)` = mean per-patient CTA-specific 9-mer load. By
linearity this equals `Σ(fraction_expressing × n_specific_9mers)`, so it is built on
the existing `coverage.cta_patient_fractions` (proteoform-summed) — **no second pass**
over the per-sample matrix.

### Plot
`plots.cta_specific_9mer_load(against="tmb"|"apd1")` — family-coloured scatter of
per-cohort 9-mer load vs TMB / aPD1 ORR, on the shared `_family_scatter` primitive.
Wired into the CLI (`plot cta-specific-9mer-load --against`).

## Verified end to end

Real release-114 proteome: 288 CTAs, 100,624 specific 9-mers (CCDC168/TEX14 top).
LUAD load ≈ 1122; SKCM (melanoma) highest load + TMB — biologically sensible.

## Tests

345 passed. Peptide logic tested hermetically with a fake genome (k-mer
enumeration, longest-protein selection, background subtraction, caching, the
linearity identity for load). Requires a downloaded Ensembl release **with protein
sequences** at runtime; raises a clear error otherwise.