### PR TITLE
Harden ID/symbol mappings: weight-join miss, dead index, one normalizer

### DIFF
--- a/cancerdata/gene_ids.py
+++ b/cancerdata/gene_ids.py
@@ -27,8 +27,16 @@ import pandas as pd
 from .load_dataset import get_data
 
 
-def _unversioned(gene_id: str) -> str:
-    return str(gene_id).split(".")[0]
+def unversioned(gene_id: str) -> str:
+    """Canonical Ensembl-id normalizer: ``ENSG00000251562.5`` → ``ENSG00000251562``,
+    stripping a single version suffix *and* surrounding whitespace (idempotent on bare
+    ids). The one definition every layer shares, so a padded/versioned id can't match
+    in one place and miss in another."""
+    return str(gene_id).split(".", 1)[0].strip()
+
+
+#: Back-compat internal alias.
+_unversioned = unversioned
 
 
 @lru_cache(maxsize=1)

--- a/cancerdata/gene_qc.py
+++ b/cancerdata/gene_qc.py
@@ -153,7 +153,9 @@ def classify_gene_qc(symbol: str | None = None, *, ensembl_id: str | None = None
     """
     family = None
     if ensembl_id:
-        family = _ensembl_id_to_family().get(str(ensembl_id).split(".")[0])
+        from .gene_ids import unversioned
+
+        family = _ensembl_id_to_family().get(unversioned(ensembl_id))
 
     raw = str(symbol or "").strip()
     upper = raw.upper()

--- a/cancerdata/genome.py
+++ b/cancerdata/genome.py
@@ -34,7 +34,7 @@ from functools import lru_cache
 
 from pyensembl.shell import collect_all_installed_ensembl_releases
 
-from .gene_ids import resolve_symbol
+from .gene_ids import resolve_symbol, unversioned
 
 #: Curated literary display aliases used as extra symbol candidates (NY-ESO-1 ↔
 #: CTAG1B, gp100 ↔ PMEL, …). Small, base-layer reference — not a full alias table.
@@ -71,8 +71,9 @@ def genomes():
 
 
 def strip_version(gene_id: str) -> str:
-    """``ENSG00000251562.5`` → ``ENSG00000251562`` (idempotent on bare ids)."""
-    return str(gene_id).split(".", 1)[0].strip()
+    """``ENSG00000251562.5`` → ``ENSG00000251562`` (idempotent on bare ids). Alias of
+    :func:`cancerdata.gene_ids.unversioned`, the one shared normalizer."""
+    return unversioned(gene_id)
 
 
 def gene_for_ensembl_id(genome, gene_id: str):
@@ -85,34 +86,50 @@ def gene_for_ensembl_id(genome, gene_id: str):
 
 
 @lru_cache(maxsize=1)
+def _index_genome():
+    """Newest installed release with a **queryable GTF** (gene/transcript tables
+    built), or ``None``. A release with sequence FASTA but no built GTF database
+    (``gene_ids()`` raises) is skipped — otherwise it would be picked as ``genomes()[0]``
+    yet yield empty indexes, silently forcing every lookup onto the slow per-release
+    fallback."""
+    for g in genomes():
+        try:
+            g.gene_ids()  # GTF probe — raises if the database isn't built
+            return g
+        except Exception:
+            continue
+    return None
+
+
+@lru_cache(maxsize=1)
 def _newest_indexes():
-    """``(gene_id->name, transcript_id->gene_name)`` from the newest installed
-    release, built once in memory (pyensembl persists its own SQLite cache)."""
+    """``(gene_id->name, transcript_id->gene_name)`` from the newest *usable* release,
+    built once in memory (pyensembl persists its own SQLite cache)."""
     gid_to_name: dict[str, str] = {}
     tid_to_gene: dict[str, str] = {}
-    gs = genomes()
-    if gs:
-        g = gs[0]
-        try:
-            for gene in g.genes():
-                gid_to_name[strip_version(gene.id)] = gene.name
-        except Exception:
-            pass
-        try:
-            for t in g.transcripts():
-                tid_to_gene[strip_version(t.id)] = t.gene_name
-        except Exception:
-            pass
+    g = _index_genome()
+    if g is not None:
+        for gene in g.genes():
+            gid_to_name[strip_version(gene.id)] = gene.name
+        for t in g.transcripts():
+            tid_to_gene[strip_version(t.id)] = t.gene_name
     return gid_to_name, tid_to_gene
 
 
+def _fallback_genomes():
+    """Installed releases other than the one already indexed (newest first) — for the
+    per-id fallback when the in-memory index misses."""
+    idx = _index_genome()
+    return [g for g in genomes() if g is not idx]
+
+
 def find_gene_name_from_ensembl_gene_id(gene_id: str) -> str | None:
-    """Gene symbol for an Ensembl gene id — newest release, then older releases."""
+    """Gene symbol for an Ensembl gene id — indexed release, then older releases."""
     gid = strip_version(gene_id)
     name = _newest_indexes()[0].get(gid)
     if name:
         return name
-    for genome in genomes()[1:]:
+    for genome in _fallback_genomes():
         gene = gene_for_ensembl_id(genome, gid)
         if gene and gene.gene_name:
             return gene.gene_name
@@ -120,12 +137,12 @@ def find_gene_name_from_ensembl_gene_id(gene_id: str) -> str | None:
 
 
 def find_gene_name_from_ensembl_transcript_id(transcript_id: str) -> str | None:
-    """Gene symbol for an Ensembl transcript id — newest release, then older."""
+    """Gene symbol for an Ensembl transcript id — indexed release, then older."""
     tid = strip_version(transcript_id)
     name = _newest_indexes()[1].get(tid)
     if name:
         return name
-    for genome in genomes()[1:]:
+    for genome in _fallback_genomes():
         try:
             t = genome.transcript_by_id(tid)
         except Exception:

--- a/cancerdata/peptides.py
+++ b/cancerdata/peptides.py
@@ -197,6 +197,30 @@ def cta_specific_9mer_weights(*, k: int = DEFAULT_K, by: str = "ensembl_gene_id"
     return {str(key): int(n) for key, n in zip(keys, df["n_specific_9mers"])}
 
 
+def _weight_by_gene_id(*, k: int = DEFAULT_K, scope: str = "cta") -> dict[str, int]:
+    """``{unversioned member gene id -> n_specific_9mers}`` covering **every** member
+    of each proteoform group, not just the ones in the counts table.
+
+    The counts table only has rows for the expressed/filtered CTA set, so a group's
+    weight lives under whichever member(s) are expressed. But a collapsed proteoform's
+    canonical id (``min`` member, :func:`cancerdata._build.sum_proteoform_tpm`) may be
+    an *un*expressed sibling absent from that table — joining on it alone silently
+    drops the group's weight (CGB3/CGB5/CGB8, CT45A2/CT45A8/CT45A9, …). Identical-
+    protein members share a sequence, hence one count, so we propagate each group's
+    weight to all its member ids; the canonical id then always resolves."""
+    from .proteoforms import proteoform_group_map
+
+    per_gene = cta_specific_9mer_weights(k=k, by="ensembl_gene_id")
+    out = dict(per_gene)
+    for members in proteoform_group_map(scope=scope).values():
+        ids = [strip_version(m) for m in members]
+        group_weight = max((per_gene.get(i, 0) for i in ids), default=0)
+        if group_weight:
+            for i in ids:
+                out.setdefault(i, group_weight)
+    return out
+
+
 def cta_specific_9mer_load(
     cancer_type, *, threshold_tpm: float = 10.0, k: int = DEFAULT_K
 ) -> float:
@@ -211,15 +235,16 @@ def cta_specific_9mer_load(
 
     The join is on the **canonical-member Ensembl gene id**, not ``Symbol``: a
     collapsed proteoform's ``Symbol`` is the slash-joined label (``CTAG1A/CTAG1B``),
-    which would never match the per-gene weight table — but identical-protein members
-    share a sequence (hence one specific-9-mer count), so the canonical member's id
-    carries the proteoform's weight."""
+    which would never match the per-gene weight table. The weight map
+    (:func:`_weight_by_gene_id`) propagates each group's count to *all* its member ids,
+    so even when the canonical (``min``) member is an unexpressed sibling absent from
+    the counts table, it still carries the proteoform's weight."""
     from .coverage import cta_patient_fractions
 
     pf = cta_patient_fractions(cancer_type, threshold_tpm=threshold_tpm)
     if pf.empty:
         return 0.0
-    weight_by_id = cta_specific_9mer_weights(k=k, by="ensembl_gene_id")
+    weight_by_id = _weight_by_gene_id(k=k)
     w = pf["Ensembl_Gene_ID"].astype(str).map(lambda g: weight_by_id.get(strip_version(g), 0))
     return float((pf["fraction_expressing"] * w).sum())
 

--- a/tests/test_gene_ids.py
+++ b/tests/test_gene_ids.py
@@ -9,6 +9,13 @@
 from cancerdata import gene_ids as g
 
 
+def test_unversioned_normalizer():
+    assert g.unversioned("ENSG00000141510.5") == "ENSG00000141510"
+    assert g.unversioned("ENSG00000141510") == "ENSG00000141510"  # idempotent on bare
+    assert g.unversioned("  ENSG00000141510.5  ") == "ENSG00000141510"  # strips whitespace
+    assert g.unversioned("ENSG00000141510") == g.unversioned(" ENSG00000141510")  # padded == bare
+
+
 def test_ensembl_id_alias_resolution():
     aliases = g.ensembl_id_aliases()
     assert aliases  # non-empty

--- a/tests/test_peptides.py
+++ b/tests/test_peptides.py
@@ -107,6 +107,26 @@ def test_specific_9mer_weights_keyed_by_ensembl_id_by_default(fake_proteome):
         peptides.cta_specific_9mer_weights(k=3, by="nonsense")
 
 
+def test_weight_propagates_to_unexpressed_canonical_member(monkeypatch):
+    # A proteoform's canonical id is min(member ids); that member can be unexpressed
+    # and absent from the per-gene counts table. The group's weight must still reach
+    # it (members share a sequence -> one count), else the load silently drops it.
+    import cancerdata.proteoforms as pmod
+
+    monkeypatch.setattr(
+        peptides,
+        "cta_specific_9mer_weights",
+        lambda *, k, by="ensembl_gene_id": {"ENSG_EXPRESSED": 7},  # only the expressed member
+    )
+    monkeypatch.setattr(
+        pmod, "proteoform_group_map", lambda *, scope="cta": {"A/B": ("ENSG_AAA", "ENSG_EXPRESSED")}
+    )
+    wbi = peptides._weight_by_gene_id(k=3)
+    # canonical = min(members) = ENSG_AAA, absent from the counts table, now carries 7
+    assert wbi["ENSG_AAA"] == 7
+    assert wbi["ENSG_EXPRESSED"] == 7
+
+
 def test_specific_9mer_load_joins_on_ensembl_id_not_symbol(fake_proteome, monkeypatch):
     # A collapsed proteoform's Symbol is the slash-joined label, which never matches
     # the per-gene weight table — the load must join on the canonical-member ENSG.


### PR DESCRIPTION
Data-driven audit of the ID/symbol join keys (ran code against the real
registries + cached LUAD/MM/SKCM matrices). One real correctness bug, one
perf/robustness bug, one normalizer inconsistency. The rest of the mapping layer
(CTA id↔name bijection, proteoform registry integrity, alias table, symbol→id
determinism) was verified **correct**.

## 1. Correctness: proteoform 9-mer weight silently zeroed
`cta_specific_9mer_load` joined per-patient antigens to 9-mer weights on the
**canonical-member ENSG** (`min` of the group). But the per-gene counts table only
has rows for *expressed/filtered* CTAs, and `min` can be an **unexpressed** sibling
absent from it → `.get(id, 0)` returned 0, dropping the group's real weight.
Confirmed on `CGB3/CGB5/CGB8` (lost 31) and `CT45A2/CT45A8/CT45A9` (lost 33) in
every cached cohort.

Fix: new `_weight_by_gene_id` propagates each group's (shared) count to **all** its
member ids via `proteoform_group_map`, so whichever member is canonical resolves.
`cta_specific_9mer_load('LUAD')` **1286.57 → 1287.25** (the true value).

## 2. Perf: the in-memory id→name index was dead
`_newest_indexes` built from `genomes()[0]`. When the newest installed release has
sequence FASTA but no built GTF (`gene_ids()` raises — a common state), the
`try/except: pass` left **both indexes empty**, silently forcing every
`find_gene_name_from_ensembl_*` onto the per-release SQLite fallback (~0.84 ms each;
minutes for `aggregate_gene_expression`).

Fix: `_index_genome()` selects the newest release with a **queryable GTF**; the index
is now populated (78 894 genes / 387 954 transcripts on release 114). **1000 lookups:
~840 ms → ~0.2 ms.** `_fallback_genomes()` skips the already-indexed release.

## 3. One canonical version normalizer
`genome.strip_version` stripped whitespace; `gene_ids._unversioned` and `gene_qc`
did a no-strip `.split('.')[0]`. A padded mitochondrial id (`' ENSG…'`) **escaped
technical-RNA censoring** (classified `other`, not `mt_dna`). Now all three delegate
to one `gene_ids.unversioned` (split-on-first-dot + strip). Real id columns have no
whitespace, so this is robustness, not a data change.

## Audited and cleared (no bug)
CTA id↔name is an exact unversioned bijection (288↔288); proteoform registry
integrity (labels, members, canonical = `min`∈members); `by="symbol"` weights have
no collisions; alias/`_REVERSE_ALIASES` no collisions; symbol→id resolution
deterministic across processes. Two deferred (curation-layer, not code bugs): the
NCBI synonym table has 232 aliases mapping to >1 official symbol (last-wins); a NaN
id would key as the string `'nan'`.

## Tests
357 pass. New: weight-propagation to an unexpressed canonical member; `unversioned`
normalizer (whitespace/version/idempotent); padded mt-id censoring.