### PR TITLE
Fix head and neck mortality share

### DIFF
--- a/oncoref/data/cancer-incidence-mortality.csv
+++ b/oncoref/data/cancer-incidence-mortality.csv
@@ -13,7 +13,7 @@ melanoma,5.0,1.3,1.7,0.6,high,ACS-CFF2024;GLOBOCAN2022,cutaneous; low mortality 
 ovary,1.6,2.6,1.6,2.1,medium,ACS-CFF2024;GLOBOCAN2022,HGSOC-dominant
 uterus_endometrium,3.0,2.0,2.2,1.0,medium,ACS-CFF2024;GLOBOCAN2022,corpus uteri
 cervix,0.8,0.7,3.3,3.6,high,ACS-CFF2024;GLOBOCAN2022,world>>US (screening/HPV gap)
-head_and_neck,3.5,1.8,5.0,4.5,medium,ACS-CFF2024;GLOBOCAN2022,oral+pharynx+larynx aggregate (incl larynx); world adds nasopharynx
+head_and_neck,3.5,2.6,5.0,4.5,medium,ACS-CFF2024;GLOBOCAN2022,oral+pharynx+larynx aggregate (incl larynx); world adds nasopharynx
 thyroid,2.0,0.4,4.1,0.5,high,ACS-CFF2024;GLOBOCAN2022,lowest mortality:incidence; overdiagnosis (GLOBOCAN2022 821k=4.1%)
 brain_cns,1.4,2.7,1.6,2.5,medium,ACS-CFF2024;GLOBOCAN2022,brain+CNS incl glioma (GBM/LGG)
 non_hodgkin_lymphoma,4.0,3.0,2.8,2.5,medium,ACS-CFF2024;GLOBOCAN2022,incl DLBCL/FL/MCL/BL

--- a/tests/test_data_parity.py
+++ b/tests/test_data_parity.py
@@ -40,3 +40,12 @@ def test_incidence_corrections_applied():
     thyroid = cancer_burden("thyroid", metric="world_incidence_pct")
     assert liver != 6.0 and 0 < liver < 10
     assert thyroid != 2.5 and 0 < thyroid < 10
+
+
+def test_head_and_neck_us_mortality_includes_larynx():
+    # ACS Cancer Facts & Figures 2024 Table 1 lists deaths for oral
+    # cavity/pharynx (12,230) and larynx (3,880). The curated category note says
+    # the row aggregates both, so the mortality share should be ~2.6% of 611,720
+    # total cancer deaths, not the oral/pharynx-only share.
+    expected = round(100 * (12_230 + 3_880) / 611_720, 1)
+    assert cancer_burden("head_and_neck", metric="us_mortality_pct") == expected


### PR DESCRIPTION
## Summary

- Correct the curated US mortality share for `head_and_neck` from 1.8% to 2.6% so it matches the row note's oral/pharynx + larynx aggregate.
- Add a regression check from ACS Cancer Facts & Figures 2024 counts: `(12,230 + 3,880) / 611,720`.

Fixes #136.

## Validation

- `python -m pytest tests/test_data_parity.py tests/test_incidence.py`
