### PR TITLE
Percentiles & cohort-mean relative to the collapsed proteoform key space

### DIFF
--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -39,11 +39,13 @@ import pandas as pd
 from . import data_bundle, source_matrices
 from ._build import WITHIN_SAMPLE_THRESHOLDS as _WITHIN_SAMPLE_THRESHOLD_COLS
 from .cancer_types import cohort_aggregates, resolve_cancer_type
+from .expression_engine import ID_COLUMNS
 from .load_dataset import _BUNDLED_DATA_DIR, _register_derived_cache
 from .normalization import clean_tpm
 
 _REPRESENTATIVES_DIR = "cancer-reference-expression-representatives"
 _PERCENTILES_DIR = "cancer-reference-expression-percentiles"
+_PERCENTILES_PROTEOFORM_DIR = "cancer-reference-expression-percentiles-proteoform"
 _WITHIN_SAMPLE_DIR = "cancer-reference-expression-within-sample-top5"
 _WITHIN_SAMPLE_PROTEOFORM_DIR = "cancer-reference-expression-within-sample-top5-proteoform"
 
@@ -108,7 +110,11 @@ def _representatives_root() -> Path:
     return _bundle_subdir(_REPRESENTATIVES_DIR)
 
 
-def _percentiles_root() -> Path:
+def _percentiles_root(*, proteoform: bool = False) -> Path:
+    if proteoform:
+        # The proteoform-summed variant isn't in a released bundle yet, so never
+        # trigger a fetch for it.
+        return _bundle_subdir(_PERCENTILES_PROTEOFORM_DIR, auto_fetch=False)
     return _bundle_subdir(_PERCENTILES_DIR)
 
 
@@ -117,9 +123,11 @@ def available_representative_cohorts() -> list[str]:
     return _available_shard_codes(_representatives_root())
 
 
-def available_percentile_cohorts() -> list[str]:
-    """Cohort codes that ship a per-gene percentile-vector shard (sorted)."""
-    return _available_shard_codes(_percentiles_root())
+def available_percentile_cohorts(*, proteoform: bool = False) -> list[str]:
+    """Cohort codes that ship a percentile-vector shard (sorted). With
+    ``proteoform=True``, the proteoform-summed variant (one vector per proteoform
+    key, identical-protein members collapsed before ranking)."""
+    return _available_shard_codes(_percentiles_root(proteoform=proteoform))
 
 
 _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p")
@@ -188,7 +196,12 @@ _register_derived_cache(_load_per_sample_matrix.cache_clear)
 
 
 def cohort_mean_expression(
-    cancer_type, *, normalize: str = "tpm_clean", statistic: str = "mean", auto_fetch: bool = True
+    cancer_type,
+    *,
+    normalize: str = "tpm_clean",
+    statistic: str = "mean",
+    auto_fetch: bool = True,
+    proteoform: bool = False,
 ) -> pd.DataFrame:
     """Per-gene **across-patient summary** of a cohort's expression (one value per
     gene, collapsed over all patients).
@@ -198,15 +211,24 @@ def cohort_mean_expression(
     the percentile vectors and n=5 medoids don't give directly. Reduces
     :func:`per_sample_expression` over the sample axis with ``statistic`` (``"mean"``
     / ``"median"``). ``normalize`` is passed through (clean TPM by default; use
-    ``"tpm_clean_log1p"`` to average in log space). Returns ``Ensembl_Gene_ID``,
-    ``Symbol`` and one ``expression`` column."""
+    ``"tpm_clean_log1p"`` to average in log space).
+
+    With ``proteoform=True``, identical-protein paralogs are summed per sample
+    (:func:`cancerdata.proteoforms.collapse_to_proteoforms`) **before** the
+    across-patient reduction, so the summary is over the reduced proteoform key space
+    (rows carry ``proteoform_key``). Returns ``Ensembl_Gene_ID``, ``Symbol`` (plus the
+    proteoform identity columns when collapsed) and one ``expression`` column."""
     if statistic not in ("mean", "median"):
         raise ValueError("statistic must be 'mean' or 'median'")
     df = per_sample_expression(cancer_type, normalize=normalize, auto_fetch=auto_fetch)
-    base = ["Ensembl_Gene_ID", "Symbol"]
-    samples = [c for c in df.columns if c not in base]
+    if proteoform:
+        from .proteoforms import collapse_to_proteoforms
+
+        df = collapse_to_proteoforms(df)
+    id_cols = [c for c in ID_COLUMNS if c in df.columns]
+    samples = [c for c in df.columns if c not in id_cols]
     reducer = df[samples].mean(axis=1) if statistic == "mean" else df[samples].median(axis=1)
-    out = df[base].copy()
+    out = df[id_cols].copy()
     out["expression"] = reducer.to_numpy()
     return out
 
@@ -292,7 +314,9 @@ def representative_cohort_samples(
     return long
 
 
-def cohort_gene_percentiles(cancer_type, *, as_tpm: bool = True) -> pd.DataFrame:
+def cohort_gene_percentiles(
+    cancer_type, *, as_tpm: bool = True, proteoform: bool = False
+) -> pd.DataFrame:
     """Tail-weighted per-gene percentile vector for one cohort.
 
     Returns one row per gene (``Ensembl_Gene_ID`` + ``Symbol``) with 26
