### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/cancerdata/version.py
+++ b/cancerdata/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 # Version of the downloadable data bundle (the heavy per-cohort expression
 # tarball). Bump ONLY when the reference data changes — it pins the bundle

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -60,8 +60,13 @@ def test_clean_tpm_technical_compartment_budget():
 
 def test_clean_tpm_three_compartments():
     # A canonical ribosomal protein gets its OWN 16% budget, distinct from the 9% technical.
-    rpl = next(iter(gf.gene_family_ids("ribosomal_protein")))  # e.g. RPL/RPS
-    mito = next(iter(gf.gene_family_ids("mitochondrial")))
+    # Intersect with the censored set and sort so the pick is deterministic across hash
+    # seeds AND guaranteed to be a *censored* ribosomal gene — RPL10L (ENSG00000165496) is
+    # the one ribosomal-protein gene deliberately left out of the censored set (it would
+    # land in biology, not the ribosomal compartment).
+    censored = gf.clean_tpm_censored_gene_ids()
+    rpl = sorted(gf.gene_family_ids("ribosomal_protein") & censored)[0]
+    mito = sorted(gf.gene_family_ids("mitochondrial") & censored)[0]
     gt = pd.DataFrame(
         {
             "Ensembl_Gene_ID": [rpl, mito, "ENSG00000111111", "ENSG00000222222"],


### PR DESCRIPTION
Release cut for everything merged since v1.3.0: ICI response layer (#125/#126), plot styling parity + top-40 coverage cap (#124/#127), expression_builders rename (#123), CTA promotions/watchlist (#119/#121), figure runner (#122). All code/bundled-CSV — `DATA_VERSION` unchanged (5.22.6).