### PR TITLE
Cache per_sample_expression read+clean (coverage/9-mer hot path)

### DIFF
--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -29,6 +29,7 @@ target-selection consumes.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from functools import lru_cache
 from pathlib import Path
 
 import numpy as np
@@ -37,7 +38,7 @@ import pandas as pd
 from . import data_bundle, source_matrices
 from ._build import WITHIN_SAMPLE_THRESHOLDS as _WITHIN_SAMPLE_THRESHOLD_COLS
 from .cancer_types import cohort_aggregates, resolve_cancer_type
-from .load_dataset import _BUNDLED_DATA_DIR
+from .load_dataset import _BUNDLED_DATA_DIR, _register_derived_cache
 from .normalization import clean_tpm
 
 _REPRESENTATIVES_DIR = "cancer-reference-expression-representatives"
@@ -158,6 +159,16 @@ def per_sample_expression(
                 f"per-sample matrix for {code!r} not cached at {path}. "
                 f"Run source_matrices.fetch({code!r}) to download it."
             )
+    # The read + clean_tpm of a tens-of-MB matrix is the dominant cost on every
+    # coverage / 9-mer call; memoize it (keyed on the matrix path + normalize) and
+    # hand callers a fresh copy so the shared frame can't be mutated.
+    return _load_per_sample_matrix(str(path), normalize).copy()
+
+
+@lru_cache(maxsize=2)
+def _load_per_sample_matrix(path: str, normalize: str) -> pd.DataFrame:
+    """Read + normalize one cohort's per-sample matrix (the cached canonical frame).
+    ``path`` is the resolved parquet location; the matrix must already be on disk."""
     raw = pd.read_parquet(path)
     base = ["Ensembl_Gene_ID", "Symbol"]
     samples = [c for c in raw.columns if c not in base]
@@ -168,6 +179,9 @@ def per_sample_expression(
     if normalize == "tpm_clean_log1p":
         out[samples] = np.log1p(out[samples].to_numpy(dtype=float))
     return out
+
+
+_register_derived_cache(_load_per_sample_matrix.cache_clear)
 
 
 def cohort_mean_expression(

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -28,6 +28,7 @@ target-selection consumes.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
@@ -160,15 +161,17 @@ def per_sample_expression(
                 f"Run source_matrices.fetch({code!r}) to download it."
             )
     # The read + clean_tpm of a tens-of-MB matrix is the dominant cost on every
-    # coverage / 9-mer call; memoize it (keyed on the matrix path + normalize) and
-    # hand callers a fresh copy so the shared frame can't be mutated.
-    return _load_per_sample_matrix(str(path), normalize).copy()
+    # coverage / 9-mer call; memoize it (keyed on the matrix path + its mtime +
+    # normalize) and hand callers a fresh copy so the shared frame can't be mutated.
+    # The mtime in the key self-invalidates the cache if the matrix is re-fetched.
+    return _load_per_sample_matrix(str(path), os.path.getmtime(path), normalize).copy()
 
 
 @lru_cache(maxsize=2)
-def _load_per_sample_matrix(path: str, normalize: str) -> pd.DataFrame:
+def _load_per_sample_matrix(path: str, mtime: float, normalize: str) -> pd.DataFrame:
     """Read + normalize one cohort's per-sample matrix (the cached canonical frame).
-    ``path`` is the resolved parquet location; the matrix must already be on disk."""
+    ``path``/``mtime`` identify the on-disk parquet (mtime keys cache invalidation);
+    the matrix must already be present."""
     raw = pd.read_parquet(path)
     base = ["Ensembl_Gene_ID", "Symbol"]
     samples = [c for c in raw.columns if c not in base]

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -101,6 +101,23 @@ def test_per_sample_expression_normalize_modes(tmp_path, monkeypatch):
     assert np.allclose(logged["s1"].to_numpy(), np.log1p(clean["s1"].to_numpy()))
 
 
+def test_per_sample_expression_memoizes_and_copies(tmp_path, monkeypatch):
+    path = _raw_matrix(tmp_path)
+    monkeypatch.setattr(expression.source_matrices, "ensure", lambda code: path)
+    expression._load_per_sample_matrix.cache_clear()
+
+    a = expression.per_sample_expression("PRAD", normalize="tpm_clean")
+    expression.per_sample_expression("PRAD", normalize="tpm_clean")  # served from cache
+    info = expression._load_per_sample_matrix.cache_info()
+    assert info.misses == 1 and info.hits >= 1
+
+    # Each call returns an independent copy — mutating one must not corrupt the cache.
+    col = a.columns[2]
+    a.loc[0, col] = -12345.0
+    c = expression.per_sample_expression("PRAD", normalize="tpm_clean")
+    assert c.loc[0, col] != -12345.0
+
+
 def test_per_sample_expression_bad_normalize(tmp_path, monkeypatch):
     monkeypatch.setattr(expression.source_matrices, "ensure", lambda code: _raw_matrix(tmp_path))
     with pytest.raises(ValueError, match="normalize must be one of"):


### PR DESCRIPTION
## The bottleneck (measured)

`per_sample_expression` re-read the parquet **and** re-ran `clean_tpm` on every
call. Timed on the real LUAD matrix:

| call | before |
|------|--------|
| `per_sample_expression` | 231 ms |
| `cta_patient_fractions` | 169 ms |
| `addressable_fraction` | 148 ms |
| `greedy_coverage` | 168 ms |
| `mean_antigens_per_patient` | 166 ms |
| `cta_specific_9mer_load` | 278 ms |

Analyzing one cohort with all of these did the identical tens-of-MB read+clean
**~5×** (~1.15 s of pure redundancy); a plot over N cohorts multiplied it by N.

(The static scan suspected `greedy_coverage`'s O(P²·S) set-cover loop — measurement
says that loop is **~3 ms**. The read was the cost.)

## Fix

Memoize the read+normalize in `_load_per_sample_matrix` (`lru_cache(maxsize=2)`,
keyed on the resolved matrix path + normalize mode); `per_sample_expression` hands
callers a fresh `.copy()` so the shared frame can't be mutated. Registered with the
derived-cache clear hook.

## After (LUAD, warm cache)

| call | after |
|------|-------|
| `per_sample_expression` | **5 ms** (was 231) |
| each coverage metric | **20–36 ms** (was ~150–170) |
| one-cohort-all-metrics | **~456 ms** (was ~1150) |

Cache hit/miss confirmed by `cache_info()` (6 hits / 1 miss for the 5-metric pattern).

## Tests

358 pass. New test asserts memoization (1 miss, ≥1 hit) and copy-isolation (mutating
a returned frame doesn't corrupt the cache).