### PR TITLE
Harden gene resolution: TSL no-info ranking + missing-CDS crash

### DIFF
--- a/cancerdata/genome.py
+++ b/cancerdata/genome.py
@@ -136,24 +136,37 @@ def find_gene_name_from_ensembl_transcript_id(transcript_id: str) -> str | None:
 
 
 def _best_canonical_cds_length(gene) -> int:
-    lengths = [
-        len(t.coding_sequence)
-        for t in gene.transcripts
-        if t.is_protein_coding and t.contains_start_codon
-    ]
+    lengths = []
+    for t in gene.transcripts:
+        if not (t.is_protein_coding and t.contains_start_codon):
+            continue
+        # A protein-coding transcript can still lack an assembled coding sequence when
+        # only the GTF is installed (no cDNA FASTA) — len(None) would crash resolution.
+        cds = getattr(t, "coding_sequence", None)
+        if cds is not None:
+            lengths.append(len(cds))
     return max(lengths, default=0)
+
+
+#: Score for a gene whose transcripts carry no TSL information at all. Ensembl TSL is
+#: 1 (best)..5 (worst); -min(TSL) lands in [-5, -1], so a sortable score strictly
+#: below -5 makes "no support info" rank *below* even a TSL-5 transcript (rather than
+#: above a clean TSL-1 one, which `0` did — a real mis-ranking in pick_best_gene).
+_NO_TSL_SCORE = -6
 
 
 def _best_transcript_support(gene) -> int:
     """Quality of the gene's best transcript as a sortable score (higher better):
-    Ensembl TSL is 1 (best)..5 (worst), inverted to -min(TSL); 0 if no TSL."""
+    Ensembl TSL is 1 (best)..5 (worst), inverted to ``-min(TSL)``; transcripts with
+    no/NA TSL are skipped, and a gene with *no* TSL info scores :data:`_NO_TSL_SCORE`
+    (worst), so an un-assessed gene never outranks an assessed one."""
     levels = []
     for t in gene.transcripts:
         try:
             levels.append(int(getattr(t, "support_level", None)))
         except (TypeError, ValueError):
             continue
-    return -min(levels) if levels else 0
+    return -min(levels) if levels else _NO_TSL_SCORE
 
 
 def pick_best_gene(genes):

--- a/tests/test_genome_pick.py
+++ b/tests/test_genome_pick.py
@@ -1,0 +1,64 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for the pure gene-ranking helpers (no Ensembl release needed)."""
+
+import pytest
+
+from cancerdata import genome as gx
+
+
+class _Tx:
+    def __init__(self, *, support_level=None, is_protein_coding=True, start=True, cds="A" * 30):
+        self.support_level = support_level
+        self.is_protein_coding = is_protein_coding
+        self.contains_start_codon = start
+        self.coding_sequence = cds
+
+
+class _Gene:
+    def __init__(self, name, transcripts, biotype="protein_coding"):
+        self.name = name
+        self.transcripts = transcripts
+        self.biotype = biotype
+
+
+def test_best_transcript_support_prefers_lower_tsl():
+    assert gx._best_transcript_support(_Gene("G", [_Tx(support_level=1)])) == -1
+    assert gx._best_transcript_support(_Gene("G", [_Tx(support_level=5)])) == -5
+    # best (lowest) TSL wins among several
+    assert (
+        gx._best_transcript_support(_Gene("G", [_Tx(support_level=3), _Tx(support_level=1)])) == -1
+    )
+
+
+def test_no_tsl_info_ranks_worst_not_zero():
+    # The bug: a gene with no TSL info used to score 0 and outrank a clean TSL-1 gene.
+    no_info = _Gene("G", [_Tx(support_level=None), _Tx(support_level="NA")])
+    assert gx._best_transcript_support(no_info) == gx._NO_TSL_SCORE
+    assert gx._NO_TSL_SCORE < -5  # below even a TSL-5 transcript
+
+
+def test_pick_best_gene_assessed_beats_unassessed():
+    good = _Gene("ASSESSED", [_Tx(support_level=1)])
+    unknown = _Gene("UNKNOWN", [_Tx(support_level=None)])
+    assert gx.pick_best_gene([unknown, good]) is good
+    assert gx.pick_best_gene([good, unknown]) is good
+
+
+def test_best_cds_length_tolerates_missing_coding_sequence():
+    # A protein-coding transcript with no assembled CDS (GTF-only install) must not crash.
+    g = _Gene("G", [_Tx(cds=None), _Tx(cds="A" * 60)])
+    assert gx._best_canonical_cds_length(g) == 60
+    # all-missing -> 0, not a TypeError
+    assert gx._best_canonical_cds_length(_Gene("G", [_Tx(cds=None)])) == 0
+
+
+def test_pick_best_gene_single_and_empty():
+    only = _Gene("X", [_Tx(support_level=1)])
+    assert gx.pick_best_gene([only]) is only
+    with pytest.raises(ValueError, match="at least one gene"):
+        gx.pick_best_gene([])


### PR DESCRIPTION
Two real bugs in `pick_best_gene`'s tie-breaks (`genome.py`), both triggered when a symbol maps to several genes:

- **`_best_transcript_support`** returned `0` for a gene with no TSL info — *greater* than any real `-min(TSL)` in `[-5,-1]`, so an un-assessed gene outranked a clean TSL-1 one under reverse-sort. No-info now scores `_NO_TSL_SCORE` (-6), below even TSL-5.
- **`_best_canonical_cds_length`** called `len(t.coding_sequence)`; `coding_sequence` is `None` on a GTF-only install (no cDNA FASTA) → `len(None)` crashed resolution. Now guarded.

New pure-function unit tests (no Ensembl release required) cover both ranking paths and the missing-CDS case.