### PR TITLE
Review fixes: aggregate expansion, std NaN for n<2, dedup stat loop

### DIFF
--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -29,6 +29,7 @@ target-selection consumes.
 from __future__ import annotations
 
 import os
+import warnings
 from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
@@ -302,6 +303,24 @@ _COHORT_STAT_PERCENTILES = {
 }
 
 
+def _write_cohort_stat_columns(out: pd.DataFrame, mat: np.ndarray) -> None:
+    """Write the ``mean``/``std`` + percentile-ladder columns onto ``out`` from a
+    ``(n_genes, n_samples)`` value matrix — **availability-aware** (``NaN`` cells are
+    skipped, so each gene reduces only over the samples that measured it). ``std`` is
+    ``NaN`` for a gene measured by fewer than two samples (a lone observation has no
+    spread — the same ``n >= 2`` rule used for ``std_between``). Shared by
+    :func:`cohort_stats` and :func:`pooled_cohort_stats` so the suite is defined once."""
+    pcts = list(_COHORT_STAT_PERCENTILES)
+    n_obs = np.sum(~np.isnan(mat), axis=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)  # all-NaN gene rows -> NaN
+        out["mean"] = np.nanmean(mat, axis=1)
+        out["std"] = np.where(n_obs >= 2, np.nanstd(mat, axis=1), np.nan)
+        q = np.nanpercentile(mat, pcts, axis=1)  # (len(pcts), n_genes)
+    for i, p in enumerate(pcts):
+        out[_COHORT_STAT_PERCENTILES[p]] = q[i]
+
+
 def cohort_stats(
     cancer_type,
     *,
@@ -325,8 +344,6 @@ def cohort_stats(
     sample first, ``scope`` ``"cta"``/``"genome"``) — a proteoform-level frame carrying
     ``proteoform_key`` (see :func:`cancerdata.proteoforms.expression_level`). Returns the
     id columns plus one column per statistic."""
-    import warnings
-
     df = per_sample_expression(
         cancer_type, normalize=normalize, auto_fetch=auto_fetch, proteoform=proteoform, scope=scope
     )
@@ -334,16 +351,8 @@ def cohort_stats(
     samples = [c for c in df.columns if c not in id_cols]
     if not samples:
         raise ValueError(f"no per-sample columns to summarize for {cancer_type!r}")
-    mat = df[samples].to_numpy(dtype=float)
     out = df[id_cols].copy()
-    pcts = list(_COHORT_STAT_PERCENTILES)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", RuntimeWarning)  # all-NaN gene rows -> NaN
-        out["mean"] = np.nanmean(mat, axis=1)
-        out["std"] = np.nanstd(mat, axis=1)
-        q = np.nanpercentile(mat, pcts, axis=1)  # (len(pcts), n_genes)
-    for i, p in enumerate(pcts):
-        out[_COHORT_STAT_PERCENTILES[p]] = q[i]
+    _write_cohort_stat_columns(out, df[samples].to_numpy(dtype=float))
     return out
 
 
@@ -850,10 +859,10 @@ def pooled_cohort_stats(
     ``min_cohorts`` drops genes measured by fewer than that many cohorts (default
     ``1`` keeps everything). ``normalize`` selects the pooling space (linear clean
     TPM by default; see :func:`per_sample_expression`). ``proteoform=True`` pools
-    the reduced proteoform key space (``scope`` ``"cta"``/``"genome"``)."""
-    import warnings
-
-    codes = _resolve_cancer_types(cancer_types)
+    the reduced proteoform key space (``scope`` ``"cta"``/``"genome"``). An aggregate
+    code (e.g. ``"SARC"``) expands to its member subtypes — pooling them is exactly
+    what a rollup cohort means."""
+    codes = _resolve_cancer_types(cancer_types, expand_aggregates=True)
     codes = list(dict.fromkeys(codes or []))
     if not codes:
         raise ValueError("pooled_cohort_stats needs at least one cancer type")
@@ -890,14 +899,7 @@ def pooled_cohort_stats(
     measured = pooled.notna()
     mat = pooled.to_numpy(dtype=float)
     out = ids.reset_index()
-    pcts = list(_COHORT_STAT_PERCENTILES)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", RuntimeWarning)  # all-NaN gene rows -> NaN
-        out["mean"] = np.nanmean(mat, axis=1)
-        out["std"] = np.nanstd(mat, axis=1)
-        q = np.nanpercentile(mat, pcts, axis=1)
-    for i, p in enumerate(pcts):
-        out[_COHORT_STAT_PERCENTILES[p]] = q[i]
+    _write_cohort_stat_columns(out, mat)
     cohort_mean_mat = per_cohort_mean.to_numpy(dtype=float)
     n_cohorts = per_cohort_mean.notna().to_numpy().sum(axis=1)
     with warnings.catch_warnings():

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -498,9 +498,28 @@ def test_pooled_cohort_stats_availability_and_heterogeneity(monkeypatch):
     assert out.loc["E2", "std_between"] == pytest.approx(np.std([2.0, 100.0]))
     # A single-cohort gene has no between-cohort spread.
     assert np.isnan(out.loc["E1", "std_between"])
+    # std is NaN for a gene with <2 measured samples (E3: one sample in SMALL); a
+    # multi-sample gene gets a real std.
+    assert np.isnan(out.loc["E3", "std"])
+    assert out.loc["E1", "std"] == pytest.approx(np.std([10.0, 20.0, 30.0]))
     # Off-panel cells are never imputed to zero: E1's max is BIG's max (30), not
     # dragged down by SMALL's missing samples.
     assert out.loc["E1", "max"] == 30.0
+
+
+def test_pooled_cohort_stats_expands_aggregate_cohorts(monkeypatch):
+    # An aggregate code (CRC = COAD + READ) pools its member subtypes, not the
+    # rollup label (which has no per-sample matrix of its own).
+    served = {
+        "COAD": pd.DataFrame({"Ensembl_Gene_ID": ["E1"], "Symbol": ["A"], "c1": [10.0]}),
+        "READ": pd.DataFrame({"Ensembl_Gene_ID": ["E1"], "Symbol": ["A"], "r1": [20.0]}),
+    }
+    monkeypatch.setattr(expression, "per_sample_expression", lambda code, **k: served[code].copy())
+    out = expression.pooled_cohort_stats(["CRC"]).set_index("Ensembl_Gene_ID")
+    # Both members contributed: 2 cohorts, 2 samples, pooled mean (10+20)/2 = 15.
+    assert out.loc["E1", "n_cohorts"] == 2
+    assert out.loc["E1", "n_samples"] == 2
+    assert out.loc["E1", "mean"] == pytest.approx(15.0)
 
 
 def test_pooled_cohort_stats_min_cohorts_filter(monkeypatch):


### PR DESCRIPTION
Fixes from reviewing the new accessors (#99–#105). Two correctness issues + one maintenance cleanup.

## Fixes

**1. `pooled_cohort_stats` now expands aggregate cohort codes (bug).** It resolved with `_resolve_cancer_types(cancer_types)` — no `expand_aggregates=True` — unlike its sibling `representative_cohort_samples`. So `pooled_cohort_stats(["SARC"])` (or `CRC`, `NET`, the `SARC_*` rollups) hit `per_sample_expression("SARC")` and raised, since aggregates have no own per-sample matrix. Now it expands to member subtypes and pools them — which is exactly what a rollup cohort *means* for a pooling function.

**2. `std` is now `NaN` for a gene measured by <2 samples (consistency bug).** `np.nanstd` returns `0.0` for a single observation — indistinguishable from a genuinely invariant gene. The `std_between` column already guards `n_cohorts >= 2` and its comment claimed it "mirrors std's >=2 rule," but `std` had no such rule. Now it does (matches pirlygenes' "std NaN where <2 samples"). Realistic under ragged cross-cohort pooling where a gene can have `n_available == 1`.

**3. Deduplicated the stat-computation loop (maintenance).** The mean/std/`nanpercentile` block + writeback was copy-pasted verbatim in `cohort_stats` and `pooled_cohort_stats`. Factored into `_write_cohort_stat_columns(out, mat)` so the suite — and fix #2 — lives in one place; the shared `_COHORT_STAT_PERCENTILES` dict no longer has a duplicated consumer. Moved `import warnings` to module level (was function-local in two spots).

## Not changed (considered, deferred)
- A reviewer flagged `tpm_to_housekeeping_normalized` silently skipping normalization when a sample's HK-panel denominator is ≤0 — real but **pre-existing** (not introduced this session) and very low-likelihood on real data; out of scope for this PR.
- `lru_cache(maxsize=2)` on the matrix loader means pooling ≥3 cohorts re-reads matrices — pure performance, left as-is.

## Tests
New: `test_pooled_cohort_stats_expands_aggregate_cohorts` (CRC→COAD+READ pools both members). Augmented the heterogeneity test to assert `std` is NaN for the single-sample gene and a real std for the multi-sample one. Refactor verified behavior-preserving on real LUAD+SKCM. Suite: 33 passed.