### PR TITLE
Rename cohort-stats q1/median/q3 -> p25/p50/p75 (uniform percentile ladder)

### DIFF
--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -289,9 +289,9 @@ _COHORT_STAT_PERCENTILES = {
     5: "p5",
     10: "p10",
     20: "p20",
-    25: "q1",
-    50: "median",
-    75: "q3",
+    25: "p25",
+    50: "p50",
+    75: "p75",
     80: "p80",
     90: "p90",
     95: "p95",
@@ -309,8 +309,8 @@ def cohort_stats(
     scope: str = "cta",
 ) -> pd.DataFrame:
     """Per-gene **summary statistics** across a cohort's samples, in one pass —
-    ``mean``, ``std`` and the percentiles ``min, p1, p5, p10, p20, q1, median, q3,
-    p80, p90, p95, p99, max``.
+    ``mean``, ``std`` and a uniform percentile ladder ``min, p1, p5, p10, p20, p25,
+    p50, p75, p80, p90, p95, p99, max`` (``p25``/``p50``/``p75`` are q1/median/q3).
 
     The richer companion to :func:`cohort_mean_expression` (a single statistic) and
     :func:`cohort_gene_percentiles` (the dense percentile vector): everything a consumer
@@ -663,8 +663,9 @@ def proteoform_cohort_mean_expression(
 def gene_cohort_stats(
     cancer_type, *, normalize: str = "tpm_clean", auto_fetch: bool = True
 ) -> pd.DataFrame:
-    """Gene-level per-gene cohort **summary statistics** (mean/std/min/p1/p5/p10/p20/q1/
-    median/q3/p80/p90/p95/p99/max). Proteoform counterpart: :func:`proteoform_cohort_stats`."""
+    """Gene-level per-gene cohort **summary statistics** (mean/std + the percentile ladder
+    min/p1/p5/p10/p20/p25/p50/p75/p80/p90/p95/p99/max). Proteoform counterpart:
+    :func:`proteoform_cohort_stats`."""
     return cohort_stats(cancer_type, normalize=normalize, auto_fetch=auto_fetch)
 
 
@@ -829,7 +830,7 @@ def pooled_cohort_stats(
     denominator ``n_available`` (not the constant ``n_samples``) is the honest one.
 
     Returns an id-keyed frame with the same statistic suite as :func:`cohort_stats`
-    (``mean, std, min, p1, p5, p10, p20, q1, median, q3, p80, p90, p95, p99, max`` over the
+    (``mean, std, min, p1, p5, p10, p20, p25, p50, p75, p80, p90, p95, p99, max`` over the
     pooled samples) plus the pooling columns:
 
     - ``balanced_mean`` — the mean of each cohort's per-gene mean, **equal weight

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -383,9 +383,9 @@ def test_cohort_stats_full_suite(monkeypatch):
         "p5",
         "p10",
         "p20",
-        "q1",
-        "median",
-        "q3",
+        "p25",
+        "p50",
+        "p75",
         "p80",
         "p90",
         "p95",
@@ -396,8 +396,8 @@ def test_cohort_stats_full_suite(monkeypatch):
     assert row["mean"] == pytest.approx(25.0)
     assert row["std"] == pytest.approx(np.std([10, 20, 30, 40]))
     assert row["min"] == 10.0 and row["max"] == 40.0
-    assert row["median"] == pytest.approx(25.0)
-    assert row["q1"] == pytest.approx(17.5) and row["q3"] == pytest.approx(32.5)
+    assert row["p50"] == pytest.approx(25.0)
+    assert row["p25"] == pytest.approx(17.5) and row["p75"] == pytest.approx(32.5)
     assert row["p90"] == pytest.approx(37.0)
 
 


### PR DESCRIPTION
Per the suggestion to name the quartiles as percentiles: the `cohort_stats` / `pooled_cohort_stats` suite now reads a single uniform `p<N>` ladder —

`min, p1, p5, p10, p20, p25, p50, p75, p80, p90, p95, p99, max`

This **aligns with the existing convention**: the percentile-vector shards (`cohort_gene_percentiles`) already use `p25/p50/p75` column names, and `plots._STAT_PERCENTILE_COL` maps the friendly `q1/median/q3` selectors onto them. The `q1/median/q3` naming in cohort-stats was the odd one out.

Touches `_COHORT_STAT_PERCENTILES` (one map → both accessors + `gene_*`/`proteoform_*` wrappers), the docstrings, and the full-suite test. The separate `cohort_mean_expression(statistic="median")` reducer and the CLI plot-stat selector are unchanged.

Friendly `median`/`q1`/`q3` aliases can be layered back later (e.g. as accessor properties) without disturbing this canonical `p<N>` space. Verified on real LUAD+SKCM; suite 32 passed.