### PR TITLE
Fix LIHC PD-1 response anchor

### DIFF
--- a/oncoref/data/cancer-apd1-response.csv
+++ b/oncoref/data/cancer-apd1-response.csv
@@ -9,7 +9,7 @@ BLCA,28.6,pembrolizumab,KEYNOTE-052,MK-3475-052,NCT02335424,first-line cisplatin
 COAD,5.0,pembrolizumab,KEYNOTE-177,MK-3475-177,NCT02563002,all-comers (response is MSI-dependent),PMID:33264544,medium,All-comer ~5%; only the ~13% MSI-H/dMMR respond (MSI-H ~45%; MSS ~0%),PD-1
 READ,2,pembrolizumab,KEYNOTE-177,MK-3475-177,NCT02563002,all-comers (response is MSI-dependent),PMID:33264544,medium,derived all-comer = ~0.045*43.8 = ~2%; rectal dMMR prevalence ~3-5% (much lower than colon ~13%); KEYNOTE-177 MSI-H ORR 43.8%; subtypes in READ_MSI/READ_MSS,PD-1
 STAD,12.0,pembrolizumab,KEYNOTE-059,MK-3475-059,NCT02335411,third-line; all-comers,PMID:29543932,medium,CPS>=1 ~16%; monotherapy indication later withdrawn,PD-1
-LIHC,17.0,nivolumab,CheckMate 040,CA209-040,NCT01658878,sorafenib-naive & -experienced,PMID:28434648,medium,Reported 15-20% across dose-escalation/expansion,PD-1
+LIHC,20.0,nivolumab,CheckMate 040,CA209-040,NCT01658878,sorafenib-naive & -experienced,PMID:28434648,medium,Dose-expansion ORR 20% (42/214); dose-escalation ORR 15% (7/48),PD-1
 ESCA,18.0,nivolumab,ATTRACTION-3,ONO-4538-24,NCT02569242,pretreated; esophageal SCC,PMID:31582355,medium,nivo ~19%; KEYNOTE-181 ESCC subgroup ~17%,PD-1
 CESC,15.0,pembrolizumab,KEYNOTE-158,MK-3475-158,NCT02628067,pretreated; PD-L1+ (CPS>=1) selected,PMID:30943124,high,All responders were PD-L1+; all-comer ~12%,PD-1
 HL,71.0,nivolumab,CheckMate 205,CA209-205,NCT02181738,relapsed/refractory post-ASCT,PMID:29584546,high,Very high responder; KEYNOTE-087 pembro ~69%,PD-1

--- a/oncoref/data/cancer-ici-response.csv
+++ b/oncoref/data/cancer-ici-response.csv
@@ -37,7 +37,7 @@ KIRC,PD-1,25.0,nivolumab,CheckMate 025,CA209-025,NCT01668784,pretreated (post-VE
 KIRC,PD-1+CTLA-4,42.0,nivolumab+ipilimumab,CheckMate 214,CA209-214,NCT02231749,1L IMDC intermediate/poor-risk,PMID:29562145,high,Motzer 2018; intermediate/poor-risk co-primary (not ITT); CR 9%
 KIRC,PD-L1,25.0,atezolizumab,IMmotion150,WO29074,NCT01984242,1L metastatic mono arm,PMID:29867230,high,mono missed PFS vs sunitinib; combo arm 32%
 KIRP,PD-1,25.0,pembrolizumab,KEYNOTE-427 cohort B,MK-3475-427,NCT02853344,papillary RCC 1L,PMID:33529058,medium,papillary nccRCC ORR 25.4%
-LIHC,PD-1,17.0,nivolumab,CheckMate 040,CA209-040,NCT01658878,sorafenib-naive & -experienced,PMID:28434648,medium,Reported 15-20% across dose-escalation/expansion
+LIHC,PD-1,20.0,nivolumab,CheckMate 040,CA209-040,NCT01658878,sorafenib-naive & -experienced,PMID:28434648,medium,Dose-expansion ORR 20% (42/214); dose-escalation ORR 15% (7/48)
 LIHC,PD-1+CTLA-4,32.0,nivolumab+ipilimumab,CheckMate 040,CA209-040,NCT01658878,sorafenib-experienced,PMID:33001135,high,Yau 2020; arm A approved dose
 LIHC,PD-L1,17.0,durvalumab,HIMALAYA,D419CC00002,NCT03298451,1L unresectable mono arm,DOI:10.1056/EVIDoa2100070,medium,mono OS non-inferior to sorafenib; STRIDE combo 20.1%
 LUAD,PD-1,19.0,nivolumab,CheckMate 057,CA209-057,NCT01673867,pretreated non-squamous; PD-L1 unselected (all-comer),PMID:26412456,high,All-comer mono ORR 19.2% (Borghaei 2015); PD-L1>=1% ~31% / >=50% ~36%; KEYNOTE-024 PD-L1 TPS>=50% 1L was 45% (PMID:27718847) — population-matched to all-comer TMB/expression per audit

--- a/tests/test_ici_estimates.py
+++ b/tests/test_ici_estimates.py
@@ -255,6 +255,37 @@ def test_anchor_orr_in_ballpark_of_estimates_primary():
             )
 
 
+def test_audited_anchor_values_match_primary_orr():
+    anchor = ici.cancer_ici_response_df()
+    est = ici.cancer_ici_response_estimates_df()
+    audited = {
+        ("LIHC", "PD-1"): 20.0,  # CheckMate 040 dose-expansion ORR, PMID:28434648
+    }
+    for cell, expected in audited.items():
+        code, regimen = cell
+        a = anchor[(anchor["cancer_code"] == code) & (anchor["regimen"] == regimen)]
+        assert len(a) == 1
+        assert abs(float(a["orr_pct"].iloc[0]) - expected) < 0.01
+
+        p = est[
+            (est["cancer_code"] == code)
+            & (est["regimen"] == regimen)
+            & (est["role"] == "primary")
+            & (est["metric"].str.upper() == "ORR")
+        ]
+        assert len(p) == 1
+        assert abs(float(p["value"].iloc[0]) - expected) < 0.01
+
+    from oncoref import apd1
+
+    apd1_anchor = apd1.cancer_apd1_response_df()
+    row = apd1_anchor[
+        (apd1_anchor["cancer_code"] == "LIHC") & (apd1_anchor["drug_target"] == "PD-1")
+    ]
+    assert len(row) == 1
+    assert abs(float(row["apd1_orr_pct"].iloc[0]) - audited[("LIHC", "PD-1")]) < 0.01
+
+
 def test_pooled_result_contract():
     r = ici.pooled_ici_response("SKCM", regimen="PD-1", metric="ORR")
     for key in (


### PR DESCRIPTION
## Summary

- Update the LIHC PD-1 representative anchor from 17% to the CheckMate 040 dose-expansion ORR of 20%.
- Apply the same correction to the anti-PD-1 plotting table.
- Add a regression check that the audited LIHC anchor, primary estimates row, and aPD1 table all agree.

Fixes #137.

## Validation

- `python -m pytest tests/test_ici_estimates.py`
