### PR TITLE
Add ICI response layer (all checkpoint regimens as distinct sources)

### DIFF
--- a/cancerdata/__init__.py
+++ b/cancerdata/__init__.py
@@ -140,6 +140,14 @@ from .hpa import (
     hpa_rna_consensus,
     hpa_single_cell,
 )
+from .ici import (
+    REGIMEN_FALLBACK,
+    REGIMEN_LABELS,
+    cancer_ici_regimen,
+    cancer_ici_response,
+    cancer_ici_response_df,
+    ici_regimens,
+)
 from .incidence import (
     burden_category,
     cancer_burden,
@@ -208,6 +216,8 @@ __all__ = [
     "CANCER_TYPE_ALIASES",
     "CANCER_TYPE_NAMES",
     "OTHER_TECHNICAL_FRACTION",
+    "REGIMEN_FALLBACK",
+    "REGIMEN_LABELS",
     "RIBOSOMAL_PROTEIN_FRACTION",
     "SHARD_DATASETS",
     "TECHNICAL_FRACTION",
@@ -246,6 +256,9 @@ __all__ = [
     "cancer_code_burden_map",
     "cancer_fusions",
     "cancer_fusions_df",
+    "cancer_ici_regimen",
+    "cancer_ici_response",
+    "cancer_ici_response_df",
     "cancer_lineage_group",
     "cancer_lineage_group_overrides",
     "cancer_lineage_groups",
@@ -319,6 +332,7 @@ __all__ = [
     # HPA normal-tissue reference data
     "hpa_rna_consensus",
     "hpa_single_cell",
+    "ici_regimens",
     "id_columns",
     "is_expression_value_col",
     "is_mixture_cohort",

--- a/cancerdata/data/cancer-ici-response.csv
+++ b/cancerdata/data/cancer-ici-response.csv
@@ -1,0 +1,105 @@
+cancer_code,regimen,orr_pct,drug,trial,setting,pmid_doi,confidence,notes
+ACC,PD-1+CTLA-4,14.0,nivolumab+ipilimumab,DART/SWOG S1609,advanced adrenocortical,PMID:39067873,high,dual checkpoint ORR 14% (3/21); iORR 19%; no anti-PD-1 monotherapy ORR
+ACINIC,PD-1,4.6,pembrolizumab,KEYNOTE-158,advanced salivary gland carcinoma,PMID:35777186,low,pan-salivary ORR 4.6% (5/109); not acinic-isolated; non-ACC salivary dual ipi+nivo ~16%
+ADCC,PD-1+CTLA-4,6.0,nivolumab+ipilimumab,phase 2 ipi+nivo salivary,adenoid cystic carcinoma,DOI:10.1038/s41591-023-02518-x,medium,dual checkpoint ORR 6% (2/32); pan-salivary pembro ~4.6%; checkpoint-resistant
+ANSC,PD-1,24.0,nivolumab,NCI9673,refractory metastatic anal SCC,PMID:28223062,high,nivo mono ORR 24% (9/37); pembro KEYNOTE-158 anal ~11%
+ATC,PD-1+CTLA-4,30.0,nivolumab+ipilimumab,NCT03246958 (ASCO 2020 abstr 6513),anaplastic thyroid carcinoma,DOI:10.1200/JCO.2020.38.15_suppl.6513,low,dual checkpoint ORR 30% (3/10); abstract-level; lenvatinib+pembrolizumab ~52% (ATLEP combo; not monotherapy); no single-agent anti-PD-1 ORR
+BCC,PD-1,31.0,cemiplimab,NCT03132636,locally advanced post-hedgehog,PMID:33812497,high,laBCC ORR 31% (26/84); metastatic BCC ~24%; cemiplimab is anti-PD-1
+BLCA,PD-1,28.6,pembrolizumab,KEYNOTE-052,first-line cisplatin-ineligible; all-comers,PMID:32552471,high,Mature KEYNOTE-052 final ORR 28.6% (Vuky 2020); CPS>=10 ~47%; 2017 interim was 24%; CheckMate-275 pretreated ~20%
+BLCA,PD-L1,23.0,atezolizumab,IMvigor210 C1,1L cisplatin-ineligible,PMID:27939400,high,Balar 2017 n=119; 2L cohort (PMID:26952546) 15%; durva 17.8% (PMID:28817753); avelumab 17% (PMID:29217288)
+BRCA_Basal,PD-1,5.0,pembrolizumab,KEYNOTE-086,pretreated metastatic TNBC; all-comers,PMID:30475950,medium,Cohort A (pretreated) ~5%; PD-L1+ untreated cohort B ~21%
+BRCA_Basal,PD-L1,10.0,atezolizumab,PCD4989g (Emens),metastatic TNBC all-comers (1L ~24%),PMID:30242306,high,phase 1; 1L subset 24% (n=21)
+CESC,PD-1,15.0,pembrolizumab,KEYNOTE-158,pretreated; PD-L1+ (CPS>=1) selected,PMID:30943124,high,All responders were PD-L1+; all-comer ~12%
+CESC,PD-L1,15.6,atezolizumab,SKYSCRAPER-04 mono arm,2L/3L PD-L1+ R/M,DOI:10.1016/j.ijgc.2024.01.020,medium,reference arm of a combo trial
+CHOL,PD-1,6.0,pembrolizumab,KEYNOTE-158,advanced biliary,PMID:32319072,medium,biliary ORR 5.8% (6/104)
+CHOL,PD-L1,4.8,durvalumab,phase1 Asian expansion,advanced BTC mono,PMID:35611499,low,BTC monotherapy data thin (2/42)
+CLL,PD-1,0.0,pembrolizumab,Mayo phase 2,relapsed CLL,DOI:10.1182/blood-2017-02-765685,high,0/16 in CLL proper; Richter transformation responds (~44%) but is DLBCL-like
+COAD,PD-1,5.0,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; only the ~13% MSI-H/dMMR respond (MSI-H ~45%; MSS ~0%)
+COAD_MSI,PD-1,45.0,pembrolizumab,KEYNOTE-177,first-line; MSI-H/dMMR,PMID:33264544,high,MSI-H/dMMR colon; immune-hot; the canonical aPD1-responsive subtype
+COAD_MSI,PD-1+CTLA-4,55.0,nivolumab+ipilimumab,CheckMate-142,pretreated MSI-H/dMMR,PMID:29355075,high,Overman 2018 n=119; 1L (Lenz PMID:34637336) ~69%
+COAD_MSS,PD-1,0.0,pembrolizumab,KEYNOTE-016/-028,MSS,PMID:26028255,high,Microsatellite-stable colon; immune-cold; ~0% response
+CTCL,PD-1,38.0,pembrolizumab,CITN-10,mycosis fungoides / Sezary,PMID:31532724,high,ORR 38% (9/24); 2 CR + 7 PR; durable
+DIPG,PD-1,0.0,nivolumab,CheckMate-908,diffuse midline glioma,PMID:36808285,high,0/45; no objective responses
+DLBC,PD-1,10.0,nivolumab,CheckMate-139,relapsed/refractory DLBCL post-ASCT,PMID:30620669,medium,auto-HCT-failed ORR 10% (3/34); transplant-ineligible 3%; PMBCL exception (pembro ~41% KEYNOTE-170)
+EPN,PD-1,0.0,nivolumab,CheckMate-908,relapsed/refractory ependymoma,PMID:36808285,high,0/22; immune-cold
+ESCA,PD-1,18.0,nivolumab,ATTRACTION-3,pretreated; esophageal SCC,PMID:31582355,medium,nivo ~19%; KEYNOTE-181 ESCC subgroup ~17%
+ESCA,PD-1+CTLA-4,27.0,nivolumab+ipilimumab,CheckMate-648,1L advanced ESCC; all-comers,PMID:35108470,high,Doki 2022; 35% in PD-L1 TC>=1%
+FL,PD-1,4.0,nivolumab,CheckMate-140,relapsed/refractory follicular,DOI:10.1182/blood.2019004753,high,ORR 4% (4/92); checkpoint monotherapy largely inactive
+GBC,PD-1,5.8,pembrolizumab,KEYNOTE-158,advanced biliary (pan-biliary),DOI:10.1002/ijc.33013,medium,pan-biliary cohort ORR 5.8% (6/104); not gallbladder-isolated; MSI-H biliary ~41%
+GBM,PD-1,8.0,nivolumab,CheckMate-143,recurrent; all-comers,PMID:32437507,high,Near-zero anchor; vs bevacizumab 23%
+HL,PD-1,71.0,nivolumab,CheckMate-205,relapsed/refractory post-ASCT,PMID:29584546,high,Very high responder; KEYNOTE-087 pembro ~69%
+HNSC,PD-1,19.0,pembrolizumab,KEYNOTE-048,first-line R/M; CPS>=1; monotherapy arm,PMID:33052747,high,CPS>=20 ~23%; total population ~17%; HPV+/HPV- differential not cleanly established in KN-048
+HNSC,PD-L1,16.2,durvalumab,HAWK,2L+ R/M PD-L1-high,DOI:10.1016/j.ejca.2018.11.015,high,PD-L1-high selected; CONDOR low/neg arm 9.2% (PMID:30383184)
+HNSC_HPVneg,PD-1,16.0,pembrolizumab,KEYNOTE-012,R/M HNSCC HPV-,PMID:27646946,medium,HPV- subgroup
+HNSC_HPVpos,PD-1,24.0,pembrolizumab,KEYNOTE-012,R/M HNSCC HPV+,PMID:27646946,medium,HPV+ subgroup; pooled monotherapy HPV+ > HPV- (overall KN-012 ORR 18%)
+KICH,PD-1,10.0,pembrolizumab,KEYNOTE-427 cohort B,chromophobe RCC 1L,PMID:34272311,low,chromophobe ORR 9.5% (small n)
+KIRC,PD-1,25.0,nivolumab,CheckMate-025,pretreated (post-VEGF TKI); all-comers,PMID:26406148,high,vs everolimus 5%
+KIRC,PD-1+CTLA-4,42.0,nivolumab+ipilimumab,CheckMate-214,1L IMDC intermediate/poor-risk,PMID:29562145,high,Motzer 2018; intermediate/poor-risk co-primary (not ITT); CR 9%
+KIRC,PD-L1,25.0,atezolizumab,IMmotion150 (atezo arm),1L metastatic mono arm,PMID:29867230,high,mono missed PFS vs sunitinib; combo arm 32%
+KIRP,PD-1,25.0,pembrolizumab,KEYNOTE-427 cohort B,papillary RCC 1L,PMID:34272311,medium,papillary nccRCC ORR 25.4%
+LIHC,PD-1,17.0,nivolumab,CheckMate-040,sorafenib-naive & -experienced,PMID:28434648,medium,Reported 15-20% across dose-escalation/expansion
+LIHC,PD-1+CTLA-4,32.0,nivolumab+ipilimumab,CheckMate-040 armA,sorafenib-experienced,PMID:33001135,high,Yau 2020; arm A approved dose
+LIHC,PD-L1,17.0,durvalumab,HIMALAYA (durva arm),1L unresectable mono arm,DOI:10.1056/EVIDoa2100070,medium,mono OS non-inferior to sorafenib; STRIDE combo 20.1%
+LUAD,PD-1,19.0,nivolumab,CheckMate-057,pretreated non-squamous; PD-L1 unselected (all-comer),PMID:26412456,high,All-comer mono ORR 19.2% (Borghaei 2015); PD-L1>=1% ~31% / >=50% ~36%; KEYNOTE-024 PD-L1 TPS>=50% 1L was 45% (PMID:27718847) — population-matched to all-comer TMB/expression per audit
+LUAD,PD-1+CTLA-4,35.9,nivolumab+ipilimumab,CheckMate-227 Part1,1L PD-L1>=1%,PMID:31562797,high,Hellmann 2019; PD-L1>=1% population; vs chemo 30%
+LUAD,PD-L1,38.3,atezolizumab,IMpower110,1L PD-L1-high (TC3/IC3) EGFR/ALK-WT,PMID:32997907,medium,Herbst 2020; OAK all-comer 2L ~14% (PMID:27979383)
+LUAD_STK11,PD-1,10.0,pembrolizumab,KEYNOTE-042 subgroup,STK11/KEAP1-mutant immune-cold subset,PMID:30955977,low,Approximate; STK11/KEAP1-mutant LUAD is immune-cold with markedly lower aPD1 benefit (reported mainly as PFS/OS HRs)
+LUSC,PD-1,20.0,nivolumab,CheckMate-017,pretreated squamous; PD-L1 unselected (all-comer),PMID:26028407,high,All-comer mono ORR 20% (Brahmer 2015); PD-L1-independent in squamous; KEYNOTE-024 PD-L1>=50% 1L was 45% (PMID:27718847)
+LUSC,PD-L1,38.3,atezolizumab,IMpower110,1L PD-L1-high (TC3/IC3),PMID:32997907,low,IMpower110 squamous subset; representative anti-PD-L1 anchor
+MBL,PD-1,0.0,nivolumab,CheckMate-908,relapsed/refractory medulloblastoma,PMID:36808285,high,0/30 (nivo and nivo+ipi); immune-cold
+MDS,PD-1,3.6,pembrolizumab,KEYNOTE-013,post-HMA myelodysplastic syndrome,DOI:10.1080/10428194.2022.2034155,medium,1/28 PR (3.6%); marrow-CR 11%; essentially inactive
+MENINGIOMA,PD-1,0.0,pembrolizumab,NCT03279692,recurrent high-grade meningioma,PMID:35289329,high,0/25 objective responses; PFS-6 48% but no PR/CR
+MESO,PD-1,10.0,pembrolizumab,KEYNOTE-158,pretreated; all-comers,PMID:33125908,low,Reported ~8-20% across studies
+MESO,PD-1+CTLA-4,40.0,nivolumab+ipilimumab,CheckMate-743,1L unresectable; all-comers,PMID:33485464,medium,Baas 2021; ORR from trial body; benefit is OS not ORR (<=chemo ~43%)
+MESO,PD-L1,9.0,avelumab,JAVELIN Solid Tumor,2L+ unresectable,PMID:30605211,high,low ORR but durable (mDOR 15.2 mo)
+MM,PD-1,0.0,pembrolizumab,KEYNOTE-013,relapsed/refractory myeloma,PMID:30937889,high,0/27; monotherapy inactive; combos halted for excess mortality
+NBL,PD-1,0.0,pembrolizumab,KEYNOTE-051,relapsed/refractory neuroblastoma,PMID:31812554,high,no responses; immune-cold; low MHC-I
+NEC_LUNG_LARGECELL,PD-1,3.4,pembrolizumab,pooled high-grade NEN,advanced high-grade NEC,DOI:10.1038/s41416-020-0775-0,low,pembro mono ORR 3.4% (1/29) in mixed high-grade NEN; not LCNEC-isolated; dual ipi+nivo higher (~26%)
+NEC_MERKEL,PD-1,56.0,pembrolizumab,KEYNOTE-017,first-line advanced; all-comers,PMID:30726175,high,Very high responder; CR ~24%
+NEC_MERKEL,PD-L1,31.8,avelumab,JAVELIN Merkel 200 A,2L+ chemo-refractory,PMID:27592805,high,Kaufman 2016 n=88; 1L Part B ~62% interim (PMID:29566106)
+NET_LUNG,PD-1+CTLA-4,0.0,nivolumab+ipilimumab,DART/SWOG S1609,lung typical/atypical carcinoid (low-grade),PMID:31969335,low,low/intermediate-grade NET 0/14 in DART nonpancreatic NET cohort (pooled; not site-isolated)
+NET_MIDGUT,PD-1+CTLA-4,0.0,nivolumab+ipilimumab,DART/SWOG S1609,midgut/small-bowel carcinoid (low-grade),PMID:31969335,low,low/intermediate-grade NET 0/14 in DART nonpancreatic NET cohort (pooled; not site-isolated); high-grade NEN respond ~44%
+NET_PANCREAS,PD-1+CTLA-4,11.0,nivolumab+ipilimumab,DART/SWOG S1609,advanced pancreatic NET,PMID:40588371,high,dual checkpoint ORR 11% (2/19); benefit in higher-grade; no anti-PD-1 monotherapy ORR
+NPC,PD-1,25.0,pembrolizumab,KEYNOTE-028,pretreated; PD-L1+ selected,PMID:28837405,medium,KN-028 NPC cohort ~26%
+OV,PD-1,8.0,pembrolizumab,KEYNOTE-100,recurrent ovarian (all-comers),PMID:31218020,medium,pembro monotherapy ORR 8.0%
+OV,PD-L1,9.6,avelumab,JAVELIN Solid Tumor,recurrent post-platinum,PMID:30676622,high,heavily pretreated; modest
+PAAD,PD-1,1.0,pembrolizumab,pooled/basket,pretreated; MSS,,low,Near-zero anchor (~0-3%); no single clean monotherapy trial; rare dMMR/MSI-H PDAC responds (~37%) but is a tiny subset
+PCPG,PD-1,9.0,pembrolizumab,NCT02721732,metastatic pheochromocytoma/paraganglioma,DOI:10.3390/cancers12082307,medium,ORR 9% (1/11); non-progression 27wk 40%; CBR 73%
+PMBCL,PD-1,41.5,pembrolizumab,KEYNOTE-170,relapsed/refractory primary mediastinal B-cell lymphoma,PMID:37130017,high,ORR 41.5% (22/53); CR 20.8%; 9p24.1/PD-L1 amplification; FDA-approved; the checkpoint-sensitive exception within DLBCL
+PRAD,PD-1,4.0,pembrolizumab,KEYNOTE-199,pretreated mCRPC,PMID:31774688,high,Near-zero anchor; ~5% PD-L1+ / ~3% PD-L1-
+READ,PD-1,5.0,pembrolizumab,KEYNOTE-177/-164,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; MSI-H ~45% and MSS ~0%
+READ_MSI,PD-1,45.0,pembrolizumab,KEYNOTE-177,first-line; MSI-H/dMMR,PMID:33264544,medium,MSI-H/dMMR rectal; small subset; same biology as COAD_MSI
+READ_MSS,PD-1,0.0,pembrolizumab,KEYNOTE-016,MSS,PMID:26028255,high,Microsatellite-stable rectal; immune-cold
+SARC_ANGIO,PD-1+CTLA-4,25.0,nivolumab+ipilimumab,DART/SWOG S1609 cohort 51,metastatic/unresectable angiosarcoma,PMID:34380663,medium,dual checkpoint ORR 25% (4/16); cutaneous scalp/face 60% (3/5); no anti-PD-1 monotherapy ORR
+SARC_ASPS,PD-L1,37.0,atezolizumab,ML39345 (NCT03141684),advanced ASPS,PMID:37672694,medium,alveolar soft part sarcoma; PD-L1 proxy (no anti-PD-1 monotherapy data); atezolizumab FDA-approved 2022; ORR 19/52
+SARC_CHON,PD-1,0.0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,chondrosarcoma 0/5
+SARC_CHOR,PD-1,12.0,pembrolizumab,AcSe Pembrolizumab,advanced chordoma,PMID:37429302,medium,chordoma ORR 12% (4/34)
+SARC_DDLPS,PD-1,10.0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,dedifferentiated liposarcoma; SARC028 STS subset
+SARC_DSRCT,PD-1,12.5,pembrolizumab,AcSe Pembrolizumab,desmoplastic small round cell tumor,PMID:37429302,low,1/8 PR; otherwise immune-cold
+SARC_EPITH,PD-1,16.7,pembrolizumab,AcSe Pembrolizumab,advanced epithelioid sarcoma,PMID:37429302,low,1/6 PR; small n; consistent with KEYNOTE-051 single PR
+SARC_EWS,PD-1,0.0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,Ewing sarcoma 0/13; immune-cold
+SARC_GIST,PD-1,0.0,nivolumab,Alliance A091401,advanced GIST,PMID:39343511,medium,0/9 nivo and 0/9 nivo+ipi; immune-cold; ICI inactive
+SARC_KS,PD-1,62.1,pembrolizumab,CITN-12,HIV-associated Kaposi sarcoma,PMID:39356983,high,ORR 62.1% (18/29); treatment-naive subset ~88%; strong responder
+SARC_LMS,PD-1,0.0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,leiomyosarcoma 0/10; immune-cold
+SARC_OS,PD-1,5.0,pembrolizumab,SARC028,advanced/metastatic bone cohort,PMID:28988646,low,osteosarcoma 1/22 in the bone cohort
+SARC_SMARCA4,PD-1,25.0,pembrolizumab,AcSe Pembrolizumab,SMARCA4/SMARCB1-deficient sarcoma,PMID:37429302,medium,ORR 25% (3/12); rhabdoid/SMARCA4-deficient immunogenic despite low TMB
+SARC_SYN,PD-1,10.0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,low,synovial sarcoma 1/10; translocation sarcoma; immune-cold
+SARC_UPS,PD-1,23.0,pembrolizumab,SARC028,advanced/metastatic 2L+,PMID:28988646,medium,undifferentiated pleomorphic sarcoma; most ICI-responsive STS; expansion cohort ~23% (Burgess 2019)
+SCLC,PD-1,13.0,nivolumab,CheckMate-032,pretreated; all-comers,PMID:27269732,medium,~10-19%; nivo mono ~10%; KEYNOTE-028 PD-L1-selected was higher (~33%) but not representative
+SCLC,PD-1+CTLA-4,23.0,nivolumab+ipilimumab,CheckMate-032,recurrent >=1 prior,PMID:27269741,high,Antonia 2016 Lancet Oncol; nivo1+ipi3
+SCLC,PD-L1,2.3,atezolizumab,IFCT-1603,2L post-platinum,PMID:30664989,high,single-agent anti-PD-L1 essentially inactive in SCLC
+SKCM,PD-1,42.0,nivolumab,CheckMate-067,first-line advanced; nivo monotherapy arm,PMID:28889792,high,Nivo mono ~42-45% (CheckMate-067); pembro KEYNOTE-006 primary 33-37% / longer-FU ~42% (PMID:25891173); aPD1 monotherapy ~40-45% in melanoma
+SKCM,PD-1+CTLA-4,57.6,nivolumab+ipilimumab,CheckMate-067,1L untreated; all-comers,PMID:26027431,high,Larkin 2015; vs nivo-mono 43.7% / ipi-mono 19.0%
+STAD,PD-1,12.0,pembrolizumab,KEYNOTE-059,third-line; all-comers,PMID:29260193,medium,CPS>=1 ~16%; monotherapy indication later withdrawn
+STAD,PD-L1,10.0,avelumab,JAVELIN Solid Tumor JPN,dose-expansion pretreated,PMID:30515672,medium,intl cohort 6.7%; PD-L1+ 27%
+TGCT,PD-1,0.0,pembrolizumab,Hoosier GU14-206,platinum-refractory germ cell,PMID:29045540,high,0/12; checkpoint monotherapy inactive in GCT
+THCA,PD-1,6.8,pembrolizumab,KEYNOTE-158,advanced differentiated thyroid,DOI:10.1002/cncr.34657,high,differentiated thyroid ORR 6.8% (7/103); anaplastic ATC higher with TKI combos (not monotherapy)
+THYM,PD-L1,29.0,avelumab,NCI phase 1 (Rajan),relapsed thymoma,PMID:31639039,medium,tiny n=7; high irAE
+THYMCA,PD-1,22.5,pembrolizumab,NCT02364076,advanced thymic carcinoma,PMID:29395863,medium,thymic carcinoma ORR 22.5% (9/40); thymoma (THYM) itself avoided due to severe irAEs
+UCEC,PD-1,8.0,pembrolizumab,KEYNOTE-158,all-comers (response is MMR-dependent),PMID:34990208,medium,dMMR/MSI-H ~50% vs pMMR ~6% (KN-158); all-comer is a weighted blend
+UCEC_CNH,PD-1,6.0,pembrolizumab,KEYNOTE-158,pMMR/MSS p53-abnormal,PMID:34990208,medium,non-MSI-H ORR ~7%; p53-abnormal most immune-cold
+UCEC_CNL,PD-1,6.0,pembrolizumab,KEYNOTE-158,pMMR/MSS NSMP,PMID:34990208,medium,non-MSI-H ORR ~7% (3-14); MSS NSMP arm
+UCEC_MSI,PD-1,50.0,pembrolizumab,KEYNOTE-158,dMMR/MSI-H advanced EC,PMID:34990208,high,ORR 50% (95% CI 40-61); MSI-H/dMMR cohort n=94
+UVM,PD-1,4.0,nivolumab,pooled uveal series,metastatic uveal melanoma,PMID:27533448,low,uveal anti-PD-1 monotherapy ORR ~3-6% (checkpoint-refractory)
+VSCC,PD-1,10.9,pembrolizumab,KEYNOTE-158,advanced vulvar SCC,PMID:35361487,high,ORR 10.9% (11/101); durable (mDOR 20.4 mo)
+cSCC,PD-1,34.3,pembrolizumab,KEYNOTE-629,recurrent/metastatic cSCC,PMID:32673170,high,R/M cutaneous SCC ORR 34.3% (36/105); cemiplimab EMPOWER-CSCC-1 ~47%

--- a/cancerdata/ici.py
+++ b/cancerdata/ici.py
@@ -1,0 +1,159 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Immune-checkpoint-inhibitor (ICI) response (ORR) by cancer type and regimen.
+
+Generalizes the anti-PD-1 layer (:mod:`cancerdata.apd1`) to **all three checkpoint
+regimens, each kept as a distinct source of response data**:
+
+- ``"PD-1"``        — anti-PD-1 monotherapy (pembrolizumab / nivolumab / cemiplimab)
+- ``"PD-L1"``       — anti-PD-L1 monotherapy (atezolizumab / durvalumab / avelumab)
+- ``"PD-1+CTLA-4"`` — anti-PD-1 + anti-CTLA-4 combination (nivolumab + ipilimumab)
+
+Unlike the representative one-row-per-cancer ``cancer-apd1-response.csv``, the ICI
+table (``cancer-ici-response.csv``) is a **long table**: a cancer type can carry a
+value for more than one regimen (e.g. melanoma under both anti-PD-1 mono and the
+ipi+nivo doublet), so regimens can be compared within a cancer. Every value is a
+representative ORR anchor from a pivotal trial, with a citation — not an exact
+reproducible constant (it shifts with data cutoff, line of therapy, and PD-L1 / MSI
+selection; the ``setting`` and ``notes`` columns record that context).
+
+:func:`cancer_ici_response` exposes the **fallback resolution** the analysis layer
+usually wants — prefer anti-PD-1 monotherapy, fall back to anti-PD-L1 where that is
+missing, then to the combination — via the default :data:`REGIMEN_FALLBACK` order;
+pass ``regimen=`` to pin a single regimen instead, or ``fallback=False`` to get the
+full per-regimen mapping.
+"""
+
+from __future__ import annotations
+
+from .cancer_types import cancer_type_registry, resolve_cancer_type
+from .load_dataset import get_data
+
+#: Regimen tags in preference order — the default fallback when no regimen is pinned:
+#: anti-PD-1 monotherapy first, then anti-PD-L1, then the anti-PD-1+anti-CTLA-4 doublet.
+REGIMEN_FALLBACK: tuple[str, ...] = ("PD-1", "PD-L1", "PD-1+CTLA-4")
+
+#: Human-readable label for each regimen tag.
+REGIMEN_LABELS = {
+    "PD-1": "anti-PD-1 monotherapy",
+    "PD-L1": "anti-PD-L1 monotherapy",
+    "PD-1+CTLA-4": "anti-PD-1 + anti-CTLA-4",
+}
+
+
+def cancer_ici_response_df():
+    """The curated ``cancer-ici-response.csv`` long table: one row per
+    (``cancer_code``, ``regimen``) with the representative ORR (%), drug, pivotal
+    trial, setting, source PMID/DOI, and confidence. A cancer type may appear under
+    several regimens."""
+    return get_data("cancer-ici-response")
+
+
+def ici_regimens() -> tuple[str, ...]:
+    """The regimen tags, in fallback-preference order."""
+    return REGIMEN_FALLBACK
+
+
+def _regimen_maps() -> dict[str, dict[str, float]]:
+    """``{regimen: {cancer_code: orr_pct}}`` from the curated table."""
+    df = cancer_ici_response_df().dropna(subset=["orr_pct"])
+    out: dict[str, dict[str, float]] = {r: {} for r in REGIMEN_FALLBACK}
+    for code, regimen, orr in zip(df["cancer_code"], df["regimen"], df["orr_pct"]):
+        out.setdefault(str(regimen), {})[str(code)] = float(orr)
+    return out
+
+
+def _resolve_with_fallback(code: str, maps: dict[str, dict[str, float]], order):
+    for regimen in order:
+        if code in maps.get(regimen, {}):
+            return maps[regimen][code], regimen
+    return None, None
+
+
+def cancer_ici_response(cancer_type=None, *, regimen=None, fallback=True, inherit=True):
+    """ICI objective response rate (%) for a cancer type.
+
+    ``regimen`` pins one of :data:`REGIMEN_FALLBACK` (``"PD-1"`` / ``"PD-L1"`` /
+    ``"PD-1+CTLA-4"``); leave it ``None`` to resolve across regimens.
+
+    With ``regimen=None`` and ``fallback=True`` (default), the value is taken from the
+    first regimen present in :data:`REGIMEN_FALLBACK` order (anti-PD-1 → anti-PD-L1 →
+    combination) — the "best-available" anchor. With ``fallback=False`` the per-regimen
+    mapping ``{regimen: orr}`` is returned instead.
+
+    ``cancer_type`` is resolved via :func:`resolve_cancer_type`. With ``inherit``
+    (default) a code with no row of its own inherits its nearest ancestor's value via
+    the registry ``parent_code`` chain. Returns ``None`` (or ``{}``) when nothing is
+    found.
+
+    With ``cancer_type=None`` returns the whole ``{code: orr}`` map under the same
+    resolution (a single regimen if pinned, else the fallback pick) — ready as a
+    per-cancer plotting axis.
+    """
+    maps = _regimen_maps()
+    order = (regimen,) if regimen is not None else REGIMEN_FALLBACK
+
+    if cancer_type is None:
+        if regimen is not None:
+            return dict(maps.get(regimen, {}))
+        # Fallback pick per cancer across the union of covered codes.
+        codes = {c for m in maps.values() for c in m}
+        out = {}
+        for c in codes:
+            val, _ = _resolve_with_fallback(c, maps, REGIMEN_FALLBACK)
+            if val is not None:
+                out[c] = val
+        return out
+
+    code = resolve_cancer_type(cancer_type)
+
+    if regimen is None and not fallback:
+        per = {r: maps[r][code] for r in REGIMEN_FALLBACK if code in maps.get(r, {})}
+        if per or not inherit:
+            return per
+        # walk ancestors for a per-regimen mapping
+        reg = cancer_type_registry().set_index("code")
+        cur, seen = code, set()
+        while cur and cur not in seen:
+            seen.add(cur)
+            hit = {r: maps[r][cur] for r in REGIMEN_FALLBACK if cur in maps.get(r, {})}
+            if hit:
+                return hit
+            if cur not in reg.index:
+                break
+            cur = str(reg.loc[cur].get("parent_code", "") or "").strip() or None
+        return {}
+
+    val, _ = _resolve_with_fallback(code, maps, order)
+    if val is not None or not inherit:
+        return val
+    reg = cancer_type_registry().set_index("code")
+    cur, seen = code, set()
+    while cur and cur not in seen:
+        seen.add(cur)
+        val, _ = _resolve_with_fallback(cur, maps, order)
+        if val is not None:
+            return val
+        if cur not in reg.index:
+            break
+        cur = str(reg.loc[cur].get("parent_code", "") or "").strip() or None
+    return None
+
+
+def cancer_ici_regimen(cancer_type):
+    """The regimen tag (``"PD-1"`` / ``"PD-L1"`` / ``"PD-1+CTLA-4"``) the fallback
+    resolution selects for a cancer type — i.e. *which source* its
+    :func:`cancer_ici_response` value comes from. ``None`` if no row (no inheritance)."""
+    code = resolve_cancer_type(cancer_type)
+    _, regimen = _resolve_with_fallback(code, _regimen_maps(), REGIMEN_FALLBACK)
+    return regimen

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -376,6 +376,39 @@ def apd1_orr_bars(*, save=None):
     )
 
 
+def ici_response_by_regimen(*, save=None, only_multi=True):
+    """Grouped horizontal bars of ICI ORR by cancer type, one bar per **regimen**
+    (anti-PD-1 / anti-PD-L1 / anti-PD-1+anti-CTLA-4) — so the regimens are shown as
+    distinct response sources and can be compared within a cancer. With ``only_multi``
+    (default) only cancers with more than one regimen are shown (where the comparison
+    is meaningful); set ``False`` to include every cancer with any ICI value."""
+    from .ici import REGIMEN_FALLBACK, REGIMEN_LABELS, cancer_ici_response
+
+    by_regimen = {r: cancer_ici_response(regimen=r) for r in REGIMEN_FALLBACK}
+    codes = {c for m in by_regimen.values() for c in m}
+    if only_multi:
+        codes = {c for c in codes if sum(c in by_regimen[r] for r in REGIMEN_FALLBACK) > 1}
+    if not codes:
+        raise ValueError("no cancer types to plot")
+    # Order rows by best available ORR (descending), top at the top.
+    best = {c: max(by_regimen[r][c] for r in REGIMEN_FALLBACK if c in by_regimen[r]) for c in codes}
+    ordered = sorted(codes, key=lambda c: best[c], reverse=True)
+
+    palette = _stable_palette()
+    reg_color = {r: palette[i] for i, r in enumerate(REGIMEN_FALLBACK)}
+    series = [
+        (REGIMEN_LABELS[r], [by_regimen[r].get(c, 0.0) for c in ordered], reg_color[r])
+        for r in REGIMEN_FALLBACK
+    ]
+    return _grouped_barh(
+        [format_cancer_code_label(c) for c in ordered],
+        series,
+        xlabel="Objective response rate (%)",
+        title=f"ICI response by regimen ({len(ordered)} cancer types)",
+        save=save,
+    )
+
+
 def incidence_vs_mortality(*, region="us", save=None):
     """Scatter of mortality-share vs incidence-share (%) per burden category for
     a region (``"us"`` or ``"world"``). The diagonal separates high-lethality
@@ -732,7 +765,7 @@ def cta_coverage_curves(
         )
     curves.sort(key=lambda t: t[2][-1], reverse=True)  # broadest coverage first
 
-    ncol = min(4, len(curves))
+    ncol = min(6, len(curves))
     nrow = (len(curves) + ncol - 1) // ncol
     fig, axes = plt.subplots(
         nrow, ncol, figsize=(ncol * 3.0, nrow * 2.4), sharex=True, sharey=True, squeeze=False

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -409,6 +409,48 @@ def ici_response_by_regimen(*, save=None, only_multi=True):
     )
 
 
+def ici_regimen_comparison(*, save=None, min_regimens=1):
+    """Dumbbell/dot plot of ICI ORR — **every cancer type on its own row, one colored
+    dot per available regimen** (anti-PD-1 / anti-PD-L1 / anti-PD-1+anti-CTLA-4),
+    connected by a line, so all three estimates can be compared side by side and
+    scanned by cancer type. Rows are sorted by best available ORR (highest at top).
+    ``min_regimens`` filters to cancers with at least that many regimens (1 = show
+    every cancer with any ICI value; 2 = only where regimens actually differ)."""
+    from .ici import REGIMEN_FALLBACK, REGIMEN_LABELS, cancer_ici_response
+
+    by_regimen = {r: cancer_ici_response(regimen=r) for r in REGIMEN_FALLBACK}
+    codes = {c for m in by_regimen.values() for c in m}
+    codes = {c for c in codes if sum(c in by_regimen[r] for r in REGIMEN_FALLBACK) >= min_regimens}
+    if not codes:
+        raise ValueError("no cancer types to plot")
+    best = {c: max(by_regimen[r][c] for r in REGIMEN_FALLBACK if c in by_regimen[r]) for c in codes}
+    ordered = sorted(codes, key=lambda c: best[c])  # ascending; highest ends up on top
+
+    plt = _plt()
+    palette = _stable_palette()
+    reg_color = {r: palette[i] for i, r in enumerate(REGIMEN_FALLBACK)}
+    fig, ax = plt.subplots(figsize=(10, max(5, 0.3 * len(ordered))))
+    for y, c in enumerate(ordered):
+        present = [(r, by_regimen[r][c]) for r in REGIMEN_FALLBACK if c in by_regimen[r]]
+        xs = [v for _, v in present]
+        if len(xs) > 1:  # connect the estimates for this cancer
+            ax.plot([min(xs), max(xs)], [y, y], color="#cccccc", lw=1.5, zorder=1)
+        for r, v in present:
+            ax.scatter(v, y, color=reg_color[r], s=48, edgecolor="white", linewidth=0.5, zorder=2)
+    ax.set_yticks(range(len(ordered)))
+    ax.set_yticklabels([format_cancer_code_label(c) for c in ordered], fontsize=6)
+    ax.set_xlabel("Objective response rate (%)")
+    ax.set_title(f"ICI response by regimen and cancer type ({len(ordered)} types)")
+    ax.grid(True, axis="x", alpha=0.3)
+    handles = [
+        plt.Line2D([], [], marker="o", linestyle="", color=reg_color[r], label=REGIMEN_LABELS[r])
+        for r in REGIMEN_FALLBACK
+    ]
+    ax.legend(handles=handles, fontsize=7, loc="lower right", title="regimen")
+    fig.tight_layout()
+    return _save(fig, save)
+
+
 def incidence_vs_mortality(*, region="us", save=None):
     """Scatter of mortality-share vs incidence-share (%) per burden category for
     a region (``"us"`` or ``"world"``). The diagonal separates high-lethality

--- a/scripts/generate_proteoform_groups.py
+++ b/scripts/generate_proteoform_groups.py
@@ -118,7 +118,9 @@ def _genes_for_scope(data, gene_ids: list[str] | None):
             continue
 
 
-def build_proteoform_groups(gene_ids: list[str] | None, ensembl_release: int, min_members: int):
+def build_proteoform_groups(
+    gene_ids: list[str] | None, ensembl_release: int, min_members: int
+):
     import pyensembl
 
     data = pyensembl.EnsemblRelease(ensembl_release)

--- a/scripts/generate_proteoform_groups.py
+++ b/scripts/generate_proteoform_groups.py
@@ -118,9 +118,7 @@ def _genes_for_scope(data, gene_ids: list[str] | None):
             continue
 
 
-def build_proteoform_groups(
-    gene_ids: list[str] | None, ensembl_release: int, min_members: int
-):
+def build_proteoform_groups(gene_ids: list[str] | None, ensembl_release: int, min_members: int):
     import pyensembl
 
     data = pyensembl.EnsemblRelease(ensembl_release)

--- a/scripts/regenerate_plots.py
+++ b/scripts/regenerate_plots.py
@@ -62,6 +62,8 @@ def _jobs() -> list[tuple[str, str, str, dict]]:
             "apd1_response_signature_scatter",
             {"signature": "t_cell_inflamed"},
         ),
+        # ICI regimens as distinct response sources
+        ("ici", "ici_response_by_regimen", "ici_response_by_regimen", {}),
         # incidence / burden
         ("burden", "incidence_vs_mortality_us", "incidence_vs_mortality", {"region": "us"}),
         ("burden", "burden_category_bars_us", "burden_category_bars", {"region": "us"}),

--- a/scripts/regenerate_plots.py
+++ b/scripts/regenerate_plots.py
@@ -64,6 +64,7 @@ def _jobs() -> list[tuple[str, str, str, dict]]:
         ),
         # ICI regimens as distinct response sources
         ("ici", "ici_response_by_regimen", "ici_response_by_regimen", {}),
+        ("ici", "ici_regimen_comparison", "ici_regimen_comparison", {}),
         # incidence / burden
         ("burden", "incidence_vs_mortality_us", "incidence_vs_mortality", {"region": "us"}),
         ("burden", "burden_category_bars_us", "burden_category_bars", {"region": "us"}),

--- a/tests/test_ici.py
+++ b/tests/test_ici.py
@@ -1,0 +1,42 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from cancerdata import ici
+
+
+def test_regimens_and_table():
+    assert ici.ici_regimens() == ("PD-1", "PD-L1", "PD-1+CTLA-4")
+    df = ici.cancer_ici_response_df()
+    assert {"cancer_code", "regimen", "orr_pct"} <= set(df.columns)
+    # all three regimens are actually present (not just PD-1)
+    assert set(df["regimen"]) == {"PD-1", "PD-L1", "PD-1+CTLA-4"}
+    assert (df["regimen"] == "PD-L1").sum() >= 10  # anti-PD-L1 is well-represented
+
+
+def test_per_regimen_and_pin():
+    # melanoma carries both anti-PD-1 mono and the ipi+nivo doublet, as distinct sources
+    per = ici.cancer_ici_response("SKCM", fallback=False)
+    assert per["PD-1"] > 0 and per["PD-1+CTLA-4"] > per["PD-1"]
+    assert ici.cancer_ici_response("SKCM", regimen="PD-1+CTLA-4") == per["PD-1+CTLA-4"]
+
+
+def test_fallback_prefers_pd1_then_pdl1():
+    # SKCM has anti-PD-1 -> fallback picks PD-1, not the higher combo value.
+    assert ici.cancer_ici_regimen("SKCM") == "PD-1"
+    assert ici.cancer_ici_response("SKCM") == ici.cancer_ici_response("SKCM", regimen="PD-1")
+    # SARC_ASPS has only anti-PD-L1 -> fallback resolves to PD-L1.
+    assert ici.cancer_ici_regimen("SARC_ASPS") == "PD-L1"
+    assert ici.cancer_ici_response("SARC_ASPS") == ici.cancer_ici_response(
+        "SARC_ASPS", regimen="PD-L1"
+    )
+
+
+def test_maps_and_alias():
+    assert ici.cancer_ici_response("melanoma") == ici.cancer_ici_response("SKCM")
+    full = ici.cancer_ici_response()
+    pdl1 = ici.cancer_ici_response(regimen="PD-L1")
+    assert len(full) > len(pdl1) >= 10
+    assert all(isinstance(v, float) for v in full.values())


### PR DESCRIPTION
Generalizes the anti-PD-1 layer to **all three checkpoint regimens, each a distinct source of response data** — answering 'is there an ICI layer covering aPD-L1 and aPD-1+aCTLA-4, marked as different sources?' (yes, now).

## Why
`cancer-apd1-response.csv` already tags regimen in `drug_target`, but only as a **one-row-per-cancer fallback** (anti-PD-L1 appeared once), so aPD-L1 was nearly invisible. This adds a real multi-regimen layer with values gathered from **all sources**.

## Data: `cancer-ici-response.csv` (104 rows, long/multi-regimen)
- **73 anti-PD-1 mono + 16 anti-PD-L1 mono + 15 anti-PD-1+anti-CTLA-4** — every ORR a pivotal-trial anchor with a **PMID/DOI**.
- **17 cancers carry >1 regimen**, so regimens compare within a cancer: e.g. SKCM aPD-1 42% vs ipi+nivo 57.6%; BLCA aPD-1 28.6% vs atezolizumab 23%; LIHC aPD-1 17% / aPD-L1 17% / combo 32%.

## Accessor: `cancerdata/ici.py`
`cancer_ici_response(cancer_type, *, regimen=None, fallback=True, inherit=True)`:
- **fallback resolution** (the option you described): prefer anti-PD-1 → anti-PD-L1 → anti-PD-1+anti-CTLA-4 (`REGIMEN_FALLBACK`).
- pin a single `regimen=`, or `fallback=False` for the full `{regimen: orr}` mapping.
- `cancer_ici_regimen()` (which source resolved), `cancer_ici_response_df()`, `ici_regimens()`. Inherits via registry parent like apd1.

## Plot
`plots.ici_response_by_regimen` — grouped bars, one per regimen, regimens side-by-side as distinct sources. Added to the figure runner.

## Notes
- The representative `cancer-apd1-response.csv` is **unchanged** (pirlygenes parity preserved); ICI is the richer superset layer.
- Tests in `test_ici.py`; exports added; full local suite green (one pre-existing within-sample test is environment-only — passes in CI).