### PR TITLE
Uniform proteoform_key joins on every collapsed frame

### DIFF
--- a/cancerdata/coverage.py
+++ b/cancerdata/coverage.py
@@ -157,6 +157,8 @@ def greedy_coverage(
                 "marginal_fraction",
                 "cumulative_patients",
                 "cumulative_fraction",
+                "proteoform_key",
+                "proteoform_members",
             ]
         )
 

--- a/cancerdata/coverage.py
+++ b/cancerdata/coverage.py
@@ -188,8 +188,9 @@ def greedy_coverage(
             "cumulative_patients": cum,
             "cumulative_fraction": cum / n,
         }
-        if "proteoform_members" in sub.columns:
-            row["proteoform_members"] = str(sub.at[best_g, "proteoform_members"])
+        for _idcol in ("proteoform_key", "proteoform_members"):
+            if _idcol in sub.columns:
+                row[_idcol] = str(sub.at[best_g, _idcol])
         rows.append(row)
     return pd.DataFrame(rows)
 

--- a/cancerdata/peptides.py
+++ b/cancerdata/peptides.py
@@ -179,46 +179,29 @@ def cta_specific_9mer_counts(*, k: int = DEFAULT_K, refresh: bool = False) -> pd
     return _COUNTS_CACHE[key].copy()
 
 
