### PR TITLE
Compute proteoform percentiles/within-sample on the fly (no shard/regen needed)

### DIFF
--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -346,8 +346,27 @@ def representative_cohort_samples(
     return long
 
 
+def _biological_per_sample(code, *, proteoform: bool, auto_fetch: bool) -> pd.DataFrame:
+    """Clean-TPM per-sample matrix with technical/censored genes dropped — the
+    biological view the summary artifacts are built on — collapsed to proteoform level
+    when requested. The runtime input to the percentile / within-sample build cores,
+    so a summary can be recomputed on the fly from the per-sample matrix (no shard)."""
+    from ._build import sample_columns
+    from .gene_families import clean_tpm_censored_gene_ids
+
+    clean = per_sample_expression(code, normalize="tpm_clean", auto_fetch=auto_fetch)
+    censored = clean_tpm_censored_gene_ids()
+    unversioned = clean["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+    bio = clean[~unversioned.isin(censored)].reset_index(drop=True)
+    if proteoform:
+        from .proteoforms import collapse_to_proteoforms
+
+        bio = collapse_to_proteoforms(bio, sample_cols=sample_columns(bio))
+    return bio
+
+
 def cohort_gene_percentiles(
-    cancer_type, *, as_tpm: bool = True, proteoform: bool = False
+    cancer_type, *, as_tpm: bool = True, proteoform: bool = False, auto_fetch: bool = False
 ) -> pd.DataFrame:
     """Tail-weighted per-gene percentile vector for one cohort.
 
@@ -359,23 +378,35 @@ def cohort_gene_percentiles(
     Computed on the biological clean TPM view (technical genes dropped).
     Stored compactly as ``log1p`` + float16; ``as_tpm=True`` (default)
     ``expm1``-restores clean-TPM values, ``as_tpm=False`` returns the stored
-    log1p values. Raises if the cohort has no per-sample data (summary-only
-    cohorts have no vector — see :func:`available_percentile_cohorts`).
+    log1p values.
 
-    With ``proteoform=True``, reads the proteoform-summed variant: identical-protein
-    members were summed per sample **before** the percentiles were computed, so the
-    vector is one row per proteoform key (``proteoform_key``/``Symbol`` carry the
-    collapsed identity); build it with ``generate_cohort_percentiles.py --proteoform``.
+    With ``proteoform=True``, the vector is one row per proteoform key
+    (``proteoform_key``/``Symbol`` carry the collapsed identity), identical-protein
+    members summed **before** the percentiles are computed.
+
+    The shipped percentile **shard** can't be converted to the proteoform view (you
+    can't sum already-computed percentiles), so when no shard is present the vector is
+    **recomputed on the fly** from the per-sample matrix via the same build core — the
+    live path for the proteoform variant until its shard ships. That needs the cohort's
+    per-sample matrix cached (pass ``auto_fetch=True`` to download it); otherwise a
+    clear error.
     """
     code = resolve_cancer_type(cancer_type)
     shard = _percentiles_root(proteoform=proteoform) / f"{code}.parquet"
-    if not shard.exists():
-        variant = "proteoform-summed " if proteoform else ""
-        raise ValueError(
-            f"no {variant}percentile vector for {code!r} — only cohorts with per-sample "
-            f"data ship one; see available_percentile_cohorts(proteoform={proteoform})."
-        )
-    df = pd.read_parquet(shard)
+    if shard.exists():
+        df = pd.read_parquet(shard)
+    else:
+        from ._build import cohort_percentile_vectors, sample_columns
+
+        try:
+            bio = _biological_per_sample(code, proteoform=proteoform, auto_fetch=auto_fetch)
+        except FileNotFoundError as e:
+            variant = "proteoform-summed " if proteoform else ""
+            raise ValueError(
+                f"no {variant}percentile vector for {code!r} and its per-sample matrix "
+                f"isn't cached — fetch it (source_matrices.fetch / auto_fetch=True)."
+            ) from e
+        df = cohort_percentile_vectors(bio, sample_columns(bio))
     bp_cols = [c for c in df.columns if c not in ID_COLUMNS]
     df[bp_cols] = df[bp_cols].astype("float32")
     if as_tpm:
@@ -405,7 +436,7 @@ def available_within_sample_cohorts(*, proteoform: bool = False) -> list[str]:
 
 
 def within_sample_top_fraction(
-    cancer_type, *, threshold: float = 0.95, proteoform: bool = False
+    cancer_type, *, threshold: float = 0.95, proteoform: bool = False, auto_fetch: bool = False
 ) -> pd.DataFrame:
     """Per-gene fraction of a cohort's samples in which the gene is highly
     expressed *within that sample* — the "top ~5% expressed gene in this tumor"
@@ -413,34 +444,40 @@ def within_sample_top_fraction(
 
     Returns one row per gene (``Ensembl_Gene_ID`` + ``Symbol``) with the
     ``frac_samples_top{1,5,10}pct`` column for the requested ``threshold``
-    (0.99 / 0.95 / 0.90) plus ``n_samples``. Raises if the cohort has no
-    within-sample shard — that table is built offline from per-sample matrices
-    (see ``scripts/generate_within_sample_top5.py``) and shipped in the bundle.
+    (0.99 / 0.95 / 0.90) plus ``n_samples``.
 
-    With ``proteoform=True``, reads the proteoform-summed variant: identical-
-    protein paralogs (CTAG1A+CTAG1B, the CT47A family, …) are summed per sample
-    *before* the within-sample ranking, so a duplicated antigen is ranked as one
-    proteoform rather than several individually-diluted genes. Rows for those
-    members are replaced by a single proteoform-labelled row; build it with
-    ``generate_within_sample_top5.py --proteoform``. Note that collapsing members
-    shrinks the gene axis the percentiles are computed over, so an ungrouped
-    gene's fraction can shift slightly between the two variants — they are not
-    row-for-row comparable for genes outside any proteoform group.
+    With ``proteoform=True``, identical-protein paralogs (CTAG1A+CTAG1B, the CT47A
+    family, …) are summed per sample *before* the within-sample ranking, so a
+    duplicated antigen is ranked as one proteoform rather than several individually-
+    diluted genes (``proteoform_key``/``Symbol`` carry the collapsed identity). Note
+    collapsing members shrinks the gene axis the within-sample rank is computed over,
+    so an ungrouped gene's fraction can shift slightly vs the gene variant.
+
+    Reads the shipped shard when present, else **recomputes on the fly** from the
+    per-sample matrix via the same build core (the live path for the proteoform
+    variant until its shard ships) — needs the cohort's per-sample matrix cached (pass
+    ``auto_fetch=True`` to download it), else a clear error.
     """
     col = _WITHIN_SAMPLE_THRESHOLD_COLS.get(threshold)
     if col is None:
         raise ValueError(f"threshold must be one of {sorted(_WITHIN_SAMPLE_THRESHOLD_COLS)}")
     code = resolve_cancer_type(cancer_type)
     shard = _within_sample_root(proteoform=proteoform) / f"{code}.parquet"
-    if not shard.exists():
-        variant = "proteoform-summed " if proteoform else ""
-        raise ValueError(
-            f"no {variant}within-sample top-fraction vector for {code!r} — only "
-            f"cohorts with per-sample data ship one; see "
-            f"available_within_sample_cohorts(proteoform={proteoform})."
-        )
-    df = pd.read_parquet(shard)
-    keep = ["Ensembl_Gene_ID", "Symbol", col]
+    if shard.exists():
+        df = pd.read_parquet(shard)
+    else:
+        from ._build import sample_columns, within_sample_top_fractions
+
+        try:
+            bio = _biological_per_sample(code, proteoform=proteoform, auto_fetch=auto_fetch)
+        except FileNotFoundError as e:
+            variant = "proteoform-summed " if proteoform else ""
+            raise ValueError(
+                f"no {variant}within-sample top-fraction vector for {code!r} and its "
+                f"per-sample matrix isn't cached — fetch it (auto_fetch=True)."
+            ) from e
+        df = within_sample_top_fractions(bio, sample_columns(bio))
+    keep = [c for c in ID_COLUMNS if c in df.columns] + [col]
     if "n_samples" in df.columns:
         keep.append("n_samples")
     return df[keep]
@@ -544,28 +581,43 @@ def proteoform_cohort_mean_expression(
     )
 
 
-def gene_cohort_percentiles(cancer_type, *, as_tpm: bool = True) -> pd.DataFrame:
+def gene_cohort_percentiles(
+    cancer_type, *, as_tpm: bool = True, auto_fetch: bool = False
+) -> pd.DataFrame:
     """Gene-level per-cohort **percentile vectors**. Proteoform counterpart:
     :func:`proteoform_cohort_percentiles`. (Alias of :func:`cohort_gene_percentiles`.)"""
-    return cohort_gene_percentiles(cancer_type, as_tpm=as_tpm)
+    return cohort_gene_percentiles(cancer_type, as_tpm=as_tpm, auto_fetch=auto_fetch)
 
 
-def proteoform_cohort_percentiles(cancer_type, *, as_tpm: bool = True) -> pd.DataFrame:
+def proteoform_cohort_percentiles(
+    cancer_type, *, as_tpm: bool = True, auto_fetch: bool = False
+) -> pd.DataFrame:
     """Proteoform-level per-cohort **percentile vectors** (members summed before
-    ranking). Gene-level counterpart: :func:`gene_cohort_percentiles`."""
-    return cohort_gene_percentiles(cancer_type, as_tpm=as_tpm, proteoform=True)
+    ranking). Gene-level counterpart: :func:`gene_cohort_percentiles`. Computed on the
+    fly from the per-sample matrix until the proteoform shard ships (``auto_fetch=True``
+    to download the matrix)."""
+    return cohort_gene_percentiles(
+        cancer_type, as_tpm=as_tpm, proteoform=True, auto_fetch=auto_fetch
+    )
 
 
-def gene_within_sample_top_fraction(cancer_type, *, threshold: float = 0.95) -> pd.DataFrame:
+def gene_within_sample_top_fraction(
+    cancer_type, *, threshold: float = 0.95, auto_fetch: bool = False
+) -> pd.DataFrame:
     """Gene-level within-sample top-fraction prevalence. Proteoform counterpart:
     :func:`proteoform_within_sample_top_fraction`."""
-    return within_sample_top_fraction(cancer_type, threshold=threshold)
+    return within_sample_top_fraction(cancer_type, threshold=threshold, auto_fetch=auto_fetch)
 
 
-def proteoform_within_sample_top_fraction(cancer_type, *, threshold: float = 0.95) -> pd.DataFrame:
+def proteoform_within_sample_top_fraction(
+    cancer_type, *, threshold: float = 0.95, auto_fetch: bool = False
+) -> pd.DataFrame:
     """Proteoform-level within-sample top-fraction prevalence. Gene-level counterpart:
-    :func:`gene_within_sample_top_fraction`."""
-    return within_sample_top_fraction(cancer_type, threshold=threshold, proteoform=True)
+    :func:`gene_within_sample_top_fraction`. Computed on the fly from the per-sample
+    matrix until the proteoform shard ships (``auto_fetch=True`` to download it)."""
+    return within_sample_top_fraction(
+        cancer_type, threshold=threshold, proteoform=True, auto_fetch=auto_fetch
+    )
 
 
 def gene_representative_samples(

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -55,7 +55,16 @@ def test_cohort_gene_percentiles_resolves_alias(percentile_cache):
     assert len(df) == 2
 
 
-def test_cohort_gene_percentiles_missing_raises(percentile_cache):
+def _no_cached_matrix(monkeypatch):
+    def _raise(*a, **k):
+        raise FileNotFoundError("not cached")
+
+    monkeypatch.setattr(expression, "per_sample_expression", _raise)
+
+
+def test_cohort_gene_percentiles_missing_raises(percentile_cache, monkeypatch):
+    # No shard AND no cached matrix (on-the-fly can't run) -> clear error.
+    _no_cached_matrix(monkeypatch)
     with pytest.raises(ValueError, match="no percentile vector"):
         expression.cohort_gene_percentiles("BRCA")
 
@@ -92,9 +101,38 @@ def test_cohort_gene_percentiles_proteoform(proteoform_percentile_cache):
     assert set(df.columns) >= {"proteoform_key", "Ensembl_Gene_ID", "Symbol", "proteoform_members"}
 
 
-def test_cohort_gene_percentiles_proteoform_missing_raises(proteoform_percentile_cache):
+def test_cohort_gene_percentiles_proteoform_missing_raises(
+    proteoform_percentile_cache, monkeypatch
+):
+    _no_cached_matrix(monkeypatch)
     with pytest.raises(ValueError, match="no proteoform-summed percentile vector"):
         expression.cohort_gene_percentiles("BRCA", proteoform=True)
+
+
+def test_cohort_gene_percentiles_proteoform_computed_on_the_fly(
+    proteoform_percentile_cache, monkeypatch
+):
+    # LUAD has no proteoform shard -> the percentile vector is recomputed on the fly
+    # from the (stubbed) per-sample matrix: members collapse before the percentiles.
+    import cancerdata.proteoforms as pmod
+
+    fake = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG_A1", "ENSG_A2", "ENSG_B"],
+            "Symbol": ["A1", "A2", "B"],
+            "s1": [3.0, 5.0, 1.0],
+            "s2": [9.0, 1.0, 4.0],
+        }
+    )
+    monkeypatch.setattr(expression, "per_sample_expression", lambda code, **k: fake.copy())
+    monkeypatch.setattr(
+        pmod, "proteoform_group_map", lambda *, scope="cta": {"A1/A2": ["ENSG_A1", "ENSG_A2"]}
+    )
+    out = expression.cohort_gene_percentiles("LUAD", proteoform=True)
+    assert "proteoform_key" in out.columns
+    assert "A1/2" in set(out["Symbol"]) and "A1" not in set(out["Symbol"])
+    # A1/A2 summed per sample: s1=8, s2=10 -> p100 (max) restores to 10.0 TPM
+    assert out.set_index("Symbol").loc["A1/2", "p100"] == pytest.approx(10.0, rel=1e-2)
 
 
 def test_representatives_provenance_requires_long_format():