@@ -305,16 +329,22 @@ def cohort_gene_percentiles(cancer_type, *, as_tpm: bool = True) -> pd.DataFrame
     ``expm1``-restores clean-TPM values, ``as_tpm=False`` returns the stored
     log1p values. Raises if the cohort has no per-sample data (summary-only
     cohorts have no vector — see :func:`available_percentile_cohorts`).
+
+    With ``proteoform=True``, reads the proteoform-summed variant: identical-protein
+    members were summed per sample **before** the percentiles were computed, so the
+    vector is one row per proteoform key (``proteoform_key``/``Symbol`` carry the
+    collapsed identity); build it with ``generate_cohort_percentiles.py --proteoform``.
     """
     code = resolve_cancer_type(cancer_type)
-    shard = _percentiles_root() / f"{code}.parquet"
+    shard = _percentiles_root(proteoform=proteoform) / f"{code}.parquet"
     if not shard.exists():
+        variant = "proteoform-summed " if proteoform else ""
         raise ValueError(
-            f"no percentile vector for {code!r} — only cohorts with per-sample "
-            f"data ship one; see available_percentile_cohorts()."
+            f"no {variant}percentile vector for {code!r} — only cohorts with per-sample "
+            f"data ship one; see available_percentile_cohorts(proteoform={proteoform})."
         )
     df = pd.read_parquet(shard)
-    bp_cols = [c for c in df.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    bp_cols = [c for c in df.columns if c not in ID_COLUMNS]
     df[bp_cols] = df[bp_cols].astype("float32")
     if as_tpm:
         df[bp_cols] = np.expm1(df[bp_cols])

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -379,6 +379,15 @@ def _cta_expression_matrix(stat, cohorts, *, proteoform=False):
     col = _STAT_PERCENTILE_COL[stat]
     id_to_name = CTA_gene_id_to_name()
     cta_ids = set(CTA_gene_ids())
+    # In the collapsed space, a CTA group's row is keyed by its proteoform_key, and the
+    # row's canonical Ensembl_Gene_ID may be an unexpressed member outside CTA_gene_ids
+    # — so match on the CTA *proteoform keys*, not the canonical ENSG (which would drop
+    # CGB3/5/8, CT45A2/8/9, …). The keys are derived from the CTA set itself.
+    cta_keys = None
+    if proteoform:
+        from .proteoforms import gene_to_proteoform_id
+
+        cta_keys = set(gene_to_proteoform_id(sorted(cta_ids)).values())
     rows = {}
     skipped = []
     for code in cohorts:
@@ -387,12 +396,15 @@ def _cta_expression_matrix(stat, cohorts, *, proteoform=False):
         except ValueError:
             skipped.append(str(code))
             continue
-        ids = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
-        mask = ids.isin(cta_ids)
-        sub = df.loc[mask]
-        # Label columns by the proteoform symbol when collapsed (NY-ESO-1 not CTAG1B),
-        # else the per-gene CTA symbol.
-        labels = sub["Symbol"].to_numpy() if proteoform else ids[mask].map(id_to_name).to_numpy()
+        if proteoform:
+            mask = df["proteoform_key"].astype(str).isin(cta_keys)
+            sub = df.loc[mask]
+            labels = sub["Symbol"].to_numpy()  # the proteoform symbol (NY-ESO-1, XAGE1A/B)
+        else:
+            ids = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+            sub = df.loc[ids.isin(cta_ids)]
+            ids_kept = sub["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+            labels = ids_kept.map(id_to_name).to_numpy()
         rows[code] = pd.Series(sub[col].to_numpy(), index=labels)
     if skipped:
         warnings.warn(

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -366,10 +366,11 @@ def incidence_vs_mortality(*, region="us", save=None):
     return _save(fig, save)
 
 
-def _cta_expression_matrix(stat, cohorts):
-    """cohorts × CTA-gene matrix of the requested ``stat`` TPM (NaN where a cohort
-    lacks a gene). Rows are cohort codes, columns are CTA symbols. Cohorts without
-    a percentile vector (summary-only or unknown codes) are skipped with a warning
+def _cta_expression_matrix(stat, cohorts, *, proteoform=False):
+    """cohorts × CTA matrix of the requested ``stat`` TPM (NaN where a cohort lacks a
+    gene). Rows are cohort codes, columns are CTA symbols. With ``proteoform=True``,
+    reads the proteoform-summed percentile vectors and labels columns by the proteoform
+    symbol (NY-ESO-1, XAGE1A/B). Cohorts without the vector are skipped with a warning
     rather than aborting the whole plot."""
     import warnings
 
