### PR TITLE
[codex] Tighten expression value column detection

### DIFF
--- a/oncoref/normalization.py
+++ b/oncoref/normalization.py
@@ -280,10 +280,12 @@ def percentile_rank(df: pd.DataFrame, value_cols=None) -> pd.DataFrame:
 
 # ---------- TPM-scale rescaling (FPKM->TPM, renormalize to 1e6) ----------
 
-#: Column-name conventions for "an expression value column" — TPM/nTPM/FPKM named
-#: (mirrors the pirlygenes expression schema), excluding the ``_raw`` provenance
-#: copies that must never be rescaled.
-_VALUE_COL_PREFIXES = ("TPM", "nTPM_", "FPKM_")
+#: Column-name conventions for "an expression value column" — exact scalar TPM/
+#: nTPM/FPKM labels, source-style FPKM columns, and entity-first measurement
+#: suffixes. Excludes legacy unit-first ``TPM_<entity>`` / ``nTPM_<entity>`` public
+#: names and ``_raw`` provenance copies that must never be rescaled.
+_VALUE_COL_EXACT = ("TPM", "nTPM", "FPKM")
+_VALUE_COL_PREFIXES = ("FPKM_",)
 _VALUE_COL_SUFFIXES = (
     "_TPM",
     "_nTPM",
@@ -307,9 +309,11 @@ def is_expression_value_col(col: object) -> bool:
     """True if ``col`` names an expression value column (TPM/nTPM/FPKM-named),
     excluding the ``_raw`` provenance copies."""
     name = str(col)
-    return (name.startswith(_VALUE_COL_PREFIXES) or name.endswith(_VALUE_COL_SUFFIXES)) and not (
-        name.startswith(_RAW_VALUE_COL_PREFIXES) or name.endswith(_RAW_VALUE_COL_SUFFIXES)
-    )
+    return (
+        name in _VALUE_COL_EXACT
+        or name.startswith(_VALUE_COL_PREFIXES)
+        or name.endswith(_VALUE_COL_SUFFIXES)
+    ) and not (name.startswith(_RAW_VALUE_COL_PREFIXES) or name.endswith(_RAW_VALUE_COL_SUFFIXES))
 
 
 def renormalize_to_million(df: pd.DataFrame, *, value_cols=None) -> tuple[pd.DataFrame, dict]:

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -260,9 +260,28 @@ def test_fpkm_to_tpm_equals_renormalize():
     assert out["x_FPKM"].to_numpy() == pytest.approx([2e5, 6e5, 2e5])
 
 
+def test_fpkm_to_tpm_auto_detects_source_style_fpkm_columns():
+    df = pd.DataFrame(
+        {
+            "FPKM_LUAD": [2.0, 8.0],
+            "TPM_LUAD": [2.0, 8.0],
+            "nTPM_liver": [3.0, 7.0],
+        }
+    )
+    out, stats = norm.fpkm_to_tpm(df)
+    assert out["FPKM_LUAD"].to_numpy() == pytest.approx([2e5, 8e5])
+    assert out["TPM_LUAD"].to_numpy() == pytest.approx([2.0, 8.0])
+    assert out["nTPM_liver"].to_numpy() == pytest.approx([3.0, 7.0])
+    assert stats["value_cols"] == ["FPKM_LUAD"]
+
+
 def test_is_expression_value_col():
     assert norm.is_expression_value_col("LUAD_TPM_clean")
     assert norm.is_expression_value_col("TPM")
+    assert norm.is_expression_value_col("FPKM")
+    assert norm.is_expression_value_col("FPKM_LUAD")
+    assert not norm.is_expression_value_col("TPM_LUAD")
+    assert not norm.is_expression_value_col("nTPM_liver")
     assert not norm.is_expression_value_col("LUAD_TPM_raw")
     assert not norm.is_expression_value_col("Ensembl_Gene_ID")
 


### PR DESCRIPTION
## Summary

- Replace the stale broad CTA/API diff with the one remaining unsuperseded change from #185.
- Keep source-style `FPKM_<CODE>` auto-detection so default `fpkm_to_tpm()` conversion still works.
- Stop treating legacy unit-first public columns like `TPM_<CODE>` and `nTPM_<tissue>` as canonical expression value columns; entity-first suffix columns such as `<CODE>_TPM_clean` remain detected.

The CTA compatibility helpers and entity-first `pan_cancer_expression()` output from the original PR are already present on `main`; this PR now carries only the remaining detector regression coverage.

Closes #183.
Closes #184.

Validation:
- `python -m pytest tests/test_normalization.py tests/test_expression.py::test_pan_cancer_expression_converts_fpkm_to_tpm tests/test_expression.py::test_pan_cancer_expression_raw_only tests/test_expression.py::test_pan_cancer_expression_accepts_clean_tpm_alias tests/test_expression.py::test_pan_cancer_expression_log_modes -q` (31 passed)
- `./lint.sh`
- `./test.sh` (527 passed, 1 existing matplotlib open-figure warning)