### PR TITLE
Fix MDS PD-1 response anchor

### DIFF
--- a/oncoref/data/cancer-apd1-response.csv
+++ b/oncoref/data/cancer-apd1-response.csv
@@ -63,7 +63,7 @@ TGCT,0.0,pembrolizumab,Hoosier GU14-206,,NCT02499952,platinum-refractory germ ce
 ACINIC,4.6,pembrolizumab,KEYNOTE-158,MK-3475-158,NCT02628067,advanced salivary gland carcinoma,PMID:35777186,low,pan-salivary ORR 4.6% (5/109); not acinic-isolated; non-ACC salivary dual ipi+nivo ~16%,PD-1
 DLBC,10.0,nivolumab,CheckMate 139,CA209-139,NCT02038933,relapsed/refractory DLBCL post-ASCT,PMID:30620669,medium,auto-HCT-failed ORR 10% (3/34); transplant-ineligible 3%; PMBCL exception (pembro ~41% KEYNOTE-170),PD-1
 FL,4.0,nivolumab,CheckMate 140,,NCT02038946,relapsed/refractory follicular,DOI:10.1182/blood.2019004753,high,ORR 4% (4/92); checkpoint monotherapy largely inactive,PD-1
-MDS,3.6,pembrolizumab,KEYNOTE-013,MK-3475-013,NCT01953692,post-HMA myelodysplastic syndrome,DOI:10.1080/10428194.2022.2034155,medium,1/28 PR (3.6%); marrow-CR 11%; essentially inactive,PD-1
+MDS,0.0,pembrolizumab,KEYNOTE-013,MK-3475-013,NCT01953692,post-HMA myelodysplastic syndrome,DOI:10.1080/10428194.2022.2034155,medium,No CR/PR by IWG criteria (0/28); marrow CR 19% (5/28); essentially inactive by ORR,PD-1
 MM,0.0,pembrolizumab,KEYNOTE-013,MK-3475-013,NCT01953692,relapsed/refractory myeloma,PMID:30937889,high,0/27; monotherapy inactive; combos halted for excess mortality,PD-1
 CLL,0.0,pembrolizumab,Mayo Clinic phase 2 pembrolizumab CLL/Richter trial,MC1485,NCT02332980,relapsed CLL,DOI:10.1182/blood-2017-02-765685,high,0/16 in CLL proper; Richter transformation responds (~44%) but is DLBCL-like,PD-1
 NBL,0.0,pembrolizumab,KEYNOTE-051,MK-3475-051,NCT02332668,relapsed/refractory neuroblastoma,PMID:31812554,high,no responses; immune-cold; low MHC-I,PD-1

--- a/oncoref/data/cancer-ici-response.csv
+++ b/oncoref/data/cancer-ici-response.csv
@@ -47,7 +47,7 @@ LUAD_STK11,PD-1,8,pembrolizumab,Skoulidis STK11/LKB1 aPD1-resistance analysis,,,
 LUSC,PD-1,20.0,nivolumab,CheckMate 017,CA209-017,NCT01642004,pretreated squamous; PD-L1 unselected (all-comer),PMID:26028407,high,All-comer mono ORR 20% (Brahmer 2015); PD-L1-independent in squamous; KEYNOTE-024 PD-L1>=50% 1L was 45% (PMID:27718847)
 LUSC,PD-L1,38.3,atezolizumab,IMpower110,GO29431,NCT02409342,1L PD-L1-high (TC3/IC3),PMID:32997907,low,IMpower110 squamous subset; representative anti-PD-L1 anchor
 MBL,PD-1,0.0,nivolumab,CheckMate 908,CA209-908,NCT03130959,relapsed/refractory medulloblastoma,PMID:36808285,high,0/30 (nivo and nivo+ipi); immune-cold
-MDS,PD-1,3.6,pembrolizumab,KEYNOTE-013,MK-3475-013,NCT01953692,post-HMA myelodysplastic syndrome,DOI:10.1080/10428194.2022.2034155,medium,1/28 PR (3.6%); marrow-CR 11%; essentially inactive
+MDS,PD-1,0.0,pembrolizumab,KEYNOTE-013,MK-3475-013,NCT01953692,post-HMA myelodysplastic syndrome,DOI:10.1080/10428194.2022.2034155,medium,No CR/PR by IWG criteria (0/28); marrow CR 19% (5/28); essentially inactive by ORR
 MENINGIOMA,PD-1,0.0,pembrolizumab,pembrolizumab recurrent high-grade meningioma phase 2,,NCT03279692,recurrent high-grade meningioma,PMID:35289329,high,0/25 objective responses; PFS-6 48% but no PR/CR
 MESO,PD-1,10.0,pembrolizumab,KEYNOTE-158,MK-3475-158,NCT02628067,pretreated; all-comers,PMID:33836153,low,Reported ~8-20% across studies
 MESO,PD-1+CTLA-4,40.0,nivolumab+ipilimumab,CheckMate 743,CA209-743,NCT02899299,1L unresectable; all-comers,PMID:33485464,medium,Baas 2021; ORR from trial body; benefit is OS not ORR (<=chemo ~43%)

--- a/tests/test_ici_estimates.py
+++ b/tests/test_ici_estimates.py
@@ -260,6 +260,7 @@ def test_audited_anchor_values_match_primary_orr():
     est = ici.cancer_ici_response_estimates_df()
     audited = {
         ("LIHC", "PD-1"): 20.0,  # CheckMate 040 dose-expansion ORR, PMID:28434648
+        ("MDS", "PD-1"): 0.0,  # KEYNOTE-013: no CR/PR by IWG criteria
     }
     for cell, expected in audited.items():
         code, regimen = cell
@@ -279,11 +280,12 @@ def test_audited_anchor_values_match_primary_orr():
     from oncoref import apd1
 
     apd1_anchor = apd1.cancer_apd1_response_df()
-    row = apd1_anchor[
-        (apd1_anchor["cancer_code"] == "LIHC") & (apd1_anchor["drug_target"] == "PD-1")
-    ]
-    assert len(row) == 1
-    assert abs(float(row["apd1_orr_pct"].iloc[0]) - audited[("LIHC", "PD-1")]) < 0.01
+    for (code, regimen), expected in audited.items():
+        row = apd1_anchor[
+            (apd1_anchor["cancer_code"] == code) & (apd1_anchor["drug_target"] == regimen)
+        ]
+        assert len(row) == 1
+        assert abs(float(row["apd1_orr_pct"].iloc[0]) - expected) < 0.01
 
 
 def test_pooled_result_contract():


### PR DESCRIPTION
## Summary

- Correct the MDS PD-1 representative anchor from 3.6% to 0% because KEYNOTE-013 reported no CR/PR by IWG criteria.
- Keep the marrow CR result represented only in the estimates table as `MARROW_CR` 19% (5/28), not as ORR.
- Apply the same anchor correction to the anti-PD-1 plotting table and extend the audited-anchor regression.

Fixes #138.

## Validation

- `python -m pytest tests/test_ici_estimates.py`
