### PR TITLE
Harden proteoform/coverage/peptides core: robustness + dedup

### DIFF
--- a/cancerdata/coverage.py
+++ b/cancerdata/coverage.py
@@ -51,8 +51,13 @@ def _panel_ids(gene_ids: Iterable[str] | None) -> set[str]:
     return {str(g).split(".")[0] for g in ids}
 
 
+#: Identity columns a (possibly proteoform-collapsed) antigen frame may carry;
+#: everything else is a per-sample expression column.
+_ANTIGEN_ID_COLS = ("Ensembl_Gene_ID", "Symbol", "proteoform_id")
+
+
 def _hit_matrix(cancer_type, *, threshold_tpm: float, gene_ids, proteoform: bool = True):
-    """``(panel rows of the matrix, sample columns, gene×sample boolean hit matrix)``
+    """``(panel rows, sample columns, gene×sample boolean hit matrix, id columns)``
     where a hit is clean TPM >= ``threshold_tpm`` for one antigen in one patient.
 
     With ``proteoform=True`` (default), identical-protein paralogs in the panel
@@ -69,10 +74,10 @@ def _hit_matrix(cancer_type, *, threshold_tpm: float, gene_ids, proteoform: bool
         from .proteoforms import collapse_to_proteoforms
 
         sub = collapse_to_proteoforms(sub).reset_index(drop=True)
-    id_cols = [c for c in ("Ensembl_Gene_ID", "Symbol", "proteoform_id") if c in sub.columns]
+    id_cols = [c for c in _ANTIGEN_ID_COLS if c in sub.columns]
     samples = [c for c in sub.columns if c not in id_cols]
     hits = sub[samples].to_numpy(dtype=float) >= float(threshold_tpm)
-    return sub, samples, hits
+    return sub, samples, hits, id_cols
 
 
 def cta_patient_fractions(
@@ -89,11 +94,10 @@ def cta_patient_fractions(
     ``n_patients_expressing``, ``n_patients`` — sorted by prevalence. The default
     gene panel is the expressed CTA set; identical-protein paralogs are summed to
     one antigen (``proteoform=True``)."""
-    sub, samples, hits = _hit_matrix(
+    sub, samples, hits, id_cols = _hit_matrix(
         cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
     )
     n = len(samples)
-    id_cols = [c for c in ("Ensembl_Gene_ID", "Symbol", "proteoform_id") if c in sub.columns]
     out = sub[id_cols].copy()
     counts = hits.sum(axis=1)
     out["n_patients_expressing"] = counts
@@ -114,7 +118,7 @@ def addressable_fraction(
     patients, which the per-gene fractions can't be summed into). Identical-protein
     paralogs are summed to one antigen (``proteoform=True``). 0.0 for an empty
     cohort/panel."""
-    _, samples, hits = _hit_matrix(
+    _, samples, hits, _ = _hit_matrix(
         cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
     )
     if not samples or hits.size == 0:
@@ -141,7 +145,7 @@ def greedy_coverage(
     cumulative fraction is the coverage curve; its last value equals
     :func:`addressable_fraction` once the panel is exhausted (unless ``max_genes``
     truncates it first). Ties are broken by total prevalence (deterministic)."""
-    sub, samples, hits = _hit_matrix(
+    sub, samples, hits, _ = _hit_matrix(
         cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
     )
     n = len(samples)
@@ -165,13 +169,14 @@ def greedy_coverage(
     limit = max_genes if max_genes is not None else len(sub)
 
     while remaining and len(rows) < limit:
-        best_g, best_new = None, 0
-        for g in remaining:
+        # Pick the gene covering the most still-uncovered patients; ties by total
+        # prevalence, then by smallest row index — fully deterministic (sorted scan +
+        # strict tuple comparison), independent of set-iteration order.
+        best_g, best_new, best_prev = None, 0, -1
+        for g in sorted(remaining):
             new = int(np.count_nonzero(hits[g] & ~covered))
-            if new > best_new or (
-                new == best_new and best_g is not None and total_prev[g] > total_prev[best_g]
-            ):
-                best_g, best_new = g, new
+            if (new, total_prev[g]) > (best_new, best_prev):
+                best_g, best_new, best_prev = g, new, int(total_prev[g])
         if best_g is None or best_new == 0:
             break  # no remaining gene covers a new patient
         covered |= hits[best_g]
@@ -204,12 +209,32 @@ def mean_antigens_per_patient(
     patient presents, not just whether ≥1). Equals the sum over antigens of their
     per-patient prevalence; identical-protein paralogs count once
     (``proteoform=True``). 0.0 for an empty cohort/panel."""
-    _, samples, hits = _hit_matrix(
+    _, samples, hits, _ = _hit_matrix(
         cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
     )
     if not samples or hits.size == 0:
         return 0.0
     return float(hits.sum(axis=0).mean())
+
+
+def _scalar_by_cohort(
+    scalar_fn, name, cohorts, *, threshold_tpm, gene_ids, proteoform
+) -> pd.Series:
+    """Map a per-cohort scalar coverage function over cohorts → ``Series``. When
+    ``cohorts`` is ``None`` every cohort with a *cached* per-sample matrix is used
+    (uncached ones are skipped, never fetched implicitly); an explicit ``cohorts``
+    list is taken as-is."""
+    from . import source_matrices
+
+    codes = list(cohorts) if cohorts is not None else source_matrices.available_cohorts()
+    out: dict[str, float] = {}
+    for code in codes:
+        if cohorts is None and not source_matrices.is_cached(code):
+            continue
+        out[str(code)] = scalar_fn(
+            code, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
+        )
+    return pd.Series(out, name=name)
 
 
 def mean_antigens_per_patient_by_cohort(
@@ -220,20 +245,16 @@ def mean_antigens_per_patient_by_cohort(
     proteoform: bool = True,
 ) -> pd.Series:
     """``{cohort code -> mean antigens per patient}`` over the cohorts that have a
-    per-sample matrix (default: all cached ones). Mirrors
-    :func:`addressable_fraction_by_cohort`: skips uncached cohorts rather than
-    fetching every one implicitly."""
-    from . import source_matrices
-
-    codes = list(cohorts) if cohorts is not None else source_matrices.available_cohorts()
-    out: dict[str, float] = {}
-    for code in codes:
-        if cohorts is None and not source_matrices.is_cached(code):
-            continue
-        out[str(code)] = mean_antigens_per_patient(
-            code, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
-        )
-    return pd.Series(out, name="mean_antigens_per_patient")
+    cached per-sample matrix (default: all cached ones); uncached cohorts are skipped
+    rather than fetched."""
+    return _scalar_by_cohort(
+        mean_antigens_per_patient,
+        "mean_antigens_per_patient",
+        cohorts,
+        threshold_tpm=threshold_tpm,
+        gene_ids=gene_ids,
+        proteoform=proteoform,
+    )
 
 
 def addressable_fraction_by_cohort(
@@ -243,20 +264,17 @@ def addressable_fraction_by_cohort(
     gene_ids: Iterable[str] | None = None,
     proteoform: bool = True,
 ) -> pd.Series:
-    """``{cohort code -> addressable fraction}`` over the cohorts that have a
-    per-sample matrix (default: all of them). Skips cohorts whose matrix isn't
-    available rather than fetching every one implicitly."""
-    from . import source_matrices
-
-    codes = list(cohorts) if cohorts is not None else source_matrices.available_cohorts()
-    out: dict[str, float] = {}
-    for code in codes:
-        if cohorts is None and not source_matrices.is_cached(code):
-            continue
-        out[str(code)] = addressable_fraction(
-            code, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
-        )
-    return pd.Series(out, name="addressable_fraction")
+    """``{cohort code -> addressable fraction}`` over the cohorts that have a cached
+    per-sample matrix (default: all cached ones); uncached cohorts are skipped rather
+    than fetched."""
+    return _scalar_by_cohort(
+        addressable_fraction,
+        "addressable_fraction",
+        cohorts,
+        threshold_tpm=threshold_tpm,
+        gene_ids=gene_ids,
+        proteoform=proteoform,
+    )
 
 
 def cta_id_to_name() -> dict[str, str]:

--- a/cancerdata/peptides.py
+++ b/cancerdata/peptides.py
@@ -33,7 +33,7 @@ protein sequences (``pyensembl install --release N --species homo_sapiens``).
 
 from __future__ import annotations
 
-from functools import lru_cache
+import hashlib
 from pathlib import Path
 
 import pandas as pd
@@ -43,6 +43,15 @@ from .genome import find_gene_id_by_name, genomes, strip_version
 
 #: 9 = the canonical MHC-I epitope length.
 DEFAULT_K: int = 9
+
+#: A complete human proteome resolves ~19–20k protein-coding genes. Far fewer means
+#: the cDNA/protein FASTA is missing or partial — refuse to build (and cache) a
+#: degenerate background that would inflate every CTA's "specific" count.
+_MIN_PROTEOME_GENES: int = 10_000
+
+#: In-process memo of the per-CTA counts table, keyed by (k, release, CTA-set
+#: fingerprint). Holds the canonical frame; public accessors return a copy.
+_COUNTS_CACHE: dict[tuple[int, int, str], pd.DataFrame] = {}
 
 
 def _derived_cache_dir() -> Path:
@@ -94,25 +103,26 @@ def _longest_protein_per_gene(genome, k: int) -> dict[str, str]:
     return longest
 
 
-@lru_cache(maxsize=4)
-def cta_specific_9mer_counts(*, k: int = DEFAULT_K, refresh: bool = False) -> pd.DataFrame:
-    """Per filtered CTA, its distinct-9-mer count and how many are CTA-specific.
+def _cta_set_fingerprint() -> str:
+    """Short hash of the filtered + unfiltered CTA id sets — the inputs that define
+    the output rows and the background. Embedded in the cache key so a curation edit
+    (a CTA added/removed) invalidates a stale cache *within* the same Ensembl release,
+    not only across releases."""
+    payload = "F:" + ",".join(sorted(strip_version(g) for g in CTA_gene_ids()))
+    payload += "|U:" + ",".join(sorted(strip_version(g) for g in CTA_unfiltered_gene_ids()))
+    return hashlib.sha1(payload.encode()).hexdigest()[:10]
 
-    Columns: ``Ensembl_Gene_ID`` (unversioned), ``Symbol``, ``n_9mers`` (distinct
-    9-mers in its longest protein), ``n_specific_9mers`` (those absent from every
-    non-CTA protein). Cached to a per-release CSV under the cancerdata cache; pass
-    ``refresh=True`` to rebuild. Raises if no usable Ensembl release is installed."""
-    genome = _usable_genome()
-    if genome is None:
-        raise RuntimeError(
-            "no usable human Ensembl release with protein sequences installed — run "
-            "`pyensembl install --release 111 --species homo_sapiens`"
-        )
-    cache = _derived_cache_dir() / f"cta_specific_{k}mers_r{genome.release}.csv"
-    if cache.exists() and not refresh:
-        return pd.read_csv(cache)
 
+def _build_counts(genome, k: int) -> pd.DataFrame:
+    """Compute the per-CTA specific-9-mer table from one genome (no caching)."""
     longest = _longest_protein_per_gene(genome, k)
+    if len(longest) < _MIN_PROTEOME_GENES:
+        raise RuntimeError(
+            f"only {len(longest)} protein sequences resolved from Ensembl release "
+            f"{genome.release} — the protein FASTA looks incomplete, so the CTA-specific "
+            "background would be wrong. Reinstall with "
+            f"`pyensembl install --release {genome.release} --species homo_sapiens`."
+        )
     cta_filtered = {strip_version(g) for g in CTA_gene_ids()}
     cta_universe = {strip_version(g) for g in CTA_unfiltered_gene_ids()}
 
@@ -135,19 +145,56 @@ def cta_specific_9mer_counts(*, k: int = DEFAULT_K, refresh: bool = False) -> pd
                 "n_specific_9mers": sum(1 for x in km if x not in background),
             }
         )
-    df = pd.DataFrame(rows, columns=["Ensembl_Gene_ID", "Symbol", "n_9mers", "n_specific_9mers"])
-    df.to_csv(cache, index=False)
-    return df
+    return pd.DataFrame(rows, columns=["Ensembl_Gene_ID", "Symbol", "n_9mers", "n_specific_9mers"])
 
 
-@lru_cache(maxsize=1)
-def cta_specific_9mer_weights(*, k: int = DEFAULT_K) -> dict[str, int]:
-    """``{CTA symbol -> n_specific_9mers}`` from :func:`cta_specific_9mer_counts`.
+def cta_specific_9mer_counts(*, k: int = DEFAULT_K, refresh: bool = False) -> pd.DataFrame:
+    """Per filtered CTA, its distinct-9-mer count and how many are CTA-specific.
 
-    Identical-protein paralogs (proteoforms) share a sequence, hence an identical
-    specific-9-mer count, so the per-symbol weight is the proteoform's weight."""
+    Columns: ``Ensembl_Gene_ID`` (unversioned), ``Symbol``, ``n_9mers`` (distinct
+    9-mers in its longest protein), ``n_specific_9mers`` (those absent from every
+    non-CTA protein). Cached to a CSV keyed by Ensembl release **and** a fingerprint
+    of the CTA gene set, then memoized in-process; each call returns a fresh copy.
+    Pass ``refresh=True`` to drop both caches and rebuild. Raises if no usable Ensembl
+    release is installed or its proteome looks incomplete."""
+    genome = _usable_genome()
+    if genome is None:
+        raise RuntimeError(
+            "no usable human Ensembl release with protein sequences installed — run "
+            "`pyensembl install --release 111 --species homo_sapiens`"
+        )
+    fp = _cta_set_fingerprint()
+    key = (k, genome.release, fp)
+    cache = _derived_cache_dir() / f"cta_specific_{k}mers_r{genome.release}_{fp}.csv"
+    if refresh:
+        _COUNTS_CACHE.pop(key, None)
+        cache.unlink(missing_ok=True)
+    if key not in _COUNTS_CACHE:
+        if cache.exists():
+            _COUNTS_CACHE[key] = pd.read_csv(cache)
+        else:
+            df = _build_counts(genome, k)
+            df.to_csv(cache, index=False)
+            _COUNTS_CACHE[key] = df
+    return _COUNTS_CACHE[key].copy()
+
+
+def cta_specific_9mer_weights(*, k: int = DEFAULT_K, by: str = "ensembl_gene_id") -> dict[str, int]:
+    """``{key -> n_specific_9mers}`` from :func:`cta_specific_9mer_counts`.
+
+    ``by="ensembl_gene_id"`` (default) keys by unversioned Ensembl gene id — the safe
+    join key, since a proteoform-collapsed row's ``Symbol`` is a slash-joined label
+    that no per-gene symbol key matches (see :func:`cta_specific_9mer_load`).
+    ``by="symbol"`` keys by gene symbol for display. Identical-protein paralogs share
+    a sequence, hence one count, so a canonical member's id carries the group's weight."""
     df = cta_specific_9mer_counts(k=k)
-    return {str(s): int(n) for s, n in zip(df["Symbol"], df["n_specific_9mers"])}
+    if by == "ensembl_gene_id":
+        keys = df["Ensembl_Gene_ID"]
+    elif by == "symbol":
+        keys = df["Symbol"]
+    else:
+        raise ValueError("by must be 'ensembl_gene_id' or 'symbol'")
+    return {str(key): int(n) for key, n in zip(keys, df["n_specific_9mers"])}
 
 
 def cta_specific_9mer_load(
@@ -172,10 +219,7 @@ def cta_specific_9mer_load(
     pf = cta_patient_fractions(cancer_type, threshold_tpm=threshold_tpm)
     if pf.empty:
         return 0.0
-    df = cta_specific_9mer_counts(k=k)
-    weight_by_id = {
-        strip_version(g): int(n) for g, n in zip(df["Ensembl_Gene_ID"], df["n_specific_9mers"])
-    }
+    weight_by_id = cta_specific_9mer_weights(k=k, by="ensembl_gene_id")
     w = pf["Ensembl_Gene_ID"].astype(str).map(lambda g: weight_by_id.get(strip_version(g), 0))
     return float((pf["fraction_expressing"] * w).sum())
 

--- a/cancerdata/proteoforms.py
+++ b/cancerdata/proteoforms.py
@@ -115,12 +115,12 @@ def proteoform_symbol_map(*, scope: str = "cta") -> dict[str, tuple[str, ...]]:
     return out
 
 
-@lru_cache(maxsize=1)
-def _member_to_label() -> dict[str, str]:
+@lru_cache(maxsize=len(_DATASET_BY_SCOPE))
+def _member_to_label(scope: str) -> dict[str, str]:
     """Lookup keyed by BOTH the unversioned gene ID and the uppercased symbol ->
-    proteoform label. The two key spaces don't collide (``ENSG…`` vs symbols), so
-    one flat dict serves both ``proteoform_for_gene`` lookup paths."""
-    df = _proteoform_frame("cta")
+    proteoform label, for one scope. The two key spaces don't collide (``ENSG…`` vs
+    symbols), so one flat dict serves both ``proteoform_for_gene`` lookup paths."""
+    df = _proteoform_frame(scope)
     out: dict[str, str] = {}
     for _, row in df.iterrows():
         label = str(row[_LABEL_COLUMN])
@@ -129,15 +129,12 @@ def _member_to_label() -> dict[str, str]:
     return out
 
 
-def proteoform_for_gene(gene: str) -> str | None:
+def proteoform_for_gene(gene: str, *, scope: str = "cta") -> str | None:
     """Proteoform label for a gene given by Ensembl ID (version-insensitive) or
-    symbol (case-insensitive). ``None`` if the gene isn't in any group."""
-    key = str(gene).split(".")[0]
-    mapping = _member_to_label()
-    label = mapping.get(key)
-    if label is None:
-        label = mapping.get(str(gene).upper())
-    return label
+    symbol (case-insensitive), within ``scope`` (see :func:`proteoform_groups`).
+    ``None`` if the gene isn't in any group in that scope."""
+    mapping = _member_to_label(scope)
+    return mapping.get(str(gene).split(".")[0]) or mapping.get(str(gene).upper())
 
 
 def gene_to_proteoform() -> dict[str, str]:
@@ -162,7 +159,17 @@ def gene_to_proteoform_id(genes, *, symbols=None, scope: str = "cta") -> dict[st
     pf = _proteoform_frame(scope)
     member_map = dict(zip(pf[_GENE_ID_COLUMN].astype(str), pf[_LABEL_COLUMN].astype(str)))
     genes = [str(g).split(".")[0] for g in genes]
-    syms = list(symbols) if symbols is not None else [None] * len(genes)
+    if symbols is None:
+        syms: list = [None] * len(genes)
+    else:
+        syms = list(symbols)
+        if len(syms) != len(genes):
+            # zip() would silently truncate to the shorter and drop genes from the
+            # output entirely — fail loudly instead.
+            raise ValueError(
+                f"symbols has length {len(syms)} but genes has length {len(genes)}; "
+                "they must be parallel"
+            )
     out: dict[str, str] = {}
     for gid, sym in zip(genes, syms):
         out[gid] = member_map.get(gid) or (str(sym) if sym is not None else gid)

--- a/tests/test_peptides.py
+++ b/tests/test_peptides.py
@@ -63,11 +63,10 @@ def fake_proteome(monkeypatch, tmp_path):
     monkeypatch.setattr(peptides, "CTA_gene_ids", lambda: ["ENSG_CTA"])
     monkeypatch.setattr(peptides, "CTA_unfiltered_gene_ids", lambda: ["ENSG_CTA"])
     monkeypatch.setattr(peptides, "CTA_gene_id_to_name", lambda: {"ENSG_CTA": "CTAX"})
-    peptides.cta_specific_9mer_counts.cache_clear()
-    peptides.cta_specific_9mer_weights.cache_clear()
+    monkeypatch.setattr(peptides, "_MIN_PROTEOME_GENES", 1)  # tiny fake proteome
+    peptides._COUNTS_CACHE.clear()
     yield
-    peptides.cta_specific_9mer_counts.cache_clear()
-    peptides.cta_specific_9mer_weights.cache_clear()
+    peptides._COUNTS_CACHE.clear()
 
 
 def test_specific_9mer_counts_subtracts_background(fake_proteome):
@@ -78,13 +77,34 @@ def test_specific_9mer_counts_subtracts_background(fake_proteome):
     assert row["n_specific_9mers"] == 3  # CCC also in background -> excluded
 
 
-def test_specific_9mer_counts_caches(fake_proteome, tmp_path):
+def test_specific_9mer_counts_caches_with_fingerprint(fake_proteome, tmp_path):
     peptides.cta_specific_9mer_counts(k=3)
-    assert (tmp_path / "cta_specific_3mers_r999.csv").exists()
+    # filename is keyed by release AND a CTA-set fingerprint
+    cached = list(tmp_path.glob("cta_specific_3mers_r999_*.csv"))
+    assert len(cached) == 1
 
 
-def test_specific_9mer_weights(fake_proteome):
-    assert peptides.cta_specific_9mer_weights(k=3) == {"CTAX": 3}
+def test_specific_9mer_counts_returns_fresh_copy(fake_proteome):
+    a = peptides.cta_specific_9mer_counts(k=3)
+    a.loc[0, "n_specific_9mers"] = -999  # mutating the result must not corrupt the cache
+    b = peptides.cta_specific_9mer_counts(k=3)
+    assert b.loc[0, "n_specific_9mers"] == 3
+
+
+def test_specific_9mer_counts_refresh_rebuilds(fake_proteome, tmp_path):
+    peptides.cta_specific_9mer_counts(k=3)
+    # corrupt the on-disk cache; refresh=True must drop it and rebuild correctly
+    (next(tmp_path.glob("cta_specific_3mers_r999_*.csv"))).write_text("garbage\n")
+    peptides._COUNTS_CACHE.clear()
+    df = peptides.cta_specific_9mer_counts(k=3, refresh=True)
+    assert int(df.loc[0, "n_specific_9mers"]) == 3
+
+
+def test_specific_9mer_weights_keyed_by_ensembl_id_by_default(fake_proteome):
+    assert peptides.cta_specific_9mer_weights(k=3) == {"ENSG_CTA": 3}
+    assert peptides.cta_specific_9mer_weights(k=3, by="symbol") == {"CTAX": 3}
+    with pytest.raises(ValueError, match="by must be"):
+        peptides.cta_specific_9mer_weights(k=3, by="nonsense")
 
 
 def test_specific_9mer_load_joins_on_ensembl_id_not_symbol(fake_proteome, monkeypatch):

--- a/tests/test_proteoforms.py
+++ b/tests/test_proteoforms.py
@@ -197,6 +197,14 @@ def test_gene_to_proteoform_id_is_total():
     assert m2["ENSG_Y"] == "ENSG_Y"
 
 
+def test_gene_to_proteoform_id_rejects_mismatched_symbols():
+    # A short `symbols` would zip-truncate and silently drop genes — must raise.
+    from cancerdata.proteoforms import gene_to_proteoform_id
+
+    with pytest.raises(ValueError, match="parallel"):
+        gene_to_proteoform_id(["ENSG_A", "ENSG_B", "ENSG_C"], symbols=["A"])
+
+
 def test_collapse_to_proteoforms_keeps_ensembl_id_real():
     # The reusable collapse entry point: ENSG column stays a real Ensembl id, the
     # antigen identity is in proteoform_id.


### PR DESCRIPTION
Audit-driven hardening of the antigen/proteoform compute core. No behavioural
change on valid inputs (real LUAD 9-mer load unchanged at 1286.6); the fixes
remove silent-wrongness and crash paths and de-duplicate.

## coverage.py
- **Deterministic greedy tie-break** — `greedy_coverage` scanned a `set` and broke
  ties only on strict `>` prevalence, so equal-prevalence ties resolved by
  set-iteration order. Now: sorted scan + strict tuple comparison
  `(coverage, prevalence, -index)` → fully reproducible.
- **`_hit_matrix` returns `id_cols`** — removes the duplicated id-column derivation
  in `cta_patient_fractions`; one `_ANTIGEN_ID_COLS` constant.
- **Dedup** — `addressable_fraction_by_cohort` / `mean_antigens_per_patient_by_cohort`
  collapse into one `_scalar_by_cohort` helper; fixed the former's docstring (said
  "all of them"; it skips uncached cohorts).

## peptides.py
- **Cache no longer goes stale on curation edits** — the CSV cache key was the Ensembl
  release alone, so adding/removing a CTA returned the *old* table. Now keyed by
  release **and** a fingerprint of the CTA gene set.
- **No shared mutable frame** — `cta_specific_9mer_counts` was `@lru_cache`d and handed
  the same DataFrame to every caller (one in-place mutation corrupted all). Now memoized
  in a dict and returned as a fresh `.copy()`; `refresh=True` drops the memo **and** the
  on-disk CSV.
- **Partial-install guard** — `_build_counts` refuses to build/cache when <10k proteins
  resolve (GTF-only / partial FASTA), which would otherwise inflate every CTA's
  "specific" count silently.
- **`cta_specific_9mer_weights` is ENSG-keyed by default** (the safe join key); a
  proteoform's slash-joined `Symbol` matches no per-gene key. `by="symbol"` for display.

## proteoforms.py
- **`gene_to_proteoform_id` validates `symbols` length** — a short `symbols` would
  `zip`-truncate and silently drop genes; now raises.
- **`proteoform_for_gene(scope=…)`** — was hardcoded to `"cta"`, so genome-scope genes
  wrongly returned `None`.

## Tests
353 pass. New: deterministic ranking already covered; peptides fresh-copy / refresh /
fingerprint-cache / ENSG-keyed weights; proteoform mismatched-length guard.