### PR TITLE
ICI follow-up: per-regimen whole-table map, cache, mask absent bars

### DIFF
--- a/cancerdata/ici.py
+++ b/cancerdata/ici.py
@@ -36,8 +36,10 @@ full per-regimen mapping.
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 from .cancer_types import cancer_type_registry, resolve_cancer_type
-from .load_dataset import get_data
+from .load_dataset import _register_derived_cache, get_data
 
 #: Regimen tags in preference order — the default fallback when no regimen is pinned:
 #: anti-PD-1 monotherapy first, then anti-PD-L1, then the anti-PD-1+anti-CTLA-4 doublet.
@@ -64,13 +66,18 @@ def ici_regimens() -> tuple[str, ...]:
     return REGIMEN_FALLBACK
 
 
+@lru_cache(maxsize=1)
 def _regimen_maps() -> dict[str, dict[str, float]]:
-    """``{regimen: {cancer_code: orr_pct}}`` from the curated table."""
+    """``{regimen: {cancer_code: orr_pct}}`` from the curated table. Cached; callers
+    must treat the result as read-only (copy before mutating)."""
     df = cancer_ici_response_df().dropna(subset=["orr_pct"])
     out: dict[str, dict[str, float]] = {r: {} for r in REGIMEN_FALLBACK}
     for code, regimen, orr in zip(df["cancer_code"], df["regimen"], df["orr_pct"]):
         out.setdefault(str(regimen), {})[str(code)] = float(orr)
     return out
+
+
+_register_derived_cache(_regimen_maps.cache_clear)
 
 
 def _resolve_with_fallback(code: str, maps: dict[str, dict[str, float]], order):
@@ -106,8 +113,11 @@ def cancer_ici_response(cancer_type=None, *, regimen=None, fallback=True, inheri
     if cancer_type is None:
         if regimen is not None:
             return dict(maps.get(regimen, {}))
-        # Fallback pick per cancer across the union of covered codes.
         codes = {c for m in maps.values() for c in m}
+        if not fallback:
+            # Per-regimen mapping for every covered cancer: {code: {regimen: orr}}.
+            return {c: {r: maps[r][c] for r in REGIMEN_FALLBACK if c in maps[r]} for c in codes}
+        # Fallback pick per cancer across the union of covered codes.
         out = {}
         for c in codes:
             val, _ = _resolve_with_fallback(c, maps, REGIMEN_FALLBACK)

--- a/cancerdata/plots.py
+++ b/cancerdata/plots.py
@@ -396,8 +396,10 @@ def ici_response_by_regimen(*, save=None, only_multi=True):
 
     palette = _stable_palette()
     reg_color = {r: palette[i] for i, r in enumerate(REGIMEN_FALLBACK)}
+    # Absent regimen -> NaN (no bar drawn), so a missing estimate is not confused
+    # with a true 0% ORR (matplotlib draws nothing for a NaN-width bar).
     series = [
-        (REGIMEN_LABELS[r], [by_regimen[r].get(c, 0.0) for c in ordered], reg_color[r])
+        (REGIMEN_LABELS[r], [by_regimen[r].get(c, float("nan")) for c in ordered], reg_color[r])
         for r in REGIMEN_FALLBACK
     ]
     return _grouped_barh(

--- a/tests/test_ici.py
+++ b/tests/test_ici.py
@@ -40,3 +40,21 @@ def test_maps_and_alias():
     pdl1 = ici.cancer_ici_response(regimen="PD-L1")
     assert len(full) > len(pdl1) >= 10
     assert all(isinstance(v, float) for v in full.values())
+
+
+def test_whole_table_per_regimen_mapping():
+    # cancer_type=None with fallback=False -> {code: {regimen: orr}} for every cancer.
+    per = ici.cancer_ici_response(fallback=False)
+    assert isinstance(per["SKCM"], dict)
+    assert per["SKCM"] == {"PD-1": 42.0, "PD-1+CTLA-4": 57.6}
+    # single-regimen cancers carry a one-entry mapping
+    assert set(per["SARC_ASPS"]) == {"PD-L1"}
+    # the PD-L1 members match the pinned PD-L1 map
+    assert {c for c, m in per.items() if "PD-L1" in m} == set(
+        ici.cancer_ici_response(regimen="PD-L1")
+    )
+
+
+def test_regimen_maps_cached():
+    # _regimen_maps is memoized (same object back from the cache).
+    assert ici._regimen_maps() is ici._regimen_maps()


### PR DESCRIPTION
Fixes the three review nits from #125.

1. **`cancer_ici_response(fallback=False)` with `cancer_type=None`** now returns the whole-table per-regimen mapping `{code: {regimen: orr}}` (it previously ignored `fallback=False` and returned the fallback pick). Tested.
2. **`_regimen_maps` is now `@lru_cache`'d** + registered via `_register_derived_cache` (matching the gene_families/cta pattern), so it's not rebuilt on every call.
3. **`ici_response_by_regimen` masks absent regimens with NaN** instead of 0.0 — a missing estimate now draws no bar rather than looking like a true 0% ORR (the dumbbell plot was already correct).

44 tests pass; lint clean.