### PR TITLE
Harden CANCERDATA_PER_SAMPLE_CACHE parse against malformed values

### DIFF
--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -50,12 +50,22 @@ _PERCENTILES_PROTEOFORM_DIR = "cancer-reference-expression-percentiles-proteofor
 _WITHIN_SAMPLE_DIR = "cancer-reference-expression-within-sample-top5"
 _WITHIN_SAMPLE_PROTEOFORM_DIR = "cancer-reference-expression-within-sample-top5-proteoform"
 
+
 # How many cleaned per-sample matrices to keep in the in-process LRU. Each frame is
 # a full gene x sample matrix (~100MB+), so the default is intentionally small. A
 # workflow that pools the same N>2 cohorts repeatedly (e.g. a gene then a proteoform
 # pool over one cohort set) can raise CANCERDATA_PER_SAMPLE_CACHE to keep them all
 # warm and skip the re-read, trading memory for latency.
-_PER_SAMPLE_CACHE_SIZE = max(1, int(os.environ.get("CANCERDATA_PER_SAMPLE_CACHE", "2")))
+def _per_sample_cache_size(default: int = 2) -> int:
+    """Parse the cache-size env knob, falling back to ``default`` on any malformed
+    value (empty string, non-integer) — a tuning knob must never break ``import``."""
+    try:
+        return max(1, int(os.environ.get("CANCERDATA_PER_SAMPLE_CACHE", str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+_PER_SAMPLE_CACHE_SIZE = _per_sample_cache_size()
 
 
 def _bundle_subdir(name: str, *, auto_fetch: bool = True) -> Path:

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -166,6 +166,18 @@ def test_per_sample_matrix_cache_size_is_tunable():
     assert expression._PER_SAMPLE_CACHE_SIZE >= 1
 
 
+def test_per_sample_cache_size_tolerates_malformed_env(monkeypatch):
+    # A tuning knob must never break `import cancerdata`: a malformed/empty value
+    # falls back to the default rather than raising at parse time.
+    for bad in ("", "abc", "2.5"):
+        monkeypatch.setenv("CANCERDATA_PER_SAMPLE_CACHE", bad)
+        assert expression._per_sample_cache_size() == 2
+    monkeypatch.setenv("CANCERDATA_PER_SAMPLE_CACHE", "0")  # clamps to >=1
+    assert expression._per_sample_cache_size() == 1
+    monkeypatch.setenv("CANCERDATA_PER_SAMPLE_CACHE", "8")  # honored
+    assert expression._per_sample_cache_size() == 8
+
+
 def test_per_sample_expression_normalize_modes(tmp_path, monkeypatch):
     path = _raw_matrix(tmp_path)
     monkeypatch.setattr(expression.source_matrices, "ensure", lambda code: path)


### PR DESCRIPTION
Self-review finding on #107.

## Bug

The cache-size env knob added in #107 parsed as `max(1, int(os.environ.get("CANCERDATA_PER_SAMPLE_CACHE", "2")))` at module import. A malformed or **empty** value crashes the *entire* `import cancerdata`:

```
$ CANCERDATA_PER_SAMPLE_CACHE= python -c 'import cancerdata'
ValueError: invalid literal for int() with base 10: ''
```

`export CANCERDATA_PER_SAMPLE_CACHE=` (empty) is a common shell accident, and `int("")`/`int("abc")`/`int("2.5")` all raise — bricking the library with a confusing import-time traceback. A performance tuning knob must never be able to break `import`.

## Fix

Parse in a small `_per_sample_cache_size()` helper that falls back to the default `2` on any `TypeError`/`ValueError`. Verified: `""`/`"abc"`/`"2.5"` → 2, `"0"`/`"-3"` → 1 (clamp), `"8"` → 8.

## Test
`test_per_sample_cache_size_tolerates_malformed_env` covers empty/non-int fallback, the ≥1 clamp, and an honored value. 51 passed in the affected files.