### PR TITLE
Fix deferred review items: HK scale-mixing + tunable per-sample cache

### DIFF
--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -50,6 +50,13 @@ _PERCENTILES_PROTEOFORM_DIR = "cancer-reference-expression-percentiles-proteofor
 _WITHIN_SAMPLE_DIR = "cancer-reference-expression-within-sample-top5"
 _WITHIN_SAMPLE_PROTEOFORM_DIR = "cancer-reference-expression-within-sample-top5-proteoform"
 
+# How many cleaned per-sample matrices to keep in the in-process LRU. Each frame is
+# a full gene x sample matrix (~100MB+), so the default is intentionally small. A
+# workflow that pools the same N>2 cohorts repeatedly (e.g. a gene then a proteoform
+# pool over one cohort set) can raise CANCERDATA_PER_SAMPLE_CACHE to keep them all
+# warm and skip the re-read, trading memory for latency.
+_PER_SAMPLE_CACHE_SIZE = max(1, int(os.environ.get("CANCERDATA_PER_SAMPLE_CACHE", "2")))
+
 
 def _bundle_subdir(name: str, *, auto_fetch: bool = True) -> Path:
     """Locate a bundle shard directory: an in-repo checkout (``cancerdata/data/…``)
@@ -206,7 +213,7 @@ def per_sample_expression(
     return out
 
 
-@lru_cache(maxsize=2)
+@lru_cache(maxsize=_PER_SAMPLE_CACHE_SIZE)
 def _load_per_sample_matrix(path: str, mtime: float, normalize: str) -> pd.DataFrame:
     """Read + normalize one cohort's per-sample matrix (the cached canonical frame).
     ``path``/``mtime`` identify the on-disk parquet (mtime keys cache invalidation);

--- a/cancerdata/normalization.py
+++ b/cancerdata/normalization.py
@@ -474,6 +474,12 @@ def tpm_to_housekeeping_normalized(
         if denom > 0:
             out[col] = pd.to_numeric(out[col], errors="coerce") / denom
             applied = True
+        else:
+            # No measurable panel genes in this column -> it can't be put on the
+            # ratio-to-baseline scale. Blank it to NaN rather than silently leaving
+            # it on the raw-TPM scale alongside normalized siblings (the scale-mixing
+            # trap; matches normalize_to_housekeeping's contract).
+            out[col] = np.nan
     return out, {
         "applied": applied,
         "reason": "divided by housekeeping geometric mean" if applied else "panel denominator <= 0",

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -157,6 +157,15 @@ def _raw_matrix(tmp_path):
     return path
 
 
+def test_per_sample_matrix_cache_size_is_tunable():
+    # The LRU is wired to the (env-configurable) constant, not a hardcoded literal,
+    # so heavy pooling workflows can keep >2 matrices warm via CANCERDATA_PER_SAMPLE_CACHE.
+    assert (
+        expression._load_per_sample_matrix.cache_info().maxsize == expression._PER_SAMPLE_CACHE_SIZE
+    )
+    assert expression._PER_SAMPLE_CACHE_SIZE >= 1
+
+
 def test_per_sample_expression_normalize_modes(tmp_path, monkeypatch):
     path = _raw_matrix(tmp_path)
     monkeypatch.setattr(expression.source_matrices, "ensure", lambda code: path)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -226,3 +226,27 @@ def test_tpm_to_housekeeping_normalized():
     # geomean of [100,100] (+0.1) ~ 100.1 -> GENE 50 / 100.1 ~ 0.4995
     assert stats["applied"] is True
     assert out.loc[out["Symbol"] == "GENE", "s1_TPM"].iloc[0] == pytest.approx(50 / 100.1, rel=1e-3)
+
+
+def test_tpm_to_housekeeping_normalized_blanks_column_with_no_panel():
+    # A column whose housekeeping panel rows are all NaN can't be put on the
+    # ratio-to-baseline scale; it must become NaN, not silently stay raw-TPM
+    # alongside normalized siblings (the scale-mixing trap).
+    from cancerdata import gene_families
+
+    hk = list(gene_families.housekeeping_gene_ids())[:2]
+    df = pd.DataFrame(
+        {
+            "Symbol": ["HK1", "HK2", "GENE"],
+            "Ensembl_Gene_ID": [hk[0], hk[1], "ENSG_X"],
+            "good_TPM": [100.0, 100.0, 50.0],
+            "empty_TPM": [np.nan, np.nan, 50.0],  # panel genes unmeasured here
+        }
+    )
+    out, stats = norm.tpm_to_housekeeping_normalized(df, value_cols=["good_TPM", "empty_TPM"])
+    # The measurable column is normalized; the panel-less column is fully NaN, not 50.0.
+    assert out.loc[out["Symbol"] == "GENE", "good_TPM"].iloc[0] == pytest.approx(
+        50 / 100.1, rel=1e-3
+    )
+    assert out["empty_TPM"].isna().all()
+    assert stats["columns"]["empty_TPM"]["denominator"] == 0.0


### PR DESCRIPTION
The two items deferred from the #106 review.

## 1. Housekeeping scale-mixing (correctness)

`tpm_to_housekeeping_normalized` left a value column on the **raw-TPM scale** when its housekeeping-panel denominator was ≤0 (a sample with no measurable panel genes), while sibling columns became unit-free ratio-to-baseline — silently mixing two scales in one frame, which then flows into `per_sample_expression(normalize="tpm_clean_hk")` → `cohort_stats`/`pooled_cohort_stats`.

Now such a column is blanked to `NaN` (it genuinely can't be normalized), matching the documented contract of the sibling `normalize_to_housekeeping`. Low-likelihood on real data, but it was a real silent-correctness hole.

## 2. Tunable per-sample matrix cache (performance)

The matrix LRU was a hardcoded `maxsize=2`. Each cached frame is a full gene×sample matrix (~100MB+), so a small default is deliberate — but a workflow that pools the same N>2 cohorts repeatedly (e.g. a gene pool then a proteoform pool over one cohort set) re-reads every matrix on the second call. The cap is now the **`CANCERDATA_PER_SAMPLE_CACHE` env knob (default 2, unchanged)**, so heavy pooling can opt into keeping them warm without imposing memory on the common case.

Note: within a *single* `pooled_cohort_stats` call each cohort is already read exactly once — there was no in-call redundancy to fix (the review note slightly overstated it). This addresses the genuine cross-call case without a default behavior/memory change.

## Tests
- `test_tpm_to_housekeeping_normalized_blanks_column_with_no_panel` — a panel-less column is fully NaN (not raw 50.0) while its measurable sibling normalizes; `denominator == 0.0` in stats.
- `test_per_sample_matrix_cache_size_is_tunable` — the LRU `maxsize` is wired to the constant (so the knob can't silently regress to a literal).

Full suite: 389 passed.