--- a/tests/test_within_sample_proteoform.py
+++ b/tests/test_within_sample_proteoform.py
@@ -126,6 +126,40 @@ def test_accessor_reads_proteoform_variant(proteoform_within_sample_cache):
     assert out.set_index("Symbol").loc["SSX4/SSX4B", "frac_samples_top5pct"] == 0.42
 
 
-def test_accessor_proteoform_missing_shard_raises(proteoform_within_sample_cache):
-    with pytest.raises(ValueError, match="proteoform-summed"):
+def test_accessor_proteoform_missing_shard_and_matrix_raises(
+    proteoform_within_sample_cache, monkeypatch
+):
+    # No proteoform shard AND no cached per-sample matrix -> a clear error, not a
+    # silent failure (the on-the-fly path needs the matrix).
+    from cancerdata import expression
+
+    def _no_matrix(*a, **k):
+        raise FileNotFoundError("not cached")
+
+    monkeypatch.setattr(expression, "per_sample_expression", _no_matrix)
+    with pytest.raises(ValueError, match="per-sample matrix isn't cached"):
         within_sample_top_fraction("LUAD", proteoform=True)
+
+
+def test_accessor_proteoform_computed_on_the_fly(proteoform_within_sample_cache, monkeypatch):
+    # No proteoform shard for LUAD -> the proteoform within-sample vector is recomputed
+    # on the fly from the (stubbed) per-sample matrix: members collapse before ranking.
+    import cancerdata.proteoforms as pmod
+    from cancerdata import expression
+
+    fake = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG_A1", "ENSG_A2", "ENSG_B"],
+            "Symbol": ["A1", "A2", "B"],
+            "s1": [3.0, 5.0, 1.0],
+            "s2": [4.0, 4.0, 2.0],
+            "s3": [10.0, 0.0, 50.0],
+        }
+    )
+    monkeypatch.setattr(expression, "per_sample_expression", lambda code, **k: fake.copy())
+    monkeypatch.setattr(
+        pmod, "proteoform_group_map", lambda *, scope="cta": {"A1/A2": ["ENSG_A1", "ENSG_A2"]}
+    )
+    out = within_sample_top_fraction("LUAD", threshold=0.95, proteoform=True)
+    assert "proteoform_key" in out.columns
+    assert "A1/2" in set(out["Symbol"]) and "A1" not in set(out["Symbol"])  # collapsed


