### PR TITLE
Release oncoref 1.8.1

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins


### PR DESCRIPTION
## Summary
- bump package version to 1.8.1 for the plot-regeneration PDF release
- leave data bundle versions unchanged; this is a code-only release

## Tests
- deployment will run the full lint/test/build flow before uploading