### PR TITLE
Add referenced CTA-candidate watchlist (top-of-funnel)

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -74,6 +74,7 @@ from .cta import (
     CTA_never_expressed_gene_names,
     CTA_unfiltered_gene_ids,
     CTA_unfiltered_gene_names,
+    cta_candidate_references,
     cta_dataframe,
 )
 from .expression import (
@@ -281,6 +282,7 @@ __all__ = [
     "cohort_registry_df",
     "cohort_stats",
     "collapse_to_proteoforms",
+    "cta_candidate_references",
     "cta_dataframe",
     "cta_patient_fractions",
     "cta_specific_9mer_counts",

--- a/cancerdata/cta.py
+++ b/cancerdata/cta.py
@@ -182,6 +182,23 @@ def CTA_evidence() -> pd.DataFrame:
     return cta_dataframe()
 
 
+def cta_candidate_references() -> pd.DataFrame:
+    """Top-of-funnel CTA *candidates* with literature references — overlooked
+    cancer-testis / cancer-germline antigens (paralog-family members, meiosis/
+    germline genes, recently described CTAs) that are **not yet promoted** into the
+    curated :func:`cta_dataframe` table.
+
+    This is a referenced watchlist, not the filtered set: each row carries its
+    ``candidate_source`` (paralog/literature/meiosis/registry), ``ct_designation``
+    (CTdatabase CT-number where one exists), ``pmids`` (semicolon-joined), the
+    ``family`` it belongs to, and the HPA v23 status (``hpa_testis_ntpm``,
+    ``hpa_max_somatic_ntpm``, ``hpa_max_somatic_tissue``, ``hpa_testis_restricted``)
+    so a curator can see at a glance which are clean testis-restricted promotions
+    vs. which carry somatic signal that needs a cross-reactivity/leakiness call
+    before entering the curated table. Returns a defensive copy."""
+    return get_data("cta-candidate-references").copy()
+
+
 def passes_filters_mask(df: pd.DataFrame) -> pd.Series:
     """Boolean mask for rows passing the HPA curation filter (reproductive
     restriction). Accepts the legacy ``filtered`` column too."""

--- a/cancerdata/data/cta-candidate-references.csv
+++ b/cancerdata/data/cta-candidate-references.csv
@@ -1,0 +1,15 @@
+Symbol,Ensembl_Gene_ID,candidate_source,ct_designation,family,hpa_testis_ntpm,hpa_max_somatic_ntpm,hpa_max_somatic_tissue,hpa_testis_restricted,pmids,rationale
+DDX43,ENSG00000080007,literature_cta,CT13,DDX/helicase,19.0,1.8,salivary gland,True,12399967,"HAGE DEAD-box helicase; testis-restricted, re-expressed CML and many solid tumors"
+MAGEB4,ENSG00000120289,paralog_cta,CT3.4,MAGE-B,8.6,0.1,breast,True,11454705,MAGE-B cluster; tumor-associated
+DPPA4,ENSG00000121570,paralog_cta,-,pluripotency,4.1,0.6,liver,True,34767751,Tandem paralog of DPPA2(CTA) sharing OCT4/SOX2/NANOG enhancer; embryonal carcinoma/seminoma
+SSX7,ENSG00000187754,paralog_cta,CT5.7,SSX,0.0,0.6,retina,True,12216073,Protein-coding SSX member; testis + tumor subset (bulk under-detects)
+PRAMEF12,ENSG00000116726,paralog_cta,-,PRAMEF,0.0,0.1,choroid plexus,True,31729367,"PRAMEF-cluster paralog of PRAME; spermatogonia-restricted, glioma re-expression"
+SYCE1,ENSG00000171772,meiosis_cta,-,synaptonemal,68.9,17.5,cerebellum,False,24970476,SC central element; ~80% lung adenocarcinoma
+PIWIL2,ENSG00000197181,literature_cta,-,piRNA,27.9,5.8,duodenum,False,27602489,HILI PIWI; reactivated in cervical cancer
+OIP5,ENSG00000104147,meiosis_cta,CT86,centromere,20.3,9.9,skeletal muscle,False,17151793;28184024,"CENP-A loader; ~47% gastric cancer, HCC"
+TEX12,ENSG00000150783,meiosis_cta,-,synaptonemal,20.1,8.4,retina,False,34880391,SC central element; tumor centrosome amplification
+ZNF165,ENSG00000197279,literature_cta,CT53,ZSCAN,19.2,6.2,parathyroid gland,False,32515734;15354214,ZSCAN7; SMAD3 cofactor oncogenic TGFb in TNBC; HCC/gastric/NSCLC
+PAGE4,ENSG00000101951,literature_cta,CT16,PAGE,5.5,166.6,prostate,False,21357425;27270343,"Prostate-cancer associated; intrinsically disordered (prostate-expressed, not strictly testis)"
+PNMA2,ENSG00000240694,literature_cta,-,PNMA,1.6,113.4,cerebral cortex,False,10362822,Ma2/Ta paraneoplastic onconeural antigen; seminoma-linked (strong CNS signal)
+MAGEC3,ENSG00000165509,paralog_cta,CT7.2,MAGE-C,1.0,3.6,spinal cord,False,10861452,MAGE-C member; tumor-specific (HPA shows some CNS signal — verify)
+TEX15,ENSG00000133636,registry_cta,CT42,TEX,0.3,161.0,small intestine,False,18283110,Meiotic recombination; CTdatabase CT42 (bulk under-detects testis)

--- a/tests/test_cta.py
+++ b/tests/test_cta.py
@@ -120,3 +120,26 @@ def test_gene_id_to_name():
     m = cta.CTA_gene_id_to_name()
     assert len(m) == len(cta.CTA_gene_ids())
     assert all(not k.count(".") for k in m)  # unversioned keys
+
+
+def test_cta_candidate_references_registry():
+    # Top-of-funnel referenced candidate watchlist: every row carries an Ensembl
+    # ID, a citation, and an HPA-restriction flag; none overlaps the curated set.
+    cand = cta.cta_candidate_references()
+    assert len(cand) >= 10
+    required = {
+        "Symbol",
+        "Ensembl_Gene_ID",
+        "candidate_source",
+        "pmids",
+        "hpa_testis_ntpm",
+        "hpa_testis_restricted",
+    }
+    assert required <= set(cand.columns)
+    assert cand["Ensembl_Gene_ID"].str.startswith("ENSG").all()
+    assert cand["pmids"].astype(str).str.strip().ne("").all()  # every candidate cited
+    # Watchlist genes are genuinely ABSENT from the table — not merely filtered
+    # out of the passing view. Assert against every row's id (passing or not), so
+    # a gene already sitting non-passing in the table can't sneak in here.
+    table_ids = set(cta.cta_dataframe()["Ensembl_Gene_ID"].astype(str).str.split(".").str[0])
+    assert not (set(cand["Ensembl_Gene_ID"]) & table_ids)


### PR DESCRIPTION
Surveys paralog families + literature for **overlooked cancer-testis antigens** genuinely absent from the bundled table, and captures them as a *referenced watchlist* (not silently promoted into the filtered set).

## Reconciliation (corrected)
Checked ~72 cited candidates against **every row** of `cancer-testis-antigens.csv` (passing or not). **58 were already present** (48 passing + **10 sitting non-passing** in the table), leaving **14 genuine gaps**. An earlier pass compared against `CTA_gene_names()` — which hides non-passing rows — and over-counted the gaps as 24; this is the corrected scope.

## New data: `cta-candidate-references.csv` (14 rows)
Each row carries `candidate_source` (paralog / literature / meiosis / registry), `ct_designation` (CTdatabase CT# where one exists), `family`, `pmids` (every candidate cited), `rationale`, and **HPA v23 status** (`hpa_testis_ntpm`, `hpa_max_somatic_ntpm`, `hpa_max_somatic_tissue`, `hpa_testis_restricted`).

**Clean testis-restricted → promotion-ready (5):** DDX43 (CT13/HAGE), MAGEB4 (CT3.4), DPPA4, SSX7 (CT5.7), PRAMEF12.

**Catalogued CTAs carrying somatic HPA signal → tracked, need a cross-reactivity/leakiness call first (9):** SYCE1, PIWIL2, OIP5 (CT86), TEX12, ZNF165 (CT53), PAGE4 (CT16), PNMA2 (Ma2), MAGEC3 (CT7.2), TEX15 (CT42).

## Surface
New public accessor `cta_candidate_references()`. A test asserts the watchlist is **disjoint from every table row id** (not just the passing view), so a gene already present non-passing can't be duplicated here.

## Notes
- The 10 already-present-non-passing genes (ACRBP, CABYR, CT45A3, CTAG2, GAPDHS, MAEL, MAGEA11, MAGEB3, ROPN1B, SPA17) are already in the funnel — no action needed.
- References were machine-verified by the research agents against NCBI/Europe PMC; CT decimal sub-numbers are the softest field (CTdatabase site was down).
- Promotion of the 5 clean candidates into the main filtered table (canonical-transcript seeding + regenerate) is a deliberate follow-up.
- 401 tests pass.