-def cta_specific_9mer_weights(*, k: int = DEFAULT_K, by: str = "ensembl_gene_id") -> dict[str, int]:
+def cta_specific_9mer_weights(*, k: int = DEFAULT_K, by: str = "proteoform_key") -> dict[str, int]:
     """``{key -> n_specific_9mers}`` from :func:`cta_specific_9mer_counts`.
 
-    ``by="ensembl_gene_id"`` (default) keys by unversioned Ensembl gene id — the safe
-    join key, since a proteoform-collapsed row's ``Symbol`` is a slash-joined label
-    that no per-gene symbol key matches (see :func:`cta_specific_9mer_load`).
-    ``by="symbol"`` keys by gene symbol for display. Identical-protein paralogs share
-    a sequence, hence one count, so a canonical member's id carries the group's weight."""
+    ``by="proteoform_key"`` (default) keys by the **proteoform key** — the uniform join
+    key for collapsed frames. Identical-protein group members share one sequence, hence
+    one count, so the group's proteoform key carries that count regardless of which
+    member is expressed (no canonical-member ambiguity). ``by="ensembl_gene_id"`` /
+    ``by="symbol"`` key per gene, for reference/display."""
     df = cta_specific_9mer_counts(k=k)
     if by == "ensembl_gene_id":
-        keys = df["Ensembl_Gene_ID"]
-    elif by == "symbol":
-        keys = df["Symbol"]
-    else:
-        raise ValueError("by must be 'ensembl_gene_id' or 'symbol'")
-    return {str(key): int(n) for key, n in zip(keys, df["n_specific_9mers"])}
+        return {str(g): int(n) for g, n in zip(df["Ensembl_Gene_ID"], df["n_specific_9mers"])}
+    if by == "symbol":
+        return {str(s): int(n) for s, n in zip(df["Symbol"], df["n_specific_9mers"])}
+    if by == "proteoform_key":
+        from .proteoforms import gene_to_proteoform_id
 
-
-def _weight_by_gene_id(*, k: int = DEFAULT_K, scope: str = "cta") -> dict[str, int]:
-    """``{unversioned member gene id -> n_specific_9mers}`` covering **every** member
-    of each proteoform group, not just the ones in the counts table.
-
-    The counts table only has rows for the expressed/filtered CTA set, so a group's
-    weight lives under whichever member(s) are expressed. But a collapsed proteoform's
-    canonical id (``min`` member, :func:`cancerdata._build.sum_proteoform_tpm`) may be
-    an *un*expressed sibling absent from that table — joining on it alone silently
-    drops the group's weight (CGB3/CGB5/CGB8, CT45A2/CT45A8/CT45A9, …). Identical-
-    protein members share a sequence, hence one count, so we propagate each group's
-    weight to all its member ids; the canonical id then always resolves."""
-    from .proteoforms import proteoform_group_map
-
-    per_gene = cta_specific_9mer_weights(k=k, by="ensembl_gene_id")
-    out = dict(per_gene)
-    for members in proteoform_group_map(scope=scope).values():
-        ids = [strip_version(m) for m in members]
-        group_weight = max((per_gene.get(i, 0) for i in ids), default=0)
-        if group_weight:
-            for i in ids:
-                out.setdefault(i, group_weight)
-    return out
+        key_map = gene_to_proteoform_id(df["Ensembl_Gene_ID"].tolist())
+        out: dict[str, int] = {}
+        for g, n in zip(df["Ensembl_Gene_ID"], df["n_specific_9mers"]):
+            key = str(key_map[strip_version(g)])
+            out[key] = max(out.get(key, 0), int(n))  # members share the count
+        return out
+    raise ValueError("by must be 'proteoform_key', 'ensembl_gene_id', or 'symbol'")
 
 
 def cta_specific_9mer_load(
@@ -233,19 +216,16 @@ def cta_specific_9mer_load(
     :func:`cancerdata.coverage.cta_patient_fractions` (proteoform-summed) — no second
     pass over the per-sample matrix. Needs the cohort's per-sample matrix cached.
 
-    The join is on the **canonical-member Ensembl gene id**, not ``Symbol``: a
-    collapsed proteoform's ``Symbol`` is the slash-joined label (``CTAG1A/CTAG1B``),
-    which would never match the per-gene weight table. The weight map
-    (:func:`_weight_by_gene_id`) propagates each group's count to *all* its member ids,
-    so even when the canonical (``min``) member is an unexpressed sibling absent from
-    the counts table, it still carries the proteoform's weight."""
+    The join is on ``proteoform_key`` — the uniform identity shared by the per-patient
+    frame and the weight table. A group's members share one count, so its key resolves
+    whichever member is expressed (no canonical-member ambiguity)."""
     from .coverage import cta_patient_fractions
 
     pf = cta_patient_fractions(cancer_type, threshold_tpm=threshold_tpm)
     if pf.empty:
         return 0.0
-    weight_by_id = _weight_by_gene_id(k=k)
-    w = pf["Ensembl_Gene_ID"].astype(str).map(lambda g: weight_by_id.get(strip_version(g), 0))
+    weight_by_key = cta_specific_9mer_weights(k=k, by="proteoform_key")
+    w = pf["proteoform_key"].astype(str).map(lambda key: weight_by_key.get(key, 0))
     return float((pf["fraction_expressing"] * w).sum())
 
 

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -623,13 +623,14 @@ def cta_patient_count_heatmap(
         )
     col = "fraction_expressing" if value == "fraction" else "n_patients_expressing"
     rows = {}
+    key_to_symbol = {}
     for code in cohorts:
         pf = cta_patient_fractions(code, threshold_tpm=threshold_tpm)
-        # Collapse identical-protein paralogs sharing a Symbol to one column (max
-        # prevalence) so the per-cohort index is unique — pd.DataFrame can't align
-        # Series on a duplicated index.
-        rows[code] = pf.groupby("Symbol")[col].max()
-    matrix = pd.DataFrame(rows).T  # cohorts × CTA symbols
+        # Index by the proteoform_key (unique per antigen after the collapse) so the
+        # per-cohort Series align cleanly; the column display label comes from Symbol.
+        rows[code] = pf.groupby("proteoform_key")[col].max()
+        key_to_symbol.update(zip(pf["proteoform_key"].astype(str), pf["Symbol"].astype(str)))
+    matrix = pd.DataFrame(rows).T  # cohorts × CTA proteoform keys
     if matrix.empty or matrix.shape[1] == 0:
         raise ValueError("no CTA expressed above the threshold in the selected cohorts")
 
@@ -637,6 +638,8 @@ def cta_patient_count_heatmap(
     row_score = matrix[top_ctas].max(axis=1)
     top_cohorts = row_score.sort_values(ascending=False).head(n_cohorts).index
     grid = matrix.loc[top_cohorts, top_ctas].fillna(0.0)
+    # Label columns by the proteoform symbol (NY-ESO-1, CT83), not the ENSG-or-symbol key.
+    grid = grid.rename(columns=lambda key: key_to_symbol.get(str(key), str(key)))
 
     unit = "fraction of patients" if value == "fraction" else "patients"
     return _cohort_gene_heatmap(

--- a/tests/test_peptides.py
+++ b/tests/test_peptides.py
@@ -100,49 +100,53 @@ def test_specific_9mer_counts_refresh_rebuilds(fake_proteome, tmp_path):
     assert int(df.loc[0, "n_specific_9mers"]) == 3
 
 
-def test_specific_9mer_weights_keyed_by_ensembl_id_by_default(fake_proteome):
+def test_specific_9mer_weights_keyed_by_proteoform_key_by_default(fake_proteome):
+    # Default key is the proteoform_key; for the singleton ENSG_CTA that is its ENSG.
     assert peptides.cta_specific_9mer_weights(k=3) == {"ENSG_CTA": 3}
+    assert peptides.cta_specific_9mer_weights(k=3, by="ensembl_gene_id") == {"ENSG_CTA": 3}
     assert peptides.cta_specific_9mer_weights(k=3, by="symbol") == {"CTAX": 3}
     with pytest.raises(ValueError, match="by must be"):
         peptides.cta_specific_9mer_weights(k=3, by="nonsense")
 
 
-def test_weight_propagates_to_unexpressed_canonical_member(monkeypatch):
-    # A proteoform's canonical id is min(member ids); that member can be unexpressed
-    # and absent from the per-gene counts table. The group's weight must still reach
-    # it (members share a sequence -> one count), else the load silently drops it.
-    import cancerdata.proteoforms as pmod
+def test_weight_by_proteoform_key_covers_group_via_any_member(monkeypatch):
+    # A real CGB3/5/8 group whose canonical min-ENSG (CGB3) is unexpressed: the counts
+    # table has only the expressed member (CGB8), yet keying by proteoform_key gives the
+    # group its weight — no canonical-member ambiguity.
+    import pandas as pd
 
-    monkeypatch.setattr(
-        peptides,
-        "cta_specific_9mer_weights",
-        lambda *, k, by="ensembl_gene_id": {"ENSG_EXPRESSED": 7},  # only the expressed member
+    fake_counts = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG00000213030"],  # CGB8 (expressed member of CGB3/5/8)
+            "Symbol": ["CGB8"],
+            "n_9mers": [40],
+            "n_specific_9mers": [31],
+        }
     )
     monkeypatch.setattr(
-        pmod, "proteoform_group_map", lambda *, scope="cta": {"A/B": ("ENSG_AAA", "ENSG_EXPRESSED")}
+        peptides, "cta_specific_9mer_counts", lambda *, k=peptides.DEFAULT_K: fake_counts
     )
-    wbi = peptides._weight_by_gene_id(k=3)
-    # canonical = min(members) = ENSG_AAA, absent from the counts table, now carries 7
-    assert wbi["ENSG_AAA"] == 7
-    assert wbi["ENSG_EXPRESSED"] == 7
+    weights = peptides.cta_specific_9mer_weights(by="proteoform_key")
+    assert weights == {"CGB3/5/8": 31}
 
 
-def test_specific_9mer_load_joins_on_ensembl_id_not_symbol(fake_proteome, monkeypatch):
-    # A collapsed proteoform's Symbol is the slash-joined label, which never matches
-    # the per-gene weight table — the load must join on the canonical-member ENSG.
+def test_specific_9mer_load_joins_on_proteoform_key(fake_proteome, monkeypatch):
+    # The load joins on proteoform_key (the uniform key), NOT Symbol/ENSG: a stub whose
+    # Symbol/ENSG don't match the weight key still resolves via proteoform_key.
     from cancerdata import coverage
 
     def fake_fractions(code, *, threshold_tpm):
         return pd.DataFrame(
             {
-                "Ensembl_Gene_ID": ["ENSG_CTA"],  # canonical member id
-                "Symbol": ["CTAX/CTAY"],  # slash-joined proteoform label
+                "proteoform_key": ["ENSG_CTA"],  # the weight key (singleton -> ENSG)
+                "Ensembl_Gene_ID": ["ENSG_CTA"],
+                "Symbol": ["SOMETHING_ELSE"],  # deliberately not the join key
                 "fraction_expressing": [0.5],
             }
         )
 
     monkeypatch.setattr(coverage, "cta_patient_fractions", fake_fractions)
-    # load = fraction (0.5) * n_specific_9mers (3) = 1.5; would be 0.0 on a Symbol join.
+    # load = fraction (0.5) * n_specific_9mers (3) = 1.5
     assert peptides.cta_specific_9mer_load("X", threshold_tpm=5, k=3) == pytest.approx(1.5)
 
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -220,6 +220,7 @@ def test_cta_patient_count_heatmap_renders(tmp_path, monkeypatch):
         base = {"LUAD": [0.7, 0.3, 0.1], "SKCM": [0.9, 0.2, 0.5]}[code]
         return pd.DataFrame(
             {
+                "proteoform_key": ["E1", "E2", "E3"],
                 "Ensembl_Gene_ID": ["E1", "E2", "E3"],
                 "Symbol": ["GA", "GB", "GC"],
                 "fraction_expressing": base,
@@ -243,7 +244,8 @@ def test_cta_patient_count_heatmap_no_cohorts(monkeypatch):
 
 
 def test_cta_patient_count_heatmap_duplicate_symbols(tmp_path, monkeypatch):
-    # Paralog CTAs sharing a Symbol must not crash the cohort×CTA frame alignment.
+    # Distinct proteoforms that happen to share a display Symbol must not crash the
+    # cohort×CTA frame alignment — keying is on the unique proteoform_key.
     import pandas as pd
 
     from cancerdata import coverage
@@ -251,8 +253,9 @@ def test_cta_patient_count_heatmap_duplicate_symbols(tmp_path, monkeypatch):
     def fake_fractions(code, *, threshold_tpm):
         return pd.DataFrame(
             {
+                "proteoform_key": ["K1", "K2", "K3"],  # unique keys
                 "Ensembl_Gene_ID": ["E1", "E2", "E3"],
-                "Symbol": ["GA", "GA", "GB"],  # GA duplicated (two paralogs)
+                "Symbol": ["GA", "GA", "GB"],  # GA duplicated as a display label
                 "fraction_expressing": [0.7, 0.3, 0.1],
                 "n_patients_expressing": [70, 30, 10],
                 "n_patients": [100, 100, 100],


### PR DESCRIPTION
Makes `proteoform_key` **the** join/filter/group key everywhere a collapsed frame
is consumed, so there's one code path (no per-gene vs proteoform special-casing,
no canonical-member traps) and the upcoming regen "just works."

## Changes
- **peptides** — `cta_specific_9mer_load` joins on `pf["proteoform_key"]` against a
  proteoform-key-keyed weight table (`cta_specific_9mer_weights(by="proteoform_key")`,
  the new default). **Removes `_weight_by_gene_id`** (the member-expansion workaround):
  a group's members share one count, so its proteoform key carries it regardless of
  which member is expressed — no canonical-member ambiguity. **LUAD load unchanged at
  1287.25.**
- **`cta_patient_count_heatmap`** — keys the cohort×CTA matrix on `proteoform_key`
  (unique per antigen) and relabels columns by `Symbol` for display, replacing the
  `groupby("Symbol")` dup-symbol workaround.
- **`greedy_coverage`** — now carries `proteoform_key` (+ `proteoform_members`) in its
  output, so all coverage outputs expose the uniform key.

## Audit
The only remaining `isin(cta_ids)` filters are on **per-gene** frames (the per-gene
percentile heatmap path and the within-sample addressable-burden proxy), where every
member id is present — correct, not a canonical-member trap. Collapsed frames now
uniformly key on `proteoform_key`.

## Tests
367 pass. Updated the peptides + patient-heatmap stubs to carry `proteoform_key`
(real `cta_patient_fractions` always does). New: weight covers a group via any
member (CGB3/5/8 with unexpressed canonical), load joins on proteoform_key not
Symbol/ENSG.