### PR TITLE
Scope-general, level-aware proteoform expression API

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -142,6 +142,7 @@ from .peptides import (
 )
 from .proteoforms import (
     collapse_to_proteoforms,
+    expression_level,
     gene_to_proteoform,
     gene_to_proteoform_id,
     proteoform_aliases,
@@ -246,6 +247,7 @@ __all__ = [
     "cta_specific_9mer_counts",
     "cta_specific_9mer_load",
     "cta_specific_9mer_weights",
+    "expression_level",
     "expression_source",
     "expression_sources",
     "family_display_name",

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -202,6 +202,7 @@ def cohort_mean_expression(
     statistic: str = "mean",
     auto_fetch: bool = True,
     proteoform: bool = False,
+    scope: str = "cta",
 ) -> pd.DataFrame:
     """Per-gene **across-patient summary** of a cohort's expression (one value per
     gene, collapsed over all patients).
@@ -211,20 +212,23 @@ def cohort_mean_expression(
     the percentile vectors and n=5 medoids don't give directly. Reduces
     :func:`per_sample_expression` over the sample axis with ``statistic`` (``"mean"``
     / ``"median"``). ``normalize`` is passed through (clean TPM by default; use
-    ``"tpm_clean_log1p"`` to average in log space).
+    ``"tpm_clean_log1p"`` to average in log space). A **gene-level** frame.
 
     With ``proteoform=True``, identical-protein paralogs are summed per sample
     (:func:`cancerdata.proteoforms.collapse_to_proteoforms`) **before** the
     across-patient reduction, so the summary is over the reduced proteoform key space
-    (rows carry ``proteoform_key``). Returns ``Ensembl_Gene_ID``, ``Symbol`` (plus the
-    proteoform identity columns when collapsed) and one ``expression`` column."""
+    (rows carry ``proteoform_key`` — a **proteoform-level** frame, see
+    :func:`cancerdata.proteoforms.expression_level`). ``scope`` selects the gene
+    universe to collapse: ``"cta"`` (focused) or ``"genome"`` (every protein-coding
+    gene). Returns ``Ensembl_Gene_ID``, ``Symbol`` (plus the proteoform identity
+    columns when collapsed) and one ``expression`` column."""
     if statistic not in ("mean", "median"):
         raise ValueError("statistic must be 'mean' or 'median'")
     df = per_sample_expression(cancer_type, normalize=normalize, auto_fetch=auto_fetch)
     if proteoform:
         from .proteoforms import collapse_to_proteoforms
 
-        df = collapse_to_proteoforms(df)
+        df = collapse_to_proteoforms(df, scope=scope)
     id_cols = [c for c in ID_COLUMNS if c in df.columns]
     samples = [c for c in df.columns if c not in id_cols]
     reducer = df[samples].mean(axis=1) if statistic == "mean" else df[samples].median(axis=1)

--- a/cancerdata/proteoforms.py
+++ b/cancerdata/proteoforms.py
@@ -39,6 +39,20 @@ A collapsed frame carries: ``proteoform_key`` (the identity above), ``Symbol``
 canonical-member ENSG, a real id for joining to per-gene Ensembl references), and
 ``proteoform_members`` (the sorted slash-joined member symbols, provenance only).
 
+How the groups are defined: every gene is reduced to its **best (canonical, longest)
+protein sequence**, and genes whose best protein is byte-identical form one group —
+so the key space is "one entry per distinct protein," and a group's proteoform-level
+expression is the **sum of its member genes' TPMs** (RNA-seq reads multi-map between
+identical-protein loci, so per-gene TPM under-counts the protein). ``scope`` selects
+the gene universe: ``"cta"`` (the focused cancer-germline set, the shipped default)
+or ``"genome"`` (all protein-coding genes — histones, tubulins, the PAR X/Y pairs,
+…). Both registries ship; the genome one is the universal "do this for every gene".
+
+GENE-LEVEL vs PROTEOFORM-LEVEL: an expression frame is one or the other, told apart
+by :func:`expression_level` (the ``proteoform_key`` column is present iff collapsed).
+Keep the two straight — don't mix a gene-level dict/stat with a proteoform-level one;
+convert with :func:`collapse_to_proteoforms`.
+
 This module is the read surface over the curated registry
 (``proteoform-groups.csv``, derived offline by
 ``scripts/generate_proteoform_groups.py`` from pyensembl protein sequences). It
@@ -73,6 +87,18 @@ _GENE_ID_COLUMN = "member_gene_id"
 _PROTEOFORM_ALIASES = {
     "CTAG1A/CTAG1B": "NY-ESO-1",
 }
+
+
+def expression_level(df) -> str:
+    """Which space an expression frame is in: ``"proteoform"`` if it carries a
+    ``proteoform_key`` column (the collapsed key space, where identical-protein genes
+    are summed into one row), else ``"gene"`` (one row per Ensembl gene).
+
+    The single, uniform way for any code path or caller to be **cognizant** of the
+    level it's holding — so a gene-level dict/stat is never silently mixed with a
+    proteoform-level one. Pair with :func:`collapse_to_proteoforms` to convert
+    gene-level → proteoform-level."""
+    return "proteoform" if "proteoform_key" in getattr(df, "columns", ()) else "gene"
 
 
 def _contract_members(members_label: str) -> str:

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -186,6 +186,27 @@ def test_cohort_mean_expression(monkeypatch):
     assert dict(zip(median["Symbol"], median["expression"])) == {"A": 20.0, "B": 2.0}
 
 
+def test_cohort_mean_expression_scope_threads_to_collapse(monkeypatch):
+    # proteoform scope="genome" must reach collapse_to_proteoforms (the universal
+    # all-genes key space), not just the CTA subset.
+    import cancerdata.proteoforms as pmod
+
+    seen = {}
+
+    def spy_group_map(*, scope="cta"):
+        seen["scope"] = scope
+        return {}  # no groups -> every gene a singleton (proteoform_key = its ENSG)
+
+    monkeypatch.setattr(pmod, "proteoform_group_map", spy_group_map)
+    fixture = pd.DataFrame(
+        {"Ensembl_Gene_ID": ["E1", "E2"], "Symbol": ["A", "B"], "s1": [1.0, 2.0], "s2": [3.0, 4.0]}
+    )
+    monkeypatch.setattr(expression, "per_sample_expression", lambda *a, **k: fixture.copy())
+    out = expression.cohort_mean_expression("X", proteoform=True, scope="genome")
+    assert seen["scope"] == "genome"
+    assert pmod.expression_level(out) == "proteoform"
+
+
 def test_cohort_mean_expression_bad_statistic(monkeypatch):
     monkeypatch.setattr(expression, "per_sample_expression", lambda *a, **k: pd.DataFrame())
     with pytest.raises(ValueError, match="statistic must be"):

--- a/tests/test_proteoforms.py
+++ b/tests/test_proteoforms.py
@@ -61,6 +61,20 @@ def test_ct47_family_is_a_single_large_group():
     assert len(symbol_map[ct47[0]]) >= 10
 
 
+def test_expression_level_marker():
+    from cancerdata import expression_level
+
+    gene = pd.DataFrame({"Ensembl_Gene_ID": ["E1"], "Symbol": ["A"], "s1": [1.0]})
+    assert expression_level(gene) == "gene"
+    assert expression_level(gene.assign(proteoform_key=["E1"])) == "proteoform"
+
+
+def test_genome_scope_is_superset_of_cta():
+    # Every gene mapped to its best protein, genome-wide: the genome registry has many
+    # more identical-protein groups (histones, tubulins, PAR X/Y, …) than the CTA subset.
+    assert len(proteoform_group_map(scope="genome")) > len(proteoform_group_map(scope="cta"))
+
+
 def test_contract_members_factors_common_prefix():
     assert _contract_members("XAGE1A/XAGE1B") == "XAGE1A/B"
     assert _contract_members("CGB3/CGB5/CGB8") == "CGB3/5/8"


### PR DESCRIPTION
Generalizes the proteoform mapping per the design discussion: **every gene → its
best (canonical, longest) protein → genes with a byte-identical best protein share
a proteoform key → proteoform expression is the sum of member gene TPMs** — reachable
uniformly for *all* genes, with the API explicit about gene-level vs proteoform-level.

## What this adds
- **`proteoforms.expression_level(df) → "gene" | "proteoform"`** — the one uniform way
  for any caller/code path to be **cognizant** of the level it holds (the `proteoform_key`
  column is present iff collapsed). So a gene-level dict/stat is never silently mixed
  with a proteoform-level one.
- **`cohort_mean_expression(..., scope="cta" | "genome")`** — threads `scope` into
  `collapse_to_proteoforms`, so proteoform-level expression is reachable for the focused
  CTA set *or* every protein-coding gene. The genome registry ("do this for every gene")
  already ships (`proteoform-groups-genome.csv`, 410 members).
- **Docs** — the proteoforms module docstring now spells out the scheme: best-protein
  basis, TPM summation, `scope` (cta vs genome), and the gene- vs proteoform-level split.

## Already in place (the rest of the proposal)
- *map all genes to best protein* — the generator already groups by canonical/longest
  protein (`generate_proteoform_groups.py`, `--scope genome` for all genes).
- *a key per shared protein sequence* — `proteoform_key` (ENSG for 1:1, proteoform symbol
  for groups); the genome registry covers all genes.
- *sum gene TPMs uniformly* — `collapse_to_proteoforms` (PRs #91–#93, used uniformly).

## Verified (real LUAD)
gene **34571** → cta-proteoform **34542** → genome-proteoform **34428** (143 genes merged
genome-wide vs 29 for CTAs); each frame self-identifies via `expression_level`.

## Tests
370 pass. New: `expression_level` marker, genome ⊃ cta registry, `scope` threading into
the collapse.

## Deferred / notes
- Coverage stays CTA-scoped by design (CTA antigen panels).
- Genome-scope **percentile / within-sample** artifacts would need a regen with
  `--scope genome` (operational); the runtime `cohort_mean_expression(scope="genome")`
  works today since it collapses on the fly.
- "Best protein" = canonical/longest (build-time). Switching to a TSL/MANE-based "best"
  would change groupings and need a registry regen — out of scope here.