### PR TITLE
Write combined all-figures PDF during plot regeneration

### DIFF
--- a/scripts/regenerate_plots.py
+++ b/scripts/regenerate_plots.py
@@ -40,6 +40,10 @@ import traceback
 from datetime import datetime
 from pathlib import Path
 
+import matplotlib.image as mpimg
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
 
@@ -148,6 +152,29 @@ def _update_latest(run_dir: Path) -> None:
         pass  # symlinks may be unavailable (e.g. some Windows setups)
 
 
+def _write_all_figures_pdf(run_dir: Path, generated: list[str]) -> Path | None:
+    pngs = [run_dir / rel for rel in generated if rel.endswith(".png")]
+    if not pngs:
+        return None
+
+    pdf = run_dir / "all-figures.pdf"
+    with PdfPages(pdf) as pages:
+        for png in pngs:
+            image = mpimg.imread(png)
+            height, width = image.shape[:2]
+            aspect = width / height if height else 1
+            fig_width = 11
+            fig_height = max(4, min(11, fig_width / aspect + 0.6))
+            fig, ax = plt.subplots(figsize=(fig_width, fig_height))
+            ax.imshow(image)
+            ax.set_axis_off()
+            fig.suptitle(png.relative_to(run_dir).as_posix(), fontsize=10)
+            fig.tight_layout(rect=(0, 0, 1, 0.96))
+            pages.savefig(fig)
+            plt.close(fig)
+    return pdf
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -189,11 +216,17 @@ def main() -> int:
         print(f"  SKIP  cta_curation  ({type(e).__name__}: {e})", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
 
+    pdf = _write_all_figures_pdf(run_dir, done)
+    if pdf is not None:
+        print(f"  ok    {pdf.name}")
+
     index = run_dir / "index.md"
     lines = [
         f"# oncoref figures — {run_dir.name}",
         "",
         f"{len(done)} generated, {len(skipped)} skipped.",
+        "",
+        f"Combined PDF: `{pdf.name}`" if pdf is not None else "Combined PDF: not generated.",
         "",
         "## Generated",
         *(f"- `{p}`" for p in done),

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -600,3 +600,27 @@ def test_regenerate_plots_runner_references_real_functions():
     for family, name, fn_attr, kwargs in jobs:
         assert family and name and isinstance(kwargs, dict)
         assert callable(getattr(plots, fn_attr, None)), f"{fn_attr} is not a plots function"
+
+
+def test_regenerate_plots_runner_writes_all_figures_pdf(tmp_path):
+    import importlib.util
+    from pathlib import Path
+
+    import matplotlib.pyplot as plt
+
+    runner = Path(__file__).resolve().parent.parent / "scripts" / "regenerate_plots.py"
+    spec = importlib.util.spec_from_file_location("_regen_plots", runner)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    rels = ["first/one.png", "second/two.png"]
+    for rel in rels:
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        plt.imsave(path, [[[0.2, 0.4, 0.6], [0.9, 0.8, 0.1]]])
+
+    pdf = mod._write_all_figures_pdf(tmp_path, rels)
+
+    assert pdf == tmp_path / "all-figures.pdf"
+    assert pdf.exists()
+    assert pdf.stat().st_size > 0


### PR DESCRIPTION
## Summary
- assemble generated plot PNGs into `all-figures.pdf` at the end of `scripts/regenerate_plots.py`
- list the combined PDF in the run `index.md`
- add a focused test for the PDF assembly helper

Refs #178 for the broader pirlygenes plot-parity gap.

## Tests
- `ruff check scripts/regenerate_plots.py tests/test_plots.py`
- `ruff format --check scripts/regenerate_plots.py tests/test_plots.py`
- `python -m pytest tests/test_plots.py -q`