### PR TITLE
Add ici CLI tests + bump to 1.5.0

### DIFF
--- a/oncodata/version.py
+++ b/oncodata/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 # Version of the downloadable data bundle (the heavy per-cohort expression
 # tarball). Bump ONLY when the reference data changes — it pins the bundle

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,35 @@ def test_tmb_full_map(capsys):
     assert "\t" in capsys.readouterr().out
 
 
+def test_ici_single_code_fallback(capsys):
+    # melanoma resolves to its anti-PD-1 value under the default fallback.
+    assert cli.main(["ici", "SKCM"]) == 0
+    assert float(capsys.readouterr().out.strip()) > 0
+
+
+def test_ici_all_regimens(capsys):
+    assert cli.main(["ici", "SKCM", "--all-regimens"]) == 0
+    out = capsys.readouterr().out
+    # melanoma carries both anti-PD-1 mono and the ipi+nivo doublet, as distinct rows.
+    assert "PD-1\t" in out and "PD-1+CTLA-4\t" in out
+
+
+def test_ici_pinned_regimen_absent_returns_1(capsys):
+    # SKCM has no anti-PD-L1 row -> pinning that regimen is a clean miss, not a crash.
+    assert cli.main(["ici", "SKCM", "--regimen", "PD-L1"]) == 1
+    assert "No ICI ORR" in capsys.readouterr().err
+
+
+def test_ici_unknown_code_errors(capsys):
+    assert cli.main(["ici", "not_a_real_cancer"]) == 1
+    assert "Error" in capsys.readouterr().err
+
+
+def test_ici_full_map(capsys):
+    assert cli.main(["ici"]) == 0
+    assert "\t" in capsys.readouterr().out
+
+
 def test_burden_full_map(capsys):
     assert cli.main(["burden", "--metric", "us_mortality_pct"]) == 0
     assert "\t" in capsys.readouterr().out


### PR DESCRIPTION
Closes the test-coverage gap flagged in the #131 review and cuts the release that surfaces the cleaned-up API.

- **test_cli**: covers the new `ici` command — fallback value, `--all-regimens` (both regimens for SKCM), pinned-but-absent regimen → rc 1, unknown code → rc 1, and the full map.
- **Bump 1.4.0 → 1.5.0**: publishes the API/CLI cleanup (cta_* lowercase, _df unification, drop_technical_rna, the ici command, cache/hpa CLI regroup). PyPI 1.4.0 still has the pre-cleanup names.

DATA_VERSION unchanged (5.22.6).