### PR TITLE
Publicize ShardDataset/SHARD_DATASETS + make shard selection scope-general

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -77,6 +77,8 @@ from .cta import (
     cta_dataframe,
 )
 from .expression import (
+    SHARD_DATASETS,
+    ShardDataset,
     available_percentile_cohorts,
     available_representative_cohorts,
     available_within_sample_cohorts,
@@ -103,7 +105,7 @@ from .expression import (
     representative_cohort_samples,
     within_sample_top_fraction,
 )
-from .expression_engine import aggregate_transcripts_to_genes
+from .expression_engine import aggregate_transcripts_to_genes, id_columns, sample_columns
 from .expression_registry import (
     ExpressionSource,
     expression_source,
@@ -197,6 +199,7 @@ __all__ = [
     # ontology / registry
     "CANCER_TYPE_ALIASES",
     "CANCER_TYPE_NAMES",
+    "SHARD_DATASETS",
     # cancer-testis antigens
     "CTA_evidence",
     "CTA_excluded_gene_names",
@@ -211,6 +214,7 @@ __all__ = [
     # expression sources + per-sample curation
     "ExpressionSource",
     "GeneQcClass",
+    "ShardDataset",
     "__version__",
     # expression (read accessors over the downloadable bundle)
     "addressable_fraction",
@@ -302,6 +306,7 @@ __all__ = [
     # HPA normal-tissue reference data
     "hpa_rna_consensus",
     "hpa_single_cell",
+    "id_columns",
     "is_expression_value_col",
     "is_mixture_cohort",
     "is_rescue_feature",
@@ -343,6 +348,7 @@ __all__ = [
     "response_signature_genes",
     "response_signature_names",
     "response_signatures_df",
+    "sample_columns",
     "sample_counts_by_cancer_code",
     "sample_manifest",
     "samples_for_cancer_code",

--- a/cancerdata/expression.py
+++ b/cancerdata/expression.py
@@ -47,8 +47,8 @@ and shipped as per-cohort parquet *shards*; the read path just resolves a code a
 reads a parquet. When a shard isn't shipped (every proteoform variant, today), the
 summary is **recomputed on the fly** from the per-sample matrix via the *same* build
 core, so shipped and on-the-fly values agree. Which artifact ships which variant, and
-whether a missing shard may be fetched, is recorded once in the :class:`_ShardDataset`
-registry rather than restated per accessor.
+whether a missing shard may be fetched, is recorded once in the :class:`ShardDataset`
+registry (:data:`SHARD_DATASETS`) rather than restated per accessor.
 
 The richer analysis accessors (``cancer_reference_expression`` etc.) live in
 pirlygenes; this module owns only the data-layer read surface that downstream
@@ -76,45 +76,81 @@ from .normalization import clean_tpm
 
 
 @dataclass(frozen=True)
-class _ShardDataset:
-    """One per-cohort summary artifact (one parquet shard per cohort code). The single
-    place that records, for each artifact: the bundle directory of its gene-level and
-    optional proteoform-level shards; whether each variant **ships in a released bundle**
-    (so a missing shard may be auto-fetched vs. must be computed on the fly); the
-    ``_build`` core that regenerates a missing shard from the per-sample matrix; and a
-    human ``noun`` for error messages. Replaces the parallel ``_*_DIR`` constants +
-    ``_*_root()`` + ``available_*()`` helpers that used to encode this per artifact."""
+class ShardDataset:
+    """A per-cohort summary artifact: one parquet shard per cohort code, available at
+    gene level and (optionally) proteoform level. The single declarative record of
+    everything the read path needs for one artifact, so the accessors stay generic over
+    it rather than special-casing each.
+
+    Fields:
+      - ``noun`` — human label used in error messages.
+      - ``gene_dir`` — bundle subdirectory of the gene-level shards.
+      - ``gene_fetches`` — whether the gene-level shards ship in a released bundle (so a
+        missing one may be auto-fetched) vs. must be recomputed on the fly.
+      - ``proteoform_stem`` — the *stem* of the proteoform shard directory; ``None`` if
+        the artifact has no proteoform variant. The on-disk directory is **scope-suffixed**
+        (``f"{proteoform_stem}-{scope}"``) because identical-protein members group
+        differently under ``"cta"`` vs ``"genome"``, so each scope is its own shard set.
+      - ``proteoform_fetches`` — whether proteoform shards ship (none do yet).
+      - ``build_attr`` — name of the :mod:`cancerdata._build` core that regenerates a
+        missing shard from the per-sample matrix (the same core that produced the shipped
+        shards, so on-the-fly and shipped values agree).
+
+    The registry of the concrete artifacts is :data:`SHARD_DATASETS`.
+    """
 
     noun: str
     gene_dir: str
-    gene_fetches: bool  # gene-level shard ships in a released bundle?
-    proteoform_dir: str | None = None  # None -> artifact has no proteoform variant
-    proteoform_fetches: bool = False  # proteoform shard ships? (none do yet)
-    build_attr: str | None = None  # _build core to recompute a missing shard on the fly
+    gene_fetches: bool
+    proteoform_stem: str | None = None
+    proteoform_fetches: bool = False
+    build_attr: str | None = None
+
+    def subdir(self, *, proteoform: bool, scope: str = "cta") -> str:
+        """Bundle subdirectory holding this artifact's shards at the requested level.
+        Gene-level is scope-independent; the proteoform variant is **scope-specific**
+        (``f"{proteoform_stem}-{scope}"``)."""
+        if not proteoform:
+            return self.gene_dir
+        if self.proteoform_stem is None:
+            raise ValueError(f"{self.noun} has no proteoform variant")
+        return f"{self.proteoform_stem}-{scope}"
+
+    def fetches(self, *, proteoform: bool) -> bool:
+        """Whether the requested level's shards ship in a released bundle (so a missing
+        shard may be auto-fetched rather than only recomputed)."""
+        return self.proteoform_fetches if proteoform else self.gene_fetches
 
 
-# The expression summary artifacts. Proteoform shards aren't shipped in any bundle yet,
-# so they never auto-fetch — the proteoform variant is recomputed on the fly from the
-# per-sample matrix (see _read_shard_or_recompute) until those shards ship.
-_REPRESENTATIVES = _ShardDataset(
-    noun="representative-samples shard",
-    gene_dir="cancer-reference-expression-representatives",
-    gene_fetches=True,
-)
-_PERCENTILES = _ShardDataset(
-    noun="percentile vector",
-    gene_dir="cancer-reference-expression-percentiles",
-    gene_fetches=True,
-    proteoform_dir="cancer-reference-expression-percentiles-proteoform",
-    build_attr="cohort_percentile_vectors",
-)
-_WITHIN_SAMPLE = _ShardDataset(
-    noun="within-sample top-fraction vector",
-    gene_dir="cancer-reference-expression-within-sample-top5",
-    gene_fetches=False,  # not part of a released bundle yet -> never trigger a fetch
-    proteoform_dir="cancer-reference-expression-within-sample-top5-proteoform",
-    build_attr="within_sample_top_fractions",
-)
+#: The expression summary artifacts, keyed by short name. Proteoform shards aren't shipped
+#: in any bundle yet (``proteoform_fetches=False``), so the proteoform variant is recomputed
+#: on the fly from the per-sample matrix (see ``_read_shard_or_recompute``) until they ship;
+#: when they do, each scope is a distinct ``{stem}-{scope}`` directory (see
+#: :meth:`ShardDataset.subdir`).
+SHARD_DATASETS: dict[str, ShardDataset] = {
+    "representatives": ShardDataset(
+        noun="representative-samples shard",
+        gene_dir="cancer-reference-expression-representatives",
+        gene_fetches=True,
+    ),
+    "percentiles": ShardDataset(
+        noun="percentile vector",
+        gene_dir="cancer-reference-expression-percentiles",
+        gene_fetches=True,
+        proteoform_stem="cancer-reference-expression-percentiles-proteoform",
+        build_attr="cohort_percentile_vectors",
+    ),
+    "within_sample": ShardDataset(
+        noun="within-sample top-fraction vector",
+        gene_dir="cancer-reference-expression-within-sample-top5",
+        gene_fetches=False,  # not part of a released bundle yet -> never trigger a fetch
+        proteoform_stem="cancer-reference-expression-within-sample-top5-proteoform",
+        build_attr="within_sample_top_fractions",
+    ),
+}
+_REPRESENTATIVES = SHARD_DATASETS["representatives"]
+_PERCENTILES = SHARD_DATASETS["percentiles"]
+_WITHIN_SAMPLE = SHARD_DATASETS["within_sample"]
 
 
 # How many cleaned per-sample matrices to keep in the in-process LRU. Each frame is
@@ -159,20 +195,23 @@ def _available_shard_codes(root: Path) -> list[str]:
     return sorted(p.stem for p in root.glob("*.parquet"))
 
 
-def _shard_dir(dataset: _ShardDataset, *, proteoform: bool = False) -> Path:
-    """The bundle directory holding ``dataset``'s per-cohort shards (gene-level, or the
-    proteoform variant). The per-variant auto-fetch policy lives on the dataset record,
-    so it's decided in one place rather than re-stated at each call site."""
-    if proteoform:
-        if dataset.proteoform_dir is None:
-            raise ValueError(f"{dataset.noun} has no proteoform variant")
-        return _bundle_subdir(dataset.proteoform_dir, auto_fetch=dataset.proteoform_fetches)
-    return _bundle_subdir(dataset.gene_dir, auto_fetch=dataset.gene_fetches)
+def _shard_dir(dataset: ShardDataset, *, proteoform: bool = False, scope: str = "cta") -> Path:
+    """The bundle directory holding ``dataset``'s per-cohort shards at the requested
+    level and ``scope`` (the proteoform variant is scope-specific — see
+    :meth:`ShardDataset.subdir`). The per-variant auto-fetch policy lives on the dataset
+    record, so it's decided in one place rather than re-stated at each call site."""
+    return _bundle_subdir(
+        dataset.subdir(proteoform=proteoform, scope=scope),
+        auto_fetch=dataset.fetches(proteoform=proteoform),
+    )
 
 
-def _available_cohorts(dataset: _ShardDataset, *, proteoform: bool = False) -> list[str]:
-    """Sorted cohort codes with a shipped shard for ``dataset`` (gene or proteoform)."""
-    return _available_shard_codes(_shard_dir(dataset, proteoform=proteoform))
+def _available_cohorts(
+    dataset: ShardDataset, *, proteoform: bool = False, scope: str = "cta"
+) -> list[str]:
+    """Sorted cohort codes with a shipped shard for ``dataset`` (gene, or the
+    scope-specific proteoform variant)."""
+    return _available_shard_codes(_shard_dir(dataset, proteoform=proteoform, scope=scope))
 
 
 def _resolve_cancer_types(
@@ -211,11 +250,11 @@ def available_representative_cohorts() -> list[str]:
     return _available_cohorts(_REPRESENTATIVES)
 
 
-def available_percentile_cohorts(*, proteoform: bool = False) -> list[str]:
+def available_percentile_cohorts(*, proteoform: bool = False, scope: str = "cta") -> list[str]:
     """Cohort codes that ship a percentile-vector shard (sorted). With
     ``proteoform=True``, the proteoform-summed variant (one vector per proteoform
-    key, identical-protein members collapsed before ranking)."""
-    return _available_cohorts(_PERCENTILES, proteoform=proteoform)
+    key, identical-protein members collapsed before ranking, in ``scope``)."""
+    return _available_cohorts(_PERCENTILES, proteoform=proteoform, scope=scope)
 
 
 _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p", "tpm_clean_hk")
@@ -546,17 +585,18 @@ def _biological_per_sample(
 
 
 def _read_shard_or_recompute(
-    dataset: _ShardDataset, code: str, *, proteoform: bool, auto_fetch: bool, scope: str = "cta"
+    dataset: ShardDataset, code: str, *, proteoform: bool, auto_fetch: bool, scope: str = "cta"
 ) -> pd.DataFrame:
-    """Read ``code``'s shard for ``dataset``; if no shard is present, recompute it on
-    the fly from the per-sample matrix via the dataset's ``_build`` core (the same core
-    that produced the shipped shards — so the on-the-fly and shipped values agree).
+    """Read ``code``'s shard for ``dataset`` (the ``scope``-specific one at proteoform
+    level); if no shard is present, recompute it on the fly from the per-sample matrix
+    via the dataset's ``_build`` core (the same core that produced the shipped shards —
+    so the on-the-fly and shipped values agree).
 
     The single home of the shard-or-recompute fallback shared by the percentile and
     within-sample readers. Raises a clear :class:`ValueError` — not a bare
     ``FileNotFoundError`` — when neither the shard nor the per-sample matrix is available
     (the proteoform variant has no shipped shard yet, so it always takes this path)."""
-    shard = _shard_dir(dataset, proteoform=proteoform) / f"{code}.parquet"
+    shard = _shard_dir(dataset, proteoform=proteoform, scope=scope) / f"{code}.parquet"
     if shard.exists():
         return pd.read_parquet(shard)
     try:
@@ -625,12 +665,12 @@ def cohort_gene_percentiles(
 #: source of truth shared with the generator, so the read side and write side can't drift.
 
 
-def available_within_sample_cohorts(*, proteoform: bool = False) -> list[str]:
+def available_within_sample_cohorts(*, proteoform: bool = False, scope: str = "cta") -> list[str]:
     """Cohort codes that ship a within-sample top-fraction shard (sorted).
 
     With ``proteoform=True``, the proteoform-summed variant (identical-protein
-    members collapsed before ranking — see :func:`within_sample_top_fraction`)."""
-    return _available_cohorts(_WITHIN_SAMPLE, proteoform=proteoform)
+    members collapsed before ranking, in ``scope`` — see :func:`within_sample_top_fraction`)."""
+    return _available_cohorts(_WITHIN_SAMPLE, proteoform=proteoform, scope=scope)
 
 
 def within_sample_top_fraction(

--- a/scripts/generate_cohort_percentiles.py
+++ b/scripts/generate_cohort_percentiles.py
@@ -55,10 +55,18 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from cancerdata._build import cohort_percentile_vectors, sample_columns
+from cancerdata.expression import SHARD_DATASETS
 
-_DATA_DIR = Path(__file__).resolve().parents[1] / "cancerdata" / "data"
-OUT_DIR = _DATA_DIR / "cancer-reference-expression-percentiles"
-PROTEOFORM_OUT_DIR = _DATA_DIR / "cancer-reference-expression-percentiles-proteoform"
+_DATASET = SHARD_DATASETS["percentiles"]  # the reader's record — derive dirs from it so
+_DATA_DIR = (
+    Path(__file__).resolve().parents[1] / "cancerdata" / "data"
+)  # producer/reader can't drift
+OUT_DIR = _DATA_DIR / _DATASET.gene_dir
+
+
+def _proteoform_out_dir(scope: str) -> Path:
+    """The scope-specific proteoform shard directory the reader expects."""
+    return _DATA_DIR / _DATASET.subdir(proteoform=True, scope=scope)
 
 
 def _load_drop_genes(path: Path | None) -> set[str]:
@@ -73,16 +81,18 @@ def build(
     drop_genes: set[str],
     out_dir: Path | None = None,
     proteoform: bool = False,
+    scope: str = "cta",
 ) -> None:
     """Build the percentile-vector artifact for each cohort under ``input_dir``.
 
     With ``proteoform=True``, each cohort's per-sample matrix is collapsed to the
-    proteoform key space (identical-protein members summed) *before* the percentiles
-    are computed, so the vector is one row per proteoform key. Output lands in a
-    parallel ``…-percentiles-proteoform`` directory.
+    proteoform key space (identical-protein members summed, in ``scope``) *before* the
+    percentiles are computed, so the vector is one row per proteoform key. Output lands
+    in the scope-specific ``…-percentiles-proteoform-<scope>`` directory the reader
+    expects (see :meth:`cancerdata.expression.ShardDataset.subdir`).
     """
     if out_dir is None:
-        out_dir = PROTEOFORM_OUT_DIR if proteoform else OUT_DIR
+        out_dir = _proteoform_out_dir(scope) if proteoform else OUT_DIR
     out_dir.mkdir(parents=True, exist_ok=True)
     shards = sorted(input_dir.glob("*.parquet"))
     if not shards:
@@ -102,7 +112,7 @@ def build(
             # reduced proteoform key space (one reusable collapse + proteoform_key).
             from cancerdata.proteoforms import collapse_to_proteoforms
 
-            df = collapse_to_proteoforms(df, sample_cols=cols)
+            df = collapse_to_proteoforms(df, scope=scope, sample_cols=cols)
             cols = sample_columns(df)
         out = cohort_percentile_vectors(df, cols)
         out.to_parquet(out_dir / f"{code}.parquet", index=False, compression="zstd")
@@ -128,11 +138,18 @@ def main(argv=None) -> None:
         action="store_true",
         help="Collapse identical-protein members before ranking (proteoform key space)",
     )
+    p.add_argument(
+        "--scope",
+        default="cta",
+        choices=("cta", "genome"),
+        help="Proteoform-collapse scope (only with --proteoform); writes a scope-specific dir",
+    )
     args = p.parse_args(argv)
     build(
         args.input,
         drop_genes=_load_drop_genes(args.drop_genes),
         proteoform=args.proteoform,
+        scope=args.scope,
     )
 
 

--- a/scripts/generate_within_sample_top5.py
+++ b/scripts/generate_within_sample_top5.py
@@ -40,12 +40,12 @@ Run:
 
 Pass ``--proteoform`` to additionally sum identical-protein paralogs (CTAG1A+
 CTAG1B, the CT47A family, …) to proteoform level *before* the within-sample
-ranking, written to a parallel ``…-within-sample-top5-proteoform`` directory — so
-a duplicated antigen ranks as one proteoform rather than several
-individually-diluted genes.
+ranking, written to a parallel scope-specific
+``…-within-sample-top5-proteoform-<scope>`` directory — so a duplicated antigen
+ranks as one proteoform rather than several individually-diluted genes.
 
 After building, add ``cancer-reference-expression-within-sample-top5`` (and, if
-built, ``…-within-sample-top5-proteoform``) to ``data_bundle.DOWNLOADABLE_PATHS``,
+built, ``…-within-sample-top5-proteoform-<scope>``) to ``data_bundle.DOWNLOADABLE_PATHS``,
 rebuild + upload the data tarball, and bump ``DATA_VERSION`` (never bump it before
 the tarball is uploaded — a 404 hangs fetch).
 """

--- a/scripts/generate_within_sample_top5.py
+++ b/scripts/generate_within_sample_top5.py
@@ -61,10 +61,18 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from cancerdata._build import sample_columns, within_sample_top_fractions
+from cancerdata.expression import SHARD_DATASETS
 
-_DATA_DIR = Path(__file__).resolve().parents[1] / "cancerdata" / "data"
-OUT_DIR = _DATA_DIR / "cancer-reference-expression-within-sample-top5"
-PROTEOFORM_OUT_DIR = _DATA_DIR / "cancer-reference-expression-within-sample-top5-proteoform"
+_DATASET = SHARD_DATASETS["within_sample"]  # the reader's record — derive dirs from it so
+_DATA_DIR = (
+    Path(__file__).resolve().parents[1] / "cancerdata" / "data"
+)  # producer/reader can't drift
+OUT_DIR = _DATA_DIR / _DATASET.gene_dir
+
+
+def _proteoform_out_dir(scope: str) -> Path:
+    """The scope-specific proteoform shard directory the reader expects."""
+    return _DATA_DIR / _DATASET.subdir(proteoform=True, scope=scope)
 
 
 def _load_drop_genes(path: Path | None) -> set[str]:
@@ -79,17 +87,19 @@ def build(
     drop_genes: set[str],
     out_dir: Path | None = None,
     proteoform: bool = False,
+    scope: str = "cta",
 ) -> None:
     """Build the within-sample top-fraction artifact for each cohort.
 
     With ``proteoform=True``, each cohort's per-sample matrix is collapsed to
-    proteoform level (identical-protein members summed) *before* the within-
-    sample ranking, so a duplicated antigen ranks as one proteoform rather than
-    several individually-diluted genes. Output lands in a parallel
-    ``…-within-sample-top5-proteoform`` directory.
+    proteoform level (identical-protein members summed, in ``scope``) *before* the
+    within-sample ranking, so a duplicated antigen ranks as one proteoform rather than
+    several individually-diluted genes. Output lands in the scope-specific
+    ``…-within-sample-top5-proteoform-<scope>`` directory the reader expects (see
+    :meth:`cancerdata.expression.ShardDataset.subdir`).
     """
     if out_dir is None:
-        out_dir = PROTEOFORM_OUT_DIR if proteoform else OUT_DIR
+        out_dir = _proteoform_out_dir(scope) if proteoform else OUT_DIR
     out_dir.mkdir(parents=True, exist_ok=True)
     shards = sorted(input_dir.glob("*.parquet"))
     if not shards:
@@ -109,7 +119,7 @@ def build(
             # collapsed antigen axis (one reusable collapse + proteoform_id identity).
             from cancerdata.proteoforms import collapse_to_proteoforms
 
-            df = collapse_to_proteoforms(df, sample_cols=cols)
+            df = collapse_to_proteoforms(df, scope=scope, sample_cols=cols)
             cols = sample_columns(df)
         out = within_sample_top_fractions(df, cols)
         out.to_parquet(out_dir / f"{code}.parquet", index=False, compression="zstd")
@@ -135,8 +145,19 @@ def main(argv=None) -> None:
         action="store_true",
         help="Sum identical-protein paralogs to proteoform level before ranking",
     )
+    p.add_argument(
+        "--scope",
+        default="cta",
+        choices=("cta", "genome"),
+        help="Proteoform-collapse scope (only with --proteoform); writes a scope-specific dir",
+    )
     args = p.parse_args(argv)
-    build(args.input, drop_genes=_load_drop_genes(args.drop_genes), proteoform=args.proteoform)
+    build(
+        args.input,
+        drop_genes=_load_drop_genes(args.drop_genes),
+        proteoform=args.proteoform,
+        scope=args.scope,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/rebuild_expression_artifacts.py
+++ b/scripts/rebuild_expression_artifacts.py
@@ -60,9 +60,17 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from cancerdata._build import cohort_medoids, cohort_percentile_vectors, within_sample_top_fractions
+from cancerdata.expression import SHARD_DATASETS
 from cancerdata.gene_families import clean_tpm_censored_gene_ids
 from cancerdata.normalization import clean_tpm
 from cancerdata.source_matrices import registry as source_registry
+
+# Rebuilt artifacts must land in the exact directories the reader resolves; derive every
+# name from the shared registry so producer and reader can't drift. Proteoform shards are
+# built at "cta" scope (the only scope generated today).
+_PCT_DS = SHARD_DATASETS["percentiles"]
+_WS_DS = SHARD_DATASETS["within_sample"]
+_PROTEOFORM_SCOPE = "cta"
 
 _BASE = ["Ensembl_Gene_ID", "Symbol"]
 
@@ -158,11 +166,11 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
     print(f"rebuilding {len(codes)} cohorts -> {out}", flush=True)
 
     clean_dir = out / "clean"
-    pct_dir = out / "cancer-reference-expression-percentiles"
-    pct_pf_dir = out / "cancer-reference-expression-percentiles-proteoform"
-    rep_dir = out / "cancer-reference-expression-representatives"
-    ws_dir = out / "cancer-reference-expression-within-sample-top5"
-    ws_pf_dir = out / "cancer-reference-expression-within-sample-top5-proteoform"
+    pct_dir = out / _PCT_DS.gene_dir
+    pct_pf_dir = out / _PCT_DS.subdir(proteoform=True, scope=_PROTEOFORM_SCOPE)
+    rep_dir = out / SHARD_DATASETS["representatives"].gene_dir
+    ws_dir = out / _WS_DS.gene_dir
+    ws_pf_dir = out / _WS_DS.subdir(proteoform=True, scope=_PROTEOFORM_SCOPE)
     for d in (clean_dir, pct_dir, pct_pf_dir, rep_dir, ws_dir, ws_pf_dir):
         d.mkdir(parents=True, exist_ok=True)
 
@@ -204,7 +212,7 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
         from cancerdata._build import sample_columns
         from cancerdata.proteoforms import collapse_to_proteoforms
 
-        bio_pf = collapse_to_proteoforms(bio_df, sample_cols=samples)
+        bio_pf = collapse_to_proteoforms(bio_df, scope=_PROTEOFORM_SCOPE, sample_cols=samples)
         pf_samples = sample_columns(bio_pf)
         cohort_percentile_vectors(bio_pf, pf_samples).to_parquet(
             pct_pf_dir / f"{code}.parquet", index=False, compression="zstd"

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -72,7 +72,7 @@ def test_cohort_gene_percentiles_missing_raises(percentile_cache, monkeypatch):
 @pytest.fixture
 def proteoform_percentile_cache(monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
-    shard_dir = tmp_path / "cancer-reference-expression-percentiles-proteoform"
+    shard_dir = tmp_path / "cancer-reference-expression-percentiles-proteoform-cta"
     shard_dir.mkdir(parents=True)
     # A collapsed shard carries the proteoform identity columns alongside the breakpoints.
     cols = {
@@ -158,6 +158,41 @@ def test_cohort_gene_percentiles_threads_scope(proteoform_percentile_cache, monk
         "LUAD", proteoform=True, scope="genome", auto_fetch=False
     )
     assert "A1/2" in set(genome["Symbol"]) and "A1" not in set(genome["Symbol"])  # collapsed
+
+
+def test_proteoform_shard_selection_is_scope_specific(proteoform_percentile_cache, monkeypatch):
+    # The fixture ships a *cta-scope* proteoform shard. A cta request reads it; a genome
+    # request must NOT (it resolves the genome dir, which is absent) — proving scope
+    # selects the shard directory, not just the on-the-fly collapse universe.
+    cta = expression.cohort_gene_percentiles("PRAD", proteoform=True, scope="cta", auto_fetch=False)
+    assert list(cta["proteoform_key"]) == ["NY-ESO-1", "ENSG00000185686"]
+
+    def _no_matrix(*a, **k):
+        raise FileNotFoundError("not cached")
+
+    monkeypatch.setattr(expression, "per_sample_expression", _no_matrix)
+    with pytest.raises(ValueError, match="per-sample matrix isn't cached"):
+        expression.cohort_gene_percentiles(
+            "PRAD", proteoform=True, scope="genome", auto_fetch=False
+        )
+
+
+def test_shard_dataset_registry_is_public_and_scope_aware():
+    # ShardDataset + SHARD_DATASETS are public; the proteoform shard dir is scope-specific.
+    import cancerdata
+
+    assert set(cancerdata.SHARD_DATASETS) == {"representatives", "percentiles", "within_sample"}
+    pct = cancerdata.SHARD_DATASETS["percentiles"]
+    assert isinstance(pct, cancerdata.ShardDataset)
+    assert pct.subdir(proteoform=False) == "cancer-reference-expression-percentiles"
+    assert pct.subdir(proteoform=True, scope="cta").endswith("-proteoform-cta")
+    assert pct.subdir(proteoform=True, scope="genome").endswith("-proteoform-genome")
+    assert pct.fetches(proteoform=False) is True and pct.fetches(proteoform=True) is False
+    # an artifact with no proteoform variant rejects the request
+    with pytest.raises(ValueError, match="no proteoform variant"):
+        cancerdata.SHARD_DATASETS["representatives"].subdir(proteoform=True)
+    # the column-vocabulary helpers are now package-public too
+    assert callable(cancerdata.id_columns) and callable(cancerdata.sample_columns)
 
 
 def test_proteoform_summary_wrappers_thread_scope_and_default_autofetch_true(monkeypatch):

--- a/tests/test_within_sample_proteoform.py
+++ b/tests/test_within_sample_proteoform.py
@@ -103,7 +103,7 @@ def test_generator_proteoform_rescues_diluted_members(tmp_path):
 @pytest.fixture
 def proteoform_within_sample_cache(monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
-    shard_dir = tmp_path / "cancer-reference-expression-within-sample-top5-proteoform"
+    shard_dir = tmp_path / "cancer-reference-expression-within-sample-top5-proteoform-cta"
     shard_dir.mkdir(parents=True)
     pd.DataFrame(
         {


### PR DESCRIPTION
Per the request to turn the (private) shard registry into a documented public, general abstraction, and to fix forward-looking note #1 (scope must select the shard dir).

## Publicize
- `_ShardDataset` → **`ShardDataset`** (public, exported), with a thorough docstring; the concrete artifacts are now a public registry **`SHARD_DATASETS`** (keyed `representatives`/`percentiles`/`within_sample`). Consumers can introspect cancerdata's summary artifacts (dirs, fetch policy, proteoform variants).
- **`id_columns` / `sample_columns`** (the column vocabulary) are now package-exported too.

## Make shard selection scope-general (fixes note #1)
Previously `_read_shard_or_recompute` threaded `scope` but used it only on the *recompute* path — `_shard_dir(dataset, proteoform=True)` returned one directory regardless of scope, so once proteoform shards ship a `scope="genome"` request could silently read a `cta` shard. Now:
- `ShardDataset.subdir(proteoform=, scope=)` makes the proteoform shard directory **scope-specific** (`{stem}-{scope}`) — members group differently under cta vs genome, so each scope is its own shard set.
- `_shard_dir` / `_available_cohorts` / `_read_shard_or_recompute` / `available_percentile_cohorts` / `available_within_sample_cohorts` all thread `scope`.

## No producer/reader drift
The generators (`generate_cohort_percentiles`, `generate_within_sample_top5`) and `rebuild_expression_artifacts` now **derive their output directories from the same `SHARD_DATASETS` registry** (+ a `--scope` flag, default cta), so the directory convention lives in exactly one place. Proteoform shards are written to `...-proteoform-cta`.

## Tests
- scope **selects the shard directory**: a shipped cta-scope shard is read for `scope="cta"` but NOT for `scope="genome"` (which resolves the absent genome dir → recompute).
- `SHARD_DATASETS`/`ShardDataset` are public; `subdir`/`fetches` scope-aware; no-proteoform-variant raises; `id_columns`/`sample_columns` exported.

Full suite: 395 passed. (Note #2 — the base `auto_fetch` default — follows in a small separate PR.)