### PR TITLE
Harden expression core: find_column priority + one id-column constant

### DIFF
--- a/cancerdata/_build.py
+++ b/cancerdata/_build.py
@@ -25,7 +25,7 @@ from collections.abc import Iterable, Mapping
 import numpy as np
 import pandas as pd
 
-_ID_COLS = ("Ensembl_Gene_ID", "Symbol", "proteoform_id")
+from .expression_engine import ID_COLUMNS as _ID_COLS
 
 #: Per-gene cohort percentile breakpoints — dense in the actionable upper tail so
 #: a consumer can place a sample's gene as a percentile rank within the cohort

--- a/cancerdata/coverage.py
+++ b/cancerdata/coverage.py
@@ -38,6 +38,7 @@ import pandas as pd
 
 from .cta import CTA_gene_id_to_name, CTA_gene_ids
 from .expression import per_sample_expression
+from .expression_engine import ID_COLUMNS as _ANTIGEN_ID_COLS
 
 #: Default clean-TPM threshold for "expressed in a patient". 10 TPM is a common
 #: cut for a confidently-expressed transcript.
@@ -49,11 +50,6 @@ _BASE = ["Ensembl_Gene_ID", "Symbol"]
 def _panel_ids(gene_ids: Iterable[str] | None) -> set[str]:
     ids = set(gene_ids) if gene_ids is not None else set(CTA_gene_ids())
     return {str(g).split(".")[0] for g in ids}
-
-
-#: Identity columns a (possibly proteoform-collapsed) antigen frame may carry;
-#: everything else is a per-sample expression column.
-_ANTIGEN_ID_COLS = ("Ensembl_Gene_ID", "Symbol", "proteoform_id")
 
 
 def _hit_matrix(cancer_type, *, threshold_tpm: float, gene_ids, proteoform: bool = True):

--- a/cancerdata/expression_engine.py
+++ b/cancerdata/expression_engine.py
@@ -32,6 +32,15 @@ from functools import lru_cache
 
 import pandas as pd
 
+#: Canonical identity columns of a cancerdata expression frame. Everything else is a
+#: per-sample / per-representative value column. One definition shared by every
+#: "value columns = all columns except the id columns" consumer (the build
+#: generators, the normalization helpers, the coverage hit-matrix) so a
+#: proteoform-collapsed frame's ``proteoform_id`` label is never mistaken for a
+#: sample. (The *named*-TPM rule for curated frames is :func:`is_expression_value_col`,
+#: a deliberately distinct concept.)
+ID_COLUMNS = ("Ensembl_Gene_ID", "Symbol", "proteoform_id")
+
 _DEFAULT_TX_COLUMN_CANDIDATES = (
     "transcript",
     "transcript_id",
@@ -45,12 +54,16 @@ _DEFAULT_TPM_COLUMN_CANDIDATES = ("tpm",)
 
 
 def find_column(df: pd.DataFrame, candidates, column_name: str) -> str:
-    """First column of ``df`` whose lowercase name is in ``candidates`` — absorbs
-    naming variation across upstream quantifiers (``transcript_id`` vs ``tx`` …).
-    Raises ``ValueError`` listing the available columns if nothing matches."""
-    cand = {c.lower() for c in candidates}
-    for col in df.columns:
-        if str(col).lower() in cand:
+    """The column of ``df`` matching the highest-priority ``candidates`` entry —
+    absorbs naming variation across upstream quantifiers (``transcript_id`` vs ``tx``
+    …). ``candidates`` is consulted **in order**, so a frame carrying both
+    ``transcript_id`` and ``name`` resolves by candidate priority, not by column
+    order. Matching is case-insensitive. Raises ``ValueError`` listing the available
+    columns if nothing matches."""
+    by_lower = {str(col).lower(): col for col in df.columns}
+    for cand in candidates:
+        col = by_lower.get(cand.lower())
+        if col is not None:
             return col
     raise ValueError(
         f"no column for {column_name} in expression data; available: {list(df.columns)}"

--- a/cancerdata/normalization.py
+++ b/cancerdata/normalization.py
@@ -30,14 +30,13 @@ import numpy as np
 import pandas as pd
 
 from . import gene_families
-
-_ID_COLUMNS = ("Ensembl_Gene_ID", "Symbol")
+from .expression_engine import ID_COLUMNS
 
 
 def _value_cols(df: pd.DataFrame, value_cols=None) -> list[str]:
     if value_cols is not None:
         return list(value_cols)
-    return [c for c in df.columns if c not in _ID_COLUMNS]
+    return [c for c in df.columns if c not in ID_COLUMNS]
 
 
 def _unversioned(series: pd.Series) -> pd.Series:

--- a/tests/test_expression_engine.py
+++ b/tests/test_expression_engine.py
@@ -37,6 +37,16 @@ def test_find_column_absorbs_naming():
         ee.find_column(df, ["nope"], "missing")
 
 
+def test_find_column_respects_candidate_priority():
+    # Frame carries both a transcript id and a 'name' column; the higher-priority
+    # candidate (transcript_id) must win regardless of column order.
+    df = pd.DataFrame({"name": ["n"], "transcript_id": ["t"]})
+    assert ee.find_column(df, ["transcript_id", "name"], "tx") == "transcript_id"
+    # column order reversed -> still resolves by candidate priority, not column order
+    df2 = pd.DataFrame({"transcript_id": ["t"], "name": ["n"]})
+    assert ee.find_column(df2, ["transcript_id", "name"], "tx") == "transcript_id"
+
+
 def test_expanded_tx_map_versionless():
     m = ee.expanded_tx_map({"ENST9.3": "G"})
     assert m["ENST9.3"] == "G"

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -57,6 +57,22 @@ def test_clean_tpm_validates():
         norm.clean_tpm(vals)
 
 
+def test_value_cols_excludes_proteoform_id():
+    # A proteoform-collapsed frame carries a proteoform_id label column; the
+    # "everything-not-id" value-column rule must not treat it as a sample (it would
+    # crash/poison geomean normalization). Uses the shared ID_COLUMNS constant.
+    df = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1"],
+            "Symbol": ["GA"],
+            "proteoform_id": ["GA/GB"],
+            "s1": [3.0],
+            "s2": [4.0],
+        }
+    )
+    assert norm._value_cols(df) == ["s1", "s2"]
+
+
 def test_drop_technical_vs_filter_technical_rna():
     gt, _ = _matrix()
     df = gt.assign(s1=1.0)


### PR DESCRIPTION
## Bugs fixed

- **`find_column` ignored candidate priority** — it matched the first *df column*
  whose lowercased name was in a candidate **set**, so a frame carrying both
  `transcript_id` and `name` resolved by column order rather than priority. Now
  consults `candidates` in order (case-insensitive) and returns the highest-priority
  match.
- **`normalization._ID_COLUMNS` was missing `proteoform_id`** — `_value_cols` (which
  backs `tpm_to_housekeeping_normalized` and the other geomean helpers) would treat a
  proteoform-collapsed frame's `proteoform_id` *label* column as a sample, poisoning
  the geomean. Fixed by the consolidation below.

## Elegance: one canonical id-column constant

The "value columns = everything except the id columns" rule was defined **four**
times (`normalization`, `_build`, `coverage`, plus inline). They diverged on
`proteoform_id` (the bug above). Now one `expression_engine.ID_COLUMNS`
(`Ensembl_Gene_ID`, `Symbol`, `proteoform_id`), imported by all consumers.

The *named*-TPM rule (`is_expression_value_col`, for curated HPA-style frames with
`_raw` provenance columns) stays a **separate** concept — it correctly serves a
different frame shape (named TPM columns) than the everything-not-id rule (barcode
per-sample matrices). Not merged.

## Considered, not bugs

- `representative_cohort_samples` wide-merge "column collision" — the rep columns are
  already cohort-prefixed (`ACC_rep01`, `ADCC_rep01`), so no collision occurs.

## Tests

355 pass. New: `find_column` candidate-priority (both column orders); `_value_cols`
excludes `proteoform_id`.