### PR TITLE
API coherence: scope= on percentiles/within-sample + proteoform auto_fetch default

### DIFF
--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -524,11 +524,14 @@ def representative_cohort_samples(
     return long
 
 
-def _biological_per_sample(code, *, proteoform: bool, auto_fetch: bool) -> pd.DataFrame:
+def _biological_per_sample(
+    code, *, proteoform: bool, auto_fetch: bool, scope: str = "cta"
+) -> pd.DataFrame:
     """Clean-TPM per-sample matrix with technical/censored genes dropped — the
     biological view the summary artifacts are built on — collapsed to proteoform level
-    when requested. The runtime input to the percentile / within-sample build cores,
-    so a summary can be recomputed on the fly from the per-sample matrix (no shard)."""
+    (in ``scope``) when requested. The runtime input to the percentile / within-sample
+    build cores, so a summary can be recomputed on the fly from the per-sample matrix
+    (no shard). ``scope`` is ignored when ``proteoform`` is False."""
     from .gene_families import clean_tpm_censored_gene_ids
 
     clean = per_sample_expression(code, normalize="tpm_clean", auto_fetch=auto_fetch)
@@ -538,12 +541,12 @@ def _biological_per_sample(code, *, proteoform: bool, auto_fetch: bool) -> pd.Da
     if proteoform:
         from .proteoforms import collapse_to_proteoforms
 
-        bio = collapse_to_proteoforms(bio, sample_cols=sample_columns(bio))
+        bio = collapse_to_proteoforms(bio, scope=scope, sample_cols=sample_columns(bio))
     return bio
 
 
 def _read_shard_or_recompute(
-    dataset: _ShardDataset, code: str, *, proteoform: bool, auto_fetch: bool
+    dataset: _ShardDataset, code: str, *, proteoform: bool, auto_fetch: bool, scope: str = "cta"
 ) -> pd.DataFrame:
     """Read ``code``'s shard for ``dataset``; if no shard is present, recompute it on
     the fly from the per-sample matrix via the dataset's ``_build`` core (the same core
@@ -557,7 +560,9 @@ def _read_shard_or_recompute(
     if shard.exists():
         return pd.read_parquet(shard)
     try:
-        bio = _biological_per_sample(code, proteoform=proteoform, auto_fetch=auto_fetch)
+        bio = _biological_per_sample(
+            code, proteoform=proteoform, auto_fetch=auto_fetch, scope=scope
+        )
     except FileNotFoundError as e:
         variant = "proteoform-summed " if proteoform else ""
         raise ValueError(
@@ -571,7 +576,12 @@ def _read_shard_or_recompute(
 
 
 def cohort_gene_percentiles(
-    cancer_type, *, as_tpm: bool = True, proteoform: bool = False, auto_fetch: bool = False
+    cancer_type,
+    *,
+    as_tpm: bool = True,
+    proteoform: bool = False,
+    scope: str = "cta",
+    auto_fetch: bool = False,
 ) -> pd.DataFrame:
     """Tail-weighted per-gene percentile vector for one cohort.
 
@@ -587,7 +597,8 @@ def cohort_gene_percentiles(
 
     With ``proteoform=True``, the vector is one row per proteoform key
     (``proteoform_key``/``Symbol`` carry the collapsed identity), identical-protein
-    members summed **before** the percentiles are computed.
+    members summed **before** the percentiles are computed (``scope`` ``"cta"``/``"genome"``,
+    ignored when ``proteoform`` is False).
 
     The shipped percentile **shard** can't be converted to the proteoform view (you
     can't sum already-computed percentiles), so when no shard is present the vector is
@@ -597,7 +608,9 @@ def cohort_gene_percentiles(
     clear error.
     """
     code = resolve_cancer_type(cancer_type)
-    df = _read_shard_or_recompute(_PERCENTILES, code, proteoform=proteoform, auto_fetch=auto_fetch)
+    df = _read_shard_or_recompute(
+        _PERCENTILES, code, proteoform=proteoform, auto_fetch=auto_fetch, scope=scope
+    )
     bp_cols = sample_columns(df)
     df[bp_cols] = df[bp_cols].astype("float32")
     if as_tpm:
@@ -621,7 +634,12 @@ def available_within_sample_cohorts(*, proteoform: bool = False) -> list[str]:
 
 
 def within_sample_top_fraction(
-    cancer_type, *, threshold: float = 0.95, proteoform: bool = False, auto_fetch: bool = False
+    cancer_type,
+    *,
+    threshold: float = 0.95,
+    proteoform: bool = False,
+    scope: str = "cta",
+    auto_fetch: bool = False,
 ) -> pd.DataFrame:
     """Per-gene fraction of a cohort's samples in which the gene is highly
     expressed *within that sample* — the "top ~5% expressed gene in this tumor"
@@ -634,7 +652,8 @@ def within_sample_top_fraction(
     With ``proteoform=True``, identical-protein paralogs (CTAG1A+CTAG1B, the CT47A
     family, …) are summed per sample *before* the within-sample ranking, so a
     duplicated antigen is ranked as one proteoform rather than several individually-
-    diluted genes (``proteoform_key``/``Symbol`` carry the collapsed identity). Note
+    diluted genes (``proteoform_key``/``Symbol`` carry the collapsed identity;
+    ``scope`` ``"cta"``/``"genome"``, ignored when ``proteoform`` is False). Note
     collapsing members shrinks the gene axis the within-sample rank is computed over,
     so an ungrouped gene's fraction can shift slightly vs the gene variant.
 
@@ -648,7 +667,7 @@ def within_sample_top_fraction(
         raise ValueError(f"threshold must be one of {sorted(_WITHIN_SAMPLE_THRESHOLD_COLS)}")
     code = resolve_cancer_type(cancer_type)
     df = _read_shard_or_recompute(
-        _WITHIN_SAMPLE, code, proteoform=proteoform, auto_fetch=auto_fetch
+        _WITHIN_SAMPLE, code, proteoform=proteoform, auto_fetch=auto_fetch, scope=scope
     )
     keep = [*id_columns(df), col]
     if "n_samples" in df.columns:
@@ -812,14 +831,16 @@ def gene_cohort_percentiles(
 
 
 def proteoform_cohort_percentiles(
-    cancer_type, *, as_tpm: bool = True, auto_fetch: bool = False
+    cancer_type, *, as_tpm: bool = True, scope: str = "cta", auto_fetch: bool = True
 ) -> pd.DataFrame:
     """Proteoform-level per-cohort **percentile vectors** (members summed before
-    ranking). Gene-level counterpart: :func:`gene_cohort_percentiles`. Computed on the
-    fly from the per-sample matrix until the proteoform shard ships (``auto_fetch=True``
-    to download the matrix)."""
+    ranking, ``scope`` ``"cta"``/``"genome"``). Gene-level counterpart:
+    :func:`gene_cohort_percentiles`. No proteoform shard ships yet, so this **always**
+    recomputes from the per-sample matrix — hence ``auto_fetch`` defaults to ``True``
+    here (unlike the gene variant, which reads a shipped shard); pass ``False`` to
+    require the matrix already be cached."""
     return cohort_gene_percentiles(
-        cancer_type, as_tpm=as_tpm, proteoform=True, auto_fetch=auto_fetch
+        cancer_type, as_tpm=as_tpm, proteoform=True, scope=scope, auto_fetch=auto_fetch
     )
 
 
@@ -832,13 +853,15 @@ def gene_within_sample_top_fraction(
 
 
 def proteoform_within_sample_top_fraction(
-    cancer_type, *, threshold: float = 0.95, auto_fetch: bool = False
+    cancer_type, *, threshold: float = 0.95, scope: str = "cta", auto_fetch: bool = True
 ) -> pd.DataFrame:
-    """Proteoform-level within-sample top-fraction prevalence. Gene-level counterpart:
-    :func:`gene_within_sample_top_fraction`. Computed on the fly from the per-sample
-    matrix until the proteoform shard ships (``auto_fetch=True`` to download it)."""
+    """Proteoform-level within-sample top-fraction prevalence (``scope``
+    ``"cta"``/``"genome"``). Gene-level counterpart: :func:`gene_within_sample_top_fraction`.
+    No proteoform shard ships yet, so this **always** recomputes from the per-sample
+    matrix — hence ``auto_fetch`` defaults to ``True`` here (unlike the gene variant,
+    which reads a shipped shard); pass ``False`` to require the matrix already be cached."""
     return within_sample_top_fraction(
-        cancer_type, threshold=threshold, proteoform=True, auto_fetch=auto_fetch
+        cancer_type, threshold=threshold, proteoform=True, scope=scope, auto_fetch=auto_fetch
     )
 
 

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -135,6 +135,56 @@ def test_cohort_gene_percentiles_proteoform_computed_on_the_fly(
     assert out.set_index("Symbol").loc["A1/2", "p100"] == pytest.approx(10.0, rel=1e-2)
 
 
+def test_cohort_gene_percentiles_threads_scope(proteoform_percentile_cache, monkeypatch):
+    # scope= reaches the on-the-fly collapse: the cta universe leaves A1/A2 separate,
+    # the genome universe groups them. Previously scope was silently fixed.
+    import cancerdata.proteoforms as pmod
+
+    fake = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG_A1", "ENSG_A2", "ENSG_B"],
+            "Symbol": ["A1", "A2", "B"],
+            "s1": [3.0, 5.0, 1.0],
+            "s2": [9.0, 1.0, 4.0],
+        }
+    )
+    monkeypatch.setattr(expression, "per_sample_expression", lambda code, **k: fake.copy())
+    maps = {"cta": {}, "genome": {"A1/A2": ["ENSG_A1", "ENSG_A2"]}}
+    monkeypatch.setattr(pmod, "proteoform_group_map", lambda *, scope="cta": maps[scope])
+
+    cta = expression.cohort_gene_percentiles("LUAD", proteoform=True, scope="cta", auto_fetch=False)
+    assert {"A1", "A2"} <= set(cta["Symbol"])  # cta universe: ungrouped here
+    genome = expression.cohort_gene_percentiles(
+        "LUAD", proteoform=True, scope="genome", auto_fetch=False
+    )
+    assert "A1/2" in set(genome["Symbol"]) and "A1" not in set(genome["Symbol"])  # collapsed
+
+
+def test_proteoform_summary_wrappers_thread_scope_and_default_autofetch_true(monkeypatch):
+    # The proteoform percentile/within-sample wrappers always recompute (no shard
+    # ships), so they default auto_fetch=True (vs the gene variant's False) and thread scope.
+    seen = {}
+    monkeypatch.setattr(
+        expression, "cohort_gene_percentiles", lambda ct, **k: seen.update(k) or pd.DataFrame()
+    )
+    expression.proteoform_cohort_percentiles("X", scope="genome")
+    assert seen["proteoform"] is True and seen["scope"] == "genome" and seen["auto_fetch"] is True
+
+    seen.clear()
+    monkeypatch.setattr(
+        expression, "within_sample_top_fraction", lambda ct, **k: seen.update(k) or pd.DataFrame()
+    )
+    expression.proteoform_within_sample_top_fraction("X", scope="genome")
+    assert seen["proteoform"] is True and seen["scope"] == "genome" and seen["auto_fetch"] is True
+    # The gene variant still defaults auto_fetch=False (reads a shipped shard).
+    seen.clear()
+    monkeypatch.setattr(
+        expression, "cohort_gene_percentiles", lambda ct, **k: seen.update(k) or pd.DataFrame()
+    )
+    expression.gene_cohort_percentiles("X")
+    assert seen["auto_fetch"] is False
+
+
 def test_representatives_provenance_requires_long_format():
     # Provenance is per-representative; asking for it in the default wide form is
     # a no-op, so it must fail loudly rather than silently dropping the request.


### PR DESCRIPTION
From a deep API-coherence audit of the expression accessors. Fixes the two cases where the symmetric `gene_*`/`proteoform_*` convention led a user to write a call that **silently did the wrong thing** or **hard-failed on the happy path**.

## 1. Missing `scope=` on percentiles / within-sample (silent wrong-universe)

`cohort_gene_percentiles` and `within_sample_top_fraction` accepted `proteoform=True` but had **no `scope=`** — unlike every other proteoform-capable accessor (`per_sample_expression`, `cohort_mean_expression`, `cohort_stats`, `pooled_cohort_stats`), which all thread `proteoform=`/`scope=` as a pair. The collapse in `_biological_per_sample` was silently fixed to `scope="cta"`, so genome-scope proteoform percentiles were impossible and a user mixing `proteoform_cohort_stats(scope="genome")` with `proteoform_cohort_percentiles(...)` got two different proteoform universes with no signal.

`scope=` now threads `cohort_gene_percentiles`/`within_sample_top_fraction` → `_read_shard_or_recompute` → `_biological_per_sample` → `collapse_to_proteoforms`, plus the two `proteoform_*` wrappers. (Ignored when `proteoform=False`, like the others.)

## 2. `proteoform_*` wrappers defaulted `auto_fetch=False` but always recompute (happy-path failure)

No proteoform shard ships yet, so `proteoform_cohort_percentiles`/`proteoform_within_sample_top_fraction` **always** take the recompute-from-matrix path — yet they defaulted `auto_fetch=False`, so the documented-as-normal call failed with "matrix isn't cached" unless the user knew to pass `True`. They now default `auto_fetch=True` (matching `per_sample_expression`, which likewise always needs the matrix). The **gene** variants keep `auto_fetch=False` — they read a shipped shard, so no surprise download.

## Tests
- `scope` reaches the on-the-fly collapse: cta universe leaves A1/A2 separate, genome universe groups them.
- the proteoform wrappers thread `scope` and default `auto_fetch=True`; the gene variant still defaults `False`.

Full suite: 392 passed. (Part 1 of 2 from the audit; a normalization export/doc-coherence PR follows.)