### PR TITLE
[codex] Unify data management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
 - **HPA normal tissue** — `hpa_rna_consensus`, `hpa_normal_tissue` (IHC),
   `hpa_single_cell`, and per-gene lookups (`gene_tissue_ntpm`,
   `gene_protein_tissues`, `gene_cell_type_ntpm`) over HPA v23, fetched on demand
-  (`oncoref hpa fetch`).
+  (`oncoref data fetch hpa`).
 - **Genome reference** — `canonical_gene_id_and_name`, `find_gene_id_by_name`,
   `find_gene_name_from_ensembl_{gene,transcript}_id`, `aggregate_gene_expression`
   (pyensembl-backed symbol ↔ Ensembl-ID resolution). pyensembl ships with the
@@ -127,12 +127,13 @@ oncoref plot apd1-vs-tmb --out apd1_vs_tmb.png
 oncoref plot patient-coverage --gene-set cta --out coverage_out
 oncoref plot cta-curation --out cta_curation_out
 
-# expression-bundle cache (per-cohort expression):
-oncoref cache fetch             # download the ~340 MB bundle
-oncoref cache status            # which bundle paths are cached (no download)
-oncoref cache dir               # where the data bundle is cached
-oncoref cache prune --yes       # delete stale version caches
-oncoref hpa fetch               # download HPA reference data (RNA / IHC / single-cell)
+# managed data downloads/cache:
+oncoref data list               # every wheel/bundle/HPA/source dataset
+oncoref data status bundle      # expression-bundle cache state (no download)
+oncoref data fetch bundle       # download the ~340 MB bundle
+oncoref data fetch hpa          # download HPA reference data (RNA / IHC / single-cell)
+oncoref data dir bundle         # where the data bundle is cached
+oncoref data prune --yes        # delete stale bundle version caches
 oncoref version
 ```
 

--- a/oncoref/catalog.py
+++ b/oncoref/catalog.py
@@ -111,6 +111,28 @@ def path(name: str) -> Path | None:
     return data_bundle.find(name)
 
 
+def _per_sample_status_row(name: str) -> dict:
+    code = name[len(_PER_SAMPLE) :]
+    try:
+        info = source_matrices.cohort_info(code)
+        p = path(name)
+    except source_matrices.SourceMatrixError as e:
+        raise KeyError(str(e)) from None
+    resolved = str(info["cancer_code"])
+    return {
+        "name": f"{_PER_SAMPLE}{resolved}",
+        "kind": "source",
+        "present": p is not None,
+        "path": str(p) if p is not None else None,
+        "size_bytes": _size_bytes(p),
+        "cohorts": 1,
+        "description": (
+            f"raw per-sample TPM matrix for {resolved} "
+            f"({info['source_cohort']}; n={int(info['n_samples'])})"
+        ),
+    }
+
+
 def ensure(name: str) -> Path:
     """Local path to ``name``, downloading if absent. Returns the path.
 
@@ -242,7 +264,19 @@ def status(name: str | None = None) -> list[dict]:
     """Uniform status rows over the catalog: ``name``, ``kind``, ``present``,
     ``path``, ``size_bytes``, ``cohorts`` (per-cohort file count for directory
     datasets, else ``None``), ``description``. One dataset if ``name`` given."""
-    names = [dataset(name).name] if name is not None else [d.name for d in datasets()]
+    if name == "all":
+        name = None
+    if name is not None and name.startswith(_PER_SAMPLE):
+        return [_per_sample_status_row(name)]
+    if name == "source":
+        return [
+            _per_sample_status_row(f"{_PER_SAMPLE}{code}")
+            for code in source_matrices.available_cohorts()
+        ]
+    if name in (_BUNDLE, _HPA):
+        names = [d.name for d in datasets() if d.kind == name]
+    else:
+        names = [dataset(name).name] if name is not None else [d.name for d in datasets()]
     rows = []
     for n in names:
         d = dataset(n)

--- a/oncoref/cli.py
+++ b/oncoref/cli.py
@@ -13,8 +13,7 @@
 """``oncoref`` command-line interface.
 
 Reference lookups over the bundled tables (cancer-type / TMB / burden / ICI) plus
-the ``cache`` group (fetch / status / dir / prune) for the heavy per-cohort
-expression bundle, and the ``hpa`` / ``expression-sources`` source managers.
+the ``data`` manager for downloadable expression-bundle, HPA, and per-sample sources.
 """
 
 from __future__ import annotations
@@ -53,39 +52,7 @@ def _cmd_version(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cmd_cache_dir(args: argparse.Namespace) -> int:
-    print(data_bundle.cache_dir())
-    return 0
-
-
-def _cmd_fetch(args: argparse.Namespace) -> int:
-    try:
-        if args.force or not data_bundle.is_local():
-            data_bundle.fetch()
-        else:
-            print(f"Already present at {data_bundle.cache_dir()}")
-    except Exception as e:  # network / extract failure
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-    return 0
-
-
-def _cmd_status(args: argparse.Namespace) -> int:
-    snap = data_bundle.status()
-    print(f"Data version: {snap['data_version']}")
-    print(f"Cache dir:    {snap['cache_dir']}")
-    print(f"Release URL:  {snap['release_url']}")
-    for fallback in snap.get("release_urls", [])[1:]:
-        print(f"  fallback:   {fallback}")
-    print(f"All local:    {'yes' if snap['all_local'] else 'no'}")
-    print("-" * 60)
-    for name, item in snap["items"].items():
-        mark = "present" if item["present"] else "missing"
-        print(f"  {name:<48} {mark:>8}  {_fmt_bytes(item['size_bytes']):>9}")
-    return 0
-
-
-def _cmd_prune(args: argparse.Namespace) -> int:
+def _print_bundle_prune(args: argparse.Namespace) -> int:
     deleted = data_bundle.prune_cache(keep_current=not args.include_current, dry_run=not args.yes)
     if not deleted:
         print("Nothing to prune.")
@@ -100,7 +67,7 @@ def _cmd_prune(args: argparse.Namespace) -> int:
 
 def _cmd_data(args: argparse.Namespace) -> int:
     """Unified data management over the catalog (expression bundle + HPA sources)."""
-    from . import catalog
+    from . import catalog, source_matrices
 
     if args.action == "list":
         # The full inventory: every oncoref-domain dataset and how it's held.
@@ -109,7 +76,17 @@ def _cmd_data(args: argparse.Namespace) -> int:
             f"{'Dataset':<46} {'Held':<8} {'Avail':<6} {'Cohorts':>8} {'Category':<14} Description"
         )
         print("-" * 120)
-        for r in catalog.inventory():
+        rows = catalog.inventory()
+        if args.name and args.name != "all":
+            rows = [
+                r
+                for r in rows
+                if r["held"] == args.name or r["category"] == args.name or r["name"] == args.name
+            ]
+            if not rows:
+                print(f"Error: unknown data list filter {args.name!r}", file=sys.stderr)
+                return 1
+        for r in rows:
             avail = "yes" if r["available"] else "-"
             cohorts = str(r["cohorts"]) if r["cohorts"] is not None else "-"
             print(
@@ -138,6 +115,23 @@ def _cmd_data(args: argparse.Namespace) -> int:
             )
         return 0
 
+    if args.action == "dir":
+        target = args.name or "all"
+        dirs = {
+            "bundle": data_bundle.cache_dir(),
+            "hpa": reference_data.cache_dir(),
+            "source": source_matrices.cache_dir(),
+        }
+        if target == "all":
+            for name, path in dirs.items():
+                print(f"{name}\t{path}")
+            return 0
+        if target not in dirs:
+            print("Error: data dir target must be all, bundle, hpa, or source", file=sys.stderr)
+            return 1
+        print(dirs[target])
+        return 0
+
     if args.action == "fetch":
         try:
             downloaded = catalog.fetch(args.name or "all", force=args.force)
@@ -163,6 +157,13 @@ def _cmd_data(args: argparse.Namespace) -> int:
             print(f"Error: {e}", file=sys.stderr)
             return 1
         return 0
+
+    if args.action == "prune":
+        target = args.name or "bundle"
+        if target != "bundle":
+            print("Error: data prune currently supports only the bundle cache", file=sys.stderr)
+            return 1
+        return _print_bundle_prune(args)
 
     return 1
 
@@ -358,44 +359,6 @@ def _cmd_plot(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cmd_sources(args: argparse.Namespace) -> int:
-    if args.action == "list" or args.action == "status":
-        rows = reference_data.status()
-        print(f"{'Source':<20} {'Cached':<8} {'Version':<10} {'Size':>9}  Description")
-        print("-" * 92)
-        for r in rows:
-            cached = "yes" if r["cached"] else "no"
-            ver = r["cached_version"] or f"({r['default_version']})"
-            print(
-                f"{r['name']:<20} {cached:<8} {ver:<10} {_fmt_bytes(r['bytes']):>9}  {r['description']}"
-            )
-        print(f"\nCache directory: {reference_data.cache_dir()}")
-        return 0
-    if args.action == "fetch":
-        names = [args.name] if args.name else list(reference_data.REFERENCE_SOURCES)
-        failures = []
-        for name in names:
-            try:
-                path = reference_data.download(name, force=args.force)
-            except reference_data.ReferenceDataError as e:
-                print(f"Error: {name}: {e}", file=sys.stderr)
-                failures.append(name)
-                continue
-            print(f"Ready: {name} -> {path}")
-        return 1 if failures else 0
-    if args.action == "path":
-        if not args.name:
-            print("Error: 'hpa path' requires a source name", file=sys.stderr)
-            return 1
-        try:
-            print(reference_data.ensure(args.name))
-        except reference_data.ReferenceDataError as e:
-            print(f"Error: {e}", file=sys.stderr)
-            return 1
-        return 0
-    return 1
-
-
 def _cmd_expression_sources(args: argparse.Namespace) -> int:
     srcs = expression_registry.expression_sources()
     if args.code:
@@ -463,25 +426,6 @@ def _build_parser() -> argparse.ArgumentParser:
     sub.add_parser("version", help="Print the installed oncoref version").set_defaults(
         func=_cmd_version
     )
-
-    # --- cache: the downloadable per-cohort expression bundle ---
-    p_cache = sub.add_parser("cache", help="Manage the downloadable expression-bundle cache")
-    cache_sub = p_cache.add_subparsers(dest="cache_action", required=True)
-    cache_sub.add_parser(
-        "dir", help="Print the on-disk cache dir for the data bundle"
-    ).set_defaults(func=_cmd_cache_dir)
-    p_cfetch = cache_sub.add_parser("fetch", help="Download the per-cohort expression data bundle")
-    p_cfetch.add_argument("--force", action="store_true", help="Re-download even if present")
-    p_cfetch.set_defaults(func=_cmd_fetch)
-    cache_sub.add_parser(
-        "status", help="Report which bundle paths are cached locally (no download)"
-    ).set_defaults(func=_cmd_status)
-    p_cprune = cache_sub.add_parser("prune", help="Delete stale version-pinned cache dirs")
-    p_cprune.add_argument("--yes", action="store_true", help="Actually delete (default: dry run)")
-    p_cprune.add_argument(
-        "--include-current", action="store_true", help="Also delete the current version's cache"
-    )
-    p_cprune.set_defaults(func=_cmd_prune)
 
     # --- reference lookups ---
     p_ct = sub.add_parser(
@@ -636,8 +580,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_data.add_argument(
         "action",
-        choices=["list", "status", "fetch", "path"],
-        help="list (catalog), status (cache state), fetch (download), path (ensure + print)",
+        choices=["list", "status", "dir", "fetch", "path", "prune"],
+        help=(
+            "list (catalog), status (cache state), dir (cache roots), "
+            "fetch (download), path (ensure + print), prune (bundle cache cleanup)"
+        ),
     )
     p_data.add_argument(
         "name",
@@ -647,19 +594,17 @@ def _build_parser() -> argparse.ArgumentParser:
         "per-sample:<CODE> (omit = all)",
     )
     p_data.add_argument("--force", action="store_true", help="Re-download even if cached")
+    p_data.add_argument(
+        "--yes",
+        action="store_true",
+        help="Actually delete stale bundle caches for 'data prune' (default: dry run)",
+    )
+    p_data.add_argument(
+        "--include-current",
+        action="store_true",
+        help="For 'data prune', also delete the current bundle cache",
+    )
     p_data.set_defaults(func=_cmd_data)
-
-    p_hpa = sub.add_parser(
-        "hpa", help="Manage HPA normal-tissue reference data (RNA / IHC / single-cell)"
-    )
-    p_hpa.add_argument(
-        "action",
-        choices=["list", "status", "fetch", "path"],
-        help="list/status (show cache state), fetch (download), path (print local path)",
-    )
-    p_hpa.add_argument("name", nargs="?", default=None, help="HPA source name (omit to fetch all)")
-    p_hpa.add_argument("--force", action="store_true", help="Re-download even if cached")
-    p_hpa.set_defaults(func=_cmd_sources)
 
     p_exprsrc = sub.add_parser(
         "expression-sources",

--- a/oncoref/data_bundle.py
+++ b/oncoref/data_bundle.py
@@ -243,13 +243,14 @@ def ensure_local(*, auto_fetch: bool = True, verbose: bool = True) -> Path:
         return cache_dir()
     if not auto_fetch:
         raise FileNotFoundError(
-            f"oncoref data bundle not found at {cache_dir()}. Run `oncoref cache fetch` to download it."
+            f"oncoref data bundle not found at {cache_dir()}. "
+            "Run `oncoref data fetch bundle` to download it."
         )
     return fetch(verbose=verbose)
 
 
 def status() -> dict:
-    """Snapshot of cache state — used by ``oncoref cache status``."""
+    """Snapshot of cache state — used by ``oncoref data status bundle``."""
     root = cache_dir()
     items: dict[str, dict] = {}
     for p in DOWNLOADABLE_PATHS:
@@ -309,7 +310,7 @@ def list_cache_versions() -> list[dict]:
     """Enumerate every version-pinned cache dir under :func:`cache_root`.
 
     Returns ``{"version", "path", "size_bytes", "is_current"}`` dicts sorted by
-    version label. Used by ``oncoref cache prune`` to find upgrade leftovers.
+    version label. Used by ``oncoref data prune`` to find upgrade leftovers.
     """
     root = cache_root()
     if not root.exists():

--- a/scripts/build_data_tarball.sh
+++ b/scripts/build_data_tarball.sh
@@ -5,8 +5,8 @@
 # artifacts (data_bundle.DOWNLOADABLE_PATHS) are distributed as a version-pinned
 # tarball attached to the pirl-unc/oncoref release. This script packages those
 # paths from a source directory that already contains them — e.g. a populated
-# cache dir (`oncoref cache fetch` then `oncoref cache status` for the path) or a
-# pirlygenes data checkout during the migration.
+# cache dir (`oncoref data fetch bundle` then `oncoref data dir bundle` for the
+# path) or a pirlygenes data checkout during the migration.
 #
 # Usage:
 #   scripts/build_data_tarball.sh <source-dir> [output-dir]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -39,6 +39,13 @@ def test_status_uniform_and_absent(monkeypatch, tmp_path):
     assert all(r["present"] is False and r["size_bytes"] == 0 for r in rows)
 
 
+def test_status_accepts_backend_groups(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / "bundle" / "vX"))
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path / "ref"))
+    assert {r["kind"] for r in catalog.status("bundle")} == {"bundle"}
+    assert {r["kind"] for r in catalog.status("hpa")} == {"hpa"}
+
+
 def test_path_none_when_absent_then_present(monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path / "ref"))
     assert catalog.path("hpa_normal_tissue") is None
@@ -126,6 +133,11 @@ def test_cli_data_list(capsys):
     for r in catalog.inventory():
         assert r["name"] in out
 
+    assert cli.main(["data", "list", "hpa"]) == 0
+    out = capsys.readouterr().out
+    assert "hpa_rna_consensus" in out
+    assert "pan-cancer-expression" not in out
+
 
 def test_cli_data_status_absent(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / "b" / "vX"))
@@ -133,6 +145,14 @@ def test_cli_data_status_absent(monkeypatch, tmp_path, capsys):
     assert cli.main(["data", "status"]) == 0
     out = capsys.readouterr().out
     assert "Present" in out and "no" in out
+
+    assert cli.main(["data", "status", "all"]) == 0
+    out = capsys.readouterr().out
+    assert "Present" in out and "no" in out
+
+    assert cli.main(["data", "status", "hpa"]) == 0
+    out = capsys.readouterr().out
+    assert "hpa_rna_consensus" in out
 
 
 def test_cli_data_status_unknown_errors(capsys):
@@ -155,6 +175,19 @@ def test_cli_data_fetch_nothing(monkeypatch, capsys):
     monkeypatch.setattr(catalog, "fetch", lambda name="all", *, force=False: [])
     assert cli.main(["data", "fetch"]) == 0
     assert "Already present." in capsys.readouterr().out
+
+
+def test_cli_data_dir_and_prune(capsys, monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / "bundle" / "vX"))
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path / "ref"))
+    monkeypatch.setenv("CANCERDATA_SOURCE_MATRICES", str(tmp_path / "source"))
+    assert cli.main(["data", "dir", "bundle"]) == 0
+    assert str(tmp_path / "bundle" / "vX") in capsys.readouterr().out
+    assert cli.main(["data", "dir"]) == 0
+    out = capsys.readouterr().out
+    assert "bundle\t" in out and "hpa\t" in out and "source\t" in out
+    assert cli.main(["data", "prune"]) == 0
+    assert "Nothing to prune." in capsys.readouterr().out
 
 
 def test_cli_help_never_crashes():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@
 
 import json
 
+import pytest
+
 from oncoref import cli
 
 
@@ -91,7 +93,7 @@ def test_burden_full_map(capsys):
 
 def test_cache_dir_respects_env(capsys, monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
-    assert cli.main(["cache", "dir"]) == 0
+    assert cli.main(["data", "dir", "bundle"]) == 0
     out = capsys.readouterr().out.strip()
     assert str(tmp_path) in out
 
@@ -99,13 +101,20 @@ def test_cache_dir_respects_env(capsys, monkeypatch, tmp_path):
 def test_status_no_download(capsys, monkeypatch, tmp_path):
     # status must never trigger a fetch, even with an empty cache dir.
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
-    assert cli.main(["cache", "status"]) == 0
+    assert cli.main(["data", "status", "bundle"]) == 0
     out = capsys.readouterr().out
-    assert "All local:    no" in out
+    assert "Present" in out and "no" in out
     assert "cancer-reference-expression" in out
 
 
 def test_prune_dry_run_default(capsys, monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / "v0.0.0"))
-    assert cli.main(["cache", "prune"]) == 0
+    assert cli.main(["data", "prune"]) == 0
     assert "Nothing to prune" in capsys.readouterr().out
+
+
+def test_redundant_cache_and_hpa_commands_removed():
+    with pytest.raises(SystemExit):
+        cli.main(["cache", "status"])
+    with pytest.raises(SystemExit):
+        cli.main(["hpa", "status"])

--- a/tests/test_hpa.py
+++ b/tests/test_hpa.py
@@ -103,7 +103,11 @@ def test_gene_protein_tissues_detected_only(hpa_cache):
 def test_cli_sources_list(hpa_cache, capsys):
     from oncoref import cli
 
-    assert cli.main(["hpa", "list"]) == 0
+    assert cli.main(["data", "list", "hpa"]) == 0
+    out = capsys.readouterr().out
+    assert "hpa_rna_consensus" in out and "hpa_single_cell" in out
+
+    assert cli.main(["data", "status", "hpa"]) == 0
     out = capsys.readouterr().out
     assert "hpa_rna_consensus" in out and "hpa_single_cell" in out
 
@@ -112,7 +116,7 @@ def test_cli_sources_path_uses_cache(hpa_cache, capsys):
     from oncoref import cli
 
     # already seeded -> ensure() returns the path without a network fetch
-    assert cli.main(["hpa", "path", "hpa_rna_consensus"]) == 0
+    assert cli.main(["data", "path", "hpa_rna_consensus"]) == 0
     assert "rna_tissue_consensus.tsv" in capsys.readouterr().out
 
 


### PR DESCRIPTION
## Summary

- remove the redundant top-level `oncoref cache` and `oncoref hpa` command groups
- fold their usable behaviors into `oncoref data` via `data dir`, `data prune`, and grouped `data list/status` filters
- keep HPA/source/bundle fetching and path resolution available through the unified catalog-backed `data` command
- update README and in-code command references to the new data-manager CLI

## Validation

- `python -m pytest tests/test_cli.py tests/test_catalog.py tests/test_hpa.py`
- `./lint.sh`
- `./test.sh` (`485 passed, 1 warning`)