### PR DESCRIPTION
**Why the gene shard can't be converted, but the matrix can.** The shipped *gene*
percentile / within-sample **shards** are already-aggregated (p0…p100 per gene,
fractions) — you can't sum already-computed percentiles, so you can't derive the
proteoform view from them. But the **per-sample matrix** can: sum member TPMs per
sample, then run the *same* build core. (Representatives already did this; their shard
is per-sample medoids.)

## Change
When no shard is present, `cohort_gene_percentiles` and `within_sample_top_fraction`
**recompute on the fly** from the per-sample matrix:
`per_sample_expression(tpm_clean)` → drop technical/censored genes → optional
`collapse_to_proteoforms` → `cohort_percentile_vectors` / `within_sample_top_fractions`
— exactly mirroring `rebuild_expression_artifacts.py`.

- **Removes the "needs regen" blocker** for the proteoform percentile/within-sample
  variants — live today for any cohort whose per-sample matrix is cached.
- New `auto_fetch=` (default `False`) on both accessors + their `gene_*`/`proteoform_*`
  wrappers; pass `True` to download the matrix. Clear error when neither shard nor
  matrix is available.
- Shared `_biological_per_sample` helper = the runtime input to both build cores.

## Trade-off
On-the-fly needs the per-sample matrix (the big on-demand asset) and runs the
percentile/rank computation at read time (vs reading a tiny shard). The gene shards
stay the fast default; on-the-fly is the proteoform fallback (and a fallback for any
cohort missing a gene shard).

## Verified
`proteoform_cohort_percentiles('LUAD')` computes **32847** proteoform rows with **no
shard**; `NY-ESO-1` gets its own summed percentile vector.

## Tests
376 pass. New: on-the-fly compute for percentiles + within-sample (stubbed matrix);
the "missing" tests now assert the deterministic no-shard-AND-no-matrix error.