@@ -382,17 +383,17 @@ def _cta_expression_matrix(stat, cohorts):
     skipped = []
     for code in cohorts:
         try:
-            df = cohort_gene_percentiles(code, as_tpm=True)
+            df = cohort_gene_percentiles(code, as_tpm=True, proteoform=proteoform)
         except ValueError:
             skipped.append(str(code))
             continue
         ids = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
         mask = ids.isin(cta_ids)
         sub = df.loc[mask]
-        rows[code] = pd.Series(
-            sub[col].to_numpy(),
-            index=ids[mask].map(id_to_name),
-        )
+        # Label columns by the proteoform symbol when collapsed (NY-ESO-1 not CTAG1B),
+        # else the per-gene CTA symbol.
+        labels = sub["Symbol"].to_numpy() if proteoform else ids[mask].map(id_to_name).to_numpy()
+        rows[code] = pd.Series(sub[col].to_numpy(), index=labels)
     if skipped:
         warnings.warn(
             f"skipped {len(skipped)} cohort(s) without a percentile vector: {', '.join(skipped)}",
@@ -425,24 +426,23 @@ def cta_expression_heatmap(
     ``cohorts`` restricts the cohort pool (default: every cohort with a percentile
     vector). Needs the expression bundle present (percentile artifacts).
 
-    ``proteoform=True`` is not yet available: faithful paralog summation must happen
-    on per-sample matrices *before* the percentile summary (percentiles can't be
-    summed), which is the proteoform-summed percentile artifact tracked in #13.
+    ``proteoform=True`` reads the **proteoform-summed** percentile vectors: identical-
+    protein paralogs were summed per sample *before* the percentiles were computed, so
+    a duplicated antigen appears once under its proteoform symbol (NY-ESO-1, XAGE1A/B)
+    rather than as several diluted member rows. Needs the proteoform percentile shards
+    (``generate_cohort_percentiles.py --proteoform``).
     """
     if stat not in _STAT_PERCENTILE_COL:
         raise ValueError(f"stat must be one of {sorted(_STAT_PERCENTILE_COL)}")
-    if proteoform:
-        raise NotImplementedError(
-            "proteoform-summed CTA expression needs the proteoform-summed percentile "
-            "artifact (per-sample summation before summarizing — percentiles cannot be "
-            "summed); tracked in issue #13."
-        )
     if cohorts is None:
-        cohorts = available_percentile_cohorts()
+        cohorts = available_percentile_cohorts(proteoform=proteoform)
     if not cohorts:
-        raise ValueError("no cohorts with a percentile vector — is the expression bundle present?")
+        variant = "proteoform-summed " if proteoform else ""
+        raise ValueError(
+            f"no cohorts with a {variant}percentile vector — is the expression bundle present?"
+        )
 
-    matrix = _cta_expression_matrix(stat, cohorts)
+    matrix = _cta_expression_matrix(stat, cohorts, proteoform=proteoform)
     if matrix.empty or matrix.shape[1] == 0:
         raise ValueError(
             "no CTA expression data for the selected cohorts — none had a percentile "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,10 @@ cancerdata = [
 cancerdata = [
     "data/cancer-reference-expression/*",
     "data/cancer-reference-expression-percentiles/*",
+    "data/cancer-reference-expression-percentiles-proteoform/*",
     "data/cancer-reference-expression-representatives/*",
     "data/cancer-reference-expression-within-sample-top5/*",
+    "data/cancer-reference-expression-within-sample-top5-proteoform/*",
     "data/pan-cancer-expression.csv",
     "data/hpa-cell-type-expression.csv",
 ]

--- a/scripts/generate_cohort_percentiles.py
+++ b/scripts/generate_cohort_percentiles.py
@@ -58,6 +58,7 @@ from cancerdata._build import cohort_percentile_vectors, sample_columns
 
 _DATA_DIR = Path(__file__).resolve().parents[1] / "cancerdata" / "data"
 OUT_DIR = _DATA_DIR / "cancer-reference-expression-percentiles"
+PROTEOFORM_OUT_DIR = _DATA_DIR / "cancer-reference-expression-percentiles-proteoform"
 
 
 def _load_drop_genes(path: Path | None) -> set[str]:
@@ -66,8 +67,22 @@ def _load_drop_genes(path: Path | None) -> set[str]:
     return {line.strip() for line in path.read_text().splitlines() if line.strip()}
 
 
-def build(input_dir: Path, *, drop_genes: set[str], out_dir: Path = OUT_DIR) -> None:
-    """Build the percentile-vector artifact for each cohort under ``input_dir``."""
+def build(
+    input_dir: Path,
+    *,
+    drop_genes: set[str],
+    out_dir: Path | None = None,
+    proteoform: bool = False,
+) -> None:
+    """Build the percentile-vector artifact for each cohort under ``input_dir``.
+
+    With ``proteoform=True``, each cohort's per-sample matrix is collapsed to the
+    proteoform key space (identical-protein members summed) *before* the percentiles
+    are computed, so the vector is one row per proteoform key. Output lands in a
+    parallel ``…-percentiles-proteoform`` directory.
+    """
+    if out_dir is None:
+        out_dir = PROTEOFORM_OUT_DIR if proteoform else OUT_DIR
     out_dir.mkdir(parents=True, exist_ok=True)
     shards = sorted(input_dir.glob("*.parquet"))
     if not shards:
@@ -82,6 +97,13 @@ def build(input_dir: Path, *, drop_genes: set[str], out_dir: Path = OUT_DIR) -> 
         if not cols:
             print(f"  {code}: no sample columns, skipped", flush=True)
             continue
+        if proteoform:
+            # Collapse identical-protein members per sample first, then rank on the
+            # reduced proteoform key space (one reusable collapse + proteoform_key).
+            from cancerdata.proteoforms import collapse_to_proteoforms
+
+            df = collapse_to_proteoforms(df, sample_cols=cols)
+            cols = sample_columns(df)
         out = cohort_percentile_vectors(df, cols)
         out.to_parquet(out_dir / f"{code}.parquet", index=False, compression="zstd")
         n += 1
@@ -101,8 +123,17 @@ def main(argv=None) -> None:
         default=None,
         help="Optional newline-delimited Ensembl IDs of technical genes to drop",
     )
+    p.add_argument(
+        "--proteoform",
+        action="store_true",
+        help="Collapse identical-protein members before ranking (proteoform key space)",
+    )
     args = p.parse_args(argv)
-    build(args.input, drop_genes=_load_drop_genes(args.drop_genes))
+    build(
+        args.input,
+        drop_genes=_load_drop_genes(args.drop_genes),
+        proteoform=args.proteoform,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/rebuild_expression_artifacts.py
+++ b/scripts/rebuild_expression_artifacts.py
@@ -159,9 +159,11 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
 
     clean_dir = out / "clean"
     pct_dir = out / "cancer-reference-expression-percentiles"
+    pct_pf_dir = out / "cancer-reference-expression-percentiles-proteoform"
     rep_dir = out / "cancer-reference-expression-representatives"
     ws_dir = out / "cancer-reference-expression-within-sample-top5"
-    for d in (clean_dir, pct_dir, rep_dir, ws_dir):
+    ws_pf_dir = out / "cancer-reference-expression-within-sample-top5-proteoform"
+    for d in (clean_dir, pct_dir, pct_pf_dir, rep_dir, ws_dir, ws_pf_dir):
         d.mkdir(parents=True, exist_ok=True)
 
     provenance: list[dict] = []
@@ -195,6 +197,21 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
 
         ws = within_sample_top_fractions(bio_df, samples)
         ws.to_parquet(ws_dir / f"{code}.parquet", index=False, compression="zstd")
+
+        # Proteoform key space: collapse identical-protein members per sample, then
+        # build the same percentile + within-sample summaries on the reduced space so
+        # every downstream read can compare/quantify/plot on one collapsed key space.
+        from cancerdata._build import sample_columns
+        from cancerdata.proteoforms import collapse_to_proteoforms
+
+        bio_pf = collapse_to_proteoforms(bio_df, sample_cols=samples)
+        pf_samples = sample_columns(bio_pf)
+        cohort_percentile_vectors(bio_pf, pf_samples).to_parquet(
+            pct_pf_dir / f"{code}.parquet", index=False, compression="zstd"
+        )
+        within_sample_top_fractions(bio_pf, pf_samples).to_parquet(
+            ws_pf_dir / f"{code}.parquet", index=False, compression="zstd"
+        )
 
         msg = f"  {code}: {len(samples)} samples, {len(pct)} genes"
         if validate:

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -60,6 +60,43 @@ def test_cohort_gene_percentiles_missing_raises(percentile_cache):
         expression.cohort_gene_percentiles("BRCA")
 
 
+@pytest.fixture
+def proteoform_percentile_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    shard_dir = tmp_path / "cancer-reference-expression-percentiles-proteoform"
+    shard_dir.mkdir(parents=True)
+    # A collapsed shard carries the proteoform identity columns alongside the breakpoints.
+    cols = {
+        "proteoform_key": ["NY-ESO-1", "ENSG00000185686"],
+        "Ensembl_Gene_ID": ["ENSG00000184033", "ENSG00000185686"],
+        "Symbol": ["NY-ESO-1", "PRAME"],
+        "proteoform_members": ["CTAG1A/CTAG1B", "PRAME"],
+    }
+    for bp in _BREAKPOINTS:
+        cols[f"p{bp}"] = np.log1p([float(bp), float(bp) * 2]).astype("float16")
+    pd.DataFrame(cols).to_parquet(shard_dir / "PRAD.parquet", index=False)
+    return tmp_path
+
+
+def test_available_percentile_cohorts_proteoform(proteoform_percentile_cache):
+    # The proteoform variant reads the local shard (auto_fetch=False, no bundle fetch).
+    assert expression.available_percentile_cohorts(proteoform=True) == ["PRAD"]
+
+
+def test_cohort_gene_percentiles_proteoform(proteoform_percentile_cache):
+    df = expression.cohort_gene_percentiles("PRAD", as_tpm=True, proteoform=True)
+    # the proteoform key space: NY-ESO-1 (collapsed) + PRAME (singleton -> ENSG key)
+    assert list(df["proteoform_key"]) == ["NY-ESO-1", "ENSG00000185686"]
+    # breakpoint columns are restored to TPM; the id columns are excluded from them
+    assert df.loc[0, "p95"] == pytest.approx(95.0, rel=1e-2)
+    assert set(df.columns) >= {"proteoform_key", "Ensembl_Gene_ID", "Symbol", "proteoform_members"}
+
+
+def test_cohort_gene_percentiles_proteoform_missing_raises(proteoform_percentile_cache):
+    with pytest.raises(ValueError, match="no proteoform-summed percentile vector"):
+        expression.cohort_gene_percentiles("BRCA", proteoform=True)
+
+
 def test_representatives_provenance_requires_long_format():
     # Provenance is per-representative; asking for it in the default wide form is
     # a no-op, so it must fail loudly rather than silently dropping the request.
@@ -153,3 +190,28 @@ def test_cohort_mean_expression_bad_statistic(monkeypatch):
     monkeypatch.setattr(expression, "per_sample_expression", lambda *a, **k: pd.DataFrame())
     with pytest.raises(ValueError, match="statistic must be"):
         expression.cohort_mean_expression("X", statistic="mode")
+
+
+def test_cohort_mean_expression_proteoform_collapses_first(monkeypatch):
+    # Two identical-protein paralogs are summed per sample BEFORE the across-patient
+    # reduction, so the proteoform mean is over the summed values, not per-member.
+    import cancerdata.proteoforms as pmod
+
+    fixture = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG_A1", "ENSG_A2", "ENSG_B"],
+            "Symbol": ["A1", "A2", "B"],
+            "s1": [3.0, 5.0, 1.0],
+            "s2": [1.0, 1.0, 9.0],
+        }
+    )
+    monkeypatch.setattr(expression, "per_sample_expression", lambda *a, **k: fixture.copy())
+    monkeypatch.setattr(
+        pmod, "proteoform_group_map", lambda *, scope="cta": {"A1/A2": ["ENSG_A1", "ENSG_A2"]}
+    )
+    out = expression.cohort_mean_expression("X", statistic="mean", proteoform=True)
+    assert "proteoform_key" in out.columns
+    by_key = dict(zip(out["proteoform_key"], out["expression"]))
+    # A1+A2 summed per sample = [8, 2], mean 5.0 (NOT each member's mean of ~2/3)
+    assert by_key["A1/2"] == pytest.approx(5.0)
+    assert by_key["ENSG_B"] == pytest.approx(5.0)  # singleton keyed by ENSG

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -80,16 +80,23 @@ def test_cta_expression_heatmap_proteoform_reads_collapsed_vectors(tmp_path, mon
     import pandas as pd
 
     from cancerdata import cta
+    from cancerdata.proteoforms import gene_to_proteoform_id
 
-    cta_ids = sorted(cta.CTA_gene_ids())[:2]
+    # Use two real CTAs and their real proteoform keys, so the heatmap's CTA-key filter
+    # (derived from the same CTA set) keeps both rows. At least one is a collapsed group.
+    grouped = next(g for g in sorted(cta.CTA_gene_ids()) if "/" in gene_to_proteoform_id([g])[g])
+    singleton = next(
+        g for g in sorted(cta.CTA_gene_ids()) if "/" not in gene_to_proteoform_id([g])[g]
+    )
+    keys = gene_to_proteoform_id([grouped, singleton])
 
     def fake_pct(code, *, as_tpm=True, proteoform=False):
         assert proteoform  # the heatmap must request the collapsed variant
         return pd.DataFrame(
             {
-                "proteoform_key": ["NY-ESO-1", cta_ids[1]],
-                "Ensembl_Gene_ID": cta_ids,
-                "Symbol": ["NY-ESO-1", "OTHER_CTA"],
+                "proteoform_key": [keys[grouped], keys[singleton]],
+                "Ensembl_Gene_ID": [grouped, singleton],
+                "Symbol": [keys[grouped], "OTHER_CTA"],
                 "proteoform_members": ["CTAG1A/CTAG1B", "OTHER_CTA"],
                 "p25": [5.0, 1.0],
                 "p50": [40.0, 2.0],

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -74,9 +74,39 @@ def test_cta_expression_heatmap_bad_stat():
         plots.cta_expression_heatmap(stat="mean", cohorts=["X"])
 
 
-def test_cta_expression_heatmap_proteoform_not_implemented():
-    with pytest.raises(NotImplementedError, match="#13"):
-        plots.cta_expression_heatmap(proteoform=True, cohorts=["X"])
+def test_cta_expression_heatmap_proteoform_reads_collapsed_vectors(tmp_path, monkeypatch):
+    # proteoform=True reads the proteoform-summed percentile vectors and labels CTA
+    # columns by the proteoform symbol (NY-ESO-1). Stub the per-cohort vector.
+    import pandas as pd
+
+    from cancerdata import cta
+
+    cta_ids = sorted(cta.CTA_gene_ids())[:2]
+
+    def fake_pct(code, *, as_tpm=True, proteoform=False):
+        assert proteoform  # the heatmap must request the collapsed variant
+        return pd.DataFrame(
+            {
+                "proteoform_key": ["NY-ESO-1", cta_ids[1]],
+                "Ensembl_Gene_ID": cta_ids,
+                "Symbol": ["NY-ESO-1", "OTHER_CTA"],
+                "proteoform_members": ["CTAG1A/CTAG1B", "OTHER_CTA"],
+                "p25": [5.0, 1.0],
+                "p50": [40.0, 2.0],
+                "p75": [80.0, 3.0],
+            }
+        )
+
+    monkeypatch.setattr(plots, "cohort_gene_percentiles", fake_pct)
+    monkeypatch.setattr(plots, "available_percentile_cohorts", lambda *, proteoform=False: ["LUAD"])
+    out = tmp_path / "cta_pf.png"
+    fig = plots.cta_expression_heatmap(proteoform=True, n_cohorts=2, n_ctas=4, save=str(out))
+    assert out.exists() and fig is not None
+
+
+def test_cta_expression_heatmap_proteoform_missing_bundle():
+    with pytest.raises(ValueError, match="proteoform-summed percentile vector"):
+        plots.cta_expression_heatmap(proteoform=True, cohorts=[])
 
 
 def test_cta_expression_heatmap_no_cohorts():


### PR DESCRIPTION
Your "collapse at TPM, then summarize" — apply the proteoform collapse to the
per-cohort **summaries** so they share the one reduced key space, instead of
ranking diluted individual members.

## Generators (build on the collapsed matrix)
- **`generate_cohort_percentiles.py --proteoform`** — collapses identical-protein
  members per sample **before** computing the percentile vector (mirrors the existing
  within-sample `--proteoform`). One row per `proteoform_key`.
- **`rebuild_expression_artifacts.py`** now also emits the `…-percentiles-proteoform`
  and `…-within-sample-top5-proteoform` shards.

## Accessors (read the collapsed shards)
- **`cohort_gene_percentiles(proteoform=True)`** / **`available_percentile_cohorts(proteoform=True)`**
  — read the proteoform variant (`auto_fetch=False`, not shipped yet). Breakpoint
  detection now excludes all `ID_COLUMNS`, so the carried `proteoform_key` / members
  aren't mistaken for percentile columns.
- **`cohort_mean_expression(proteoform=True)`** — collapses before the across-patient
  reduction (runtime), so the mean is over proteoform keys.

## Plot
- **`cta_expression_heatmap(proteoform=True)`** now **works** (was `NotImplementedError`):
  reads the proteoform percentile vectors and labels CTA columns by the proteoform
  symbol (`NY-ESO-1`, `XAGE1A/B`) — a duplicated antigen appears once.

## Verified
Real LUAD matrix: 34571 genes → **34542** proteoform percentile rows; `NY-ESO-1`
gets its own summed vector (`p50`/`p95` over CTAG1A+CTAG1B). 367 tests pass.

## Operational follow-up
The live proteoform shards still need generating + uploading (like the source
matrices) — the code/accessors/plot are ready and `auto_fetch=False` means nothing
breaks until they're shipped. `pyproject` excludes the new dirs from the wheel.

Closes the percentile half of "apply the collapse before comparing/quantifying/
plotting everything". Remaining: migrate the 9-mer join onto `proteoform_key`, and
(optionally) make `proteoform=True` the default once the shards ship.