### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/cancerdata/version.py
+++ b/cancerdata/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 # Version of the downloadable data bundle (the heavy per-cohort expression
 # tarball). Bump ONLY when the reference data changes — it pins the bundle


### PR DESCRIPTION
Release cut for the CTA additions merged since 1.2.0: SUN-domain CTAs (#118), the referenced candidate watchlist + `cta_candidate_references()` accessor (#119), and the clean_tpm naming alignment (#116). All bundled-CSV/code — `DATA_VERSION` unchanged (5.22.6).