### PR TITLE
[codex] Fix expression semantics for migration

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -496,10 +496,7 @@ def cancer_reference_expression(
 
     if not wide_parts:
         return pd.DataFrame(columns=["Ensembl_Gene_ID", "Symbol"])
-    out = wide_parts[0]
-    for part in wide_parts[1:]:
-        out = out.merge(part, on=["Ensembl_Gene_ID", "Symbol"], how="outer")
-    return out.sort_values("Ensembl_Gene_ID").reset_index(drop=True)
+    return _merge_cancer_reference_wide_parts(wide_parts)
 
 
 def _reference_normalize_modes(normalize: str | Iterable[str]) -> set[str]:
@@ -508,6 +505,44 @@ def _reference_normalize_modes(normalize: str | Iterable[str]) -> set[str]:
     else:
         modes = {str(mode).lower() for mode in normalize}
     return {"tpm_clean" if mode == "clean_tpm" else mode for mode in modes}
+
+
+def _merge_cancer_reference_wide_parts(parts: list[pd.DataFrame]) -> pd.DataFrame:
+    """Merge cohort reference vectors by canonical ENSG only.
+
+    Cohorts can carry different release-era symbols for the same canonical gene.
+    Joining on ``(Ensembl_Gene_ID, Symbol)`` fragments those loci into sparse rows.
+    """
+    if not parts:
+        return pd.DataFrame(columns=["Ensembl_Gene_ID", "Symbol"])
+
+    value_cols: list[str] = []
+    symbols: dict[str, Counter] = defaultdict(Counter)
+    keyed_parts: list[pd.DataFrame] = []
+    for part in parts:
+        value_cols.extend(c for c in part.columns if c not in {"Ensembl_Gene_ID", "Symbol"})
+        for gid, symbol in zip(part["Ensembl_Gene_ID"].astype(str), part["Symbol"].astype(str)):
+            symbols[gid][symbol] += 1
+        keyed = part.drop(columns=["Symbol"], errors="ignore")
+        if keyed["Ensembl_Gene_ID"].duplicated().any():
+            keyed = keyed.groupby("Ensembl_Gene_ID", sort=False).first().reset_index()
+        keyed_parts.append(keyed)
+
+    alias_symbols = ensembl_id_alias_symbols()
+
+    def _symbol(gid: str) -> str:
+        auth = alias_symbols.get(gid)
+        if auth:
+            return auth
+        named = Counter({s: c for s, c in symbols.get(gid, {}).items() if s and s != gid})
+        return named.most_common(1)[0][0] if named else gid
+
+    out = keyed_parts[0]
+    for part in keyed_parts[1:]:
+        out = out.merge(part, on="Ensembl_Gene_ID", how="outer")
+    out = out.sort_values("Ensembl_Gene_ID").reset_index(drop=True)
+    out.insert(1, "Symbol", out["Ensembl_Gene_ID"].astype(str).map(_symbol))
+    return out[["Ensembl_Gene_ID", "Symbol", *value_cols]]
 
 
 #: Per-gene cohort summary statistic -> output column. The percentiles are taken across

--- a/oncoref/normalization.py
+++ b/oncoref/normalization.py
@@ -160,10 +160,25 @@ def clean_tpm(
     compartments themselves comparable and the budget empirically interpretable.)
 
     An empty/zero compartment simply contributes 0 (the others still fill their share).
-    With ``exclude_ribosomal_proteins=False``, ribosomal proteins are treated as
-    biology, only the strict technical-RNA set is pinned, and the omitted ribosomal
-    budget is intentionally reallocated into biology so no budget compartment is
-    silently dropped."""
+    The public clean-TPM contract is deliberately singular: 16% ribosomal proteins,
+    9% other technical RNA, and 75% biological genes. Use separately named helpers
+    such as :func:`drop_technical_rna` / :func:`filter_technical_rna` for biology-only
+    or technical-drop views, not alternate clean-TPM definitions."""
+    if not exclude_ribosomal_proteins:
+        raise ValueError(
+            "clean_tpm has one canonical 16/9/75 contract and always censors "
+            "ribosomal proteins; use drop_technical_rna(..., "
+            "exclude_ribosomal_proteins=False) or filter_technical_rna for "
+            "non-clean-TPM biology-only/drop views"
+        )
+    if (
+        ribosomal_protein_fraction != RIBOSOMAL_PROTEIN_FRACTION
+        or other_technical_fraction != OTHER_TECHNICAL_FRACTION
+    ):
+        raise ValueError(
+            "clean_tpm fraction knobs are deprecated: clean_tpm always uses the "
+            "canonical 16% ribosomal / 9% other-technical / 75% biological budget"
+        )
     for name, frac in (
         ("ribosomal_protein_fraction", ribosomal_protein_fraction),
         ("other_technical_fraction", other_technical_fraction),
@@ -185,8 +200,6 @@ def clean_tpm(
     rm, tm = ribosomal.to_numpy(), technical.to_numpy()
     bm = ~(rm | tm)
     bio_fraction = 1.0 - ribosomal_protein_fraction - other_technical_fraction
-    if not exclude_ribosomal_proteins:
-        bio_fraction += ribosomal_protein_fraction
 
     clean = values.astype(float).copy()
     for mask, fraction in (
@@ -418,10 +431,10 @@ def normalize_expression(
         mtDNA / NUMT-like / rRNA-like / polyA-bias lncRNA) and rescale the kept rows
         so each column's **original total** is preserved. With ``group_cols``,
         normalizes within each group independently (e.g. per cohort in a long table).
-      - any other value — apply the two-compartment reference :func:`clean_tpm`
-        (clean_tpm_v4) over the value columns instead (the basis the packaged
-        references ship on); ``other_technical_fraction`` / ``exclude_ribosomal_proteins``
-        tune it.
+      - any other value — apply the canonical :func:`clean_tpm` 16/9/75 transform
+        over the value columns instead (the basis the packaged references ship on).
+        Historical budget knobs remain in the signature only to reject noncanonical
+        transition uses; they do not define alternate clean-TPM modes.
 
     Classification is ENSG-first when ``id_col`` is present, else symbol-only.
     """

--- a/oncoref/normalization.py
+++ b/oncoref/normalization.py
@@ -160,8 +160,10 @@ def clean_tpm(
     compartments themselves comparable and the budget empirically interpretable.)
 
     An empty/zero compartment simply contributes 0 (the others still fill their share).
-    With ``exclude_ribosomal_proteins=False`` ribosomal proteins are treated as biology
-    and only the technical-RNA set is censored (the legacy single-technical view)."""
+    With ``exclude_ribosomal_proteins=False``, ribosomal proteins are treated as
+    biology, only the strict technical-RNA set is pinned, and the omitted ribosomal
+    budget is intentionally reallocated into biology so no budget compartment is
+    silently dropped."""
     for name, frac in (
         ("ribosomal_protein_fraction", ribosomal_protein_fraction),
         ("other_technical_fraction", other_technical_fraction),
@@ -183,6 +185,8 @@ def clean_tpm(
     rm, tm = ribosomal.to_numpy(), technical.to_numpy()
     bm = ~(rm | tm)
     bio_fraction = 1.0 - ribosomal_protein_fraction - other_technical_fraction
+    if not exclude_ribosomal_proteins:
+        bio_fraction += ribosomal_protein_fraction
 
     clean = values.astype(float).copy()
     for mask, fraction in (

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -608,6 +608,41 @@ def test_cancer_reference_expression_long_and_wide(monkeypatch):
     assert wide.loc[wide["Symbol"] == "A", "X_TPM_clean"].iloc[0] == 3.0
 
 
+def test_cancer_reference_expression_wide_merges_by_gene_id_not_symbol(monkeypatch):
+    by_code = {
+        "X": pd.DataFrame(
+            {
+                "Ensembl_Gene_ID": ["E1", "E2"],
+                "Symbol": ["A", "B"],
+                "p25": [1.0, 2.0],
+                "p50": [3.0, 4.0],
+                "p75": [5.0, 6.0],
+            }
+        ),
+        "Y": pd.DataFrame(
+            {
+                "Ensembl_Gene_ID": ["E1", "E3"],
+                "Symbol": ["A_OLD", "C"],
+                "p25": [5.0, 8.0],
+                "p50": [7.0, 9.0],
+                "p75": [9.0, 10.0],
+            }
+        ),
+    }
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X", "Y"])
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+    monkeypatch.setattr(
+        expression, "cohort_gene_percentiles", lambda code, *a, **k: by_code[code].copy()
+    )
+
+    wide = expression.cancer_reference_expression(["x", "y"], format="wide")
+    e1 = wide[wide["Ensembl_Gene_ID"] == "E1"]
+    assert len(e1) == 1
+    assert e1["Symbol"].iloc[0] == "A"
+    assert e1["X_TPM_clean"].iloc[0] == pytest.approx(3.0)
+    assert e1["Y_TPM_clean"].iloc[0] == pytest.approx(7.0)
+
+
 def test_proteoform_named_accessors_delegate_with_proteoform_true(monkeypatch):
     # The proteoform_* named accessors are thin wrappers that set proteoform=True on
     # their gene-level base, threading scope/statistic/etc. through.

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -80,27 +80,12 @@ def test_clean_tpm_three_compartments():
     assert clean.loc[[2, 3], "s1"].sum() == pytest.approx(norm.BIOLOGICAL_FRACTION * 1e6)  # 750k
 
 
-def test_clean_tpm_keep_ribosomal_reallocates_omitted_budget():
-    # If ribosomal proteins are kept in biology, the 16% ribosomal budget must not
-    # remain reserved for an empty censored compartment. Strict technical RNA keeps
-    # the 9% budget and biology expands to 91%.
-    censored = gf.clean_tpm_censored_gene_ids()
-    rpl = sorted(gf.gene_family_ids("ribosomal_protein") & censored)[0]
-    mito = sorted(gf.gene_family_ids("mitochondrial") & censored)[0]
-    gt = pd.DataFrame(
-        {
-            "Ensembl_Gene_ID": [rpl, mito, "ENSG00000111111"],
-            "Symbol": ["RP", "MT", "BIO"],
-        }
-    )
-    vals = pd.DataFrame({"s1": [5000.0, 5000.0, 1000.0]}, index=gt.index)
-    clean = norm.clean_tpm(vals, gt, exclude_ribosomal_proteins=False)
-    assert clean["s1"].sum() == pytest.approx(1e6)
-    assert clean.loc[1, "s1"] == pytest.approx(norm.OTHER_TECHNICAL_FRACTION * 1e6)
-    assert clean.loc[[0, 2], "s1"].sum() == pytest.approx(
-        (1.0 - norm.OTHER_TECHNICAL_FRACTION) * 1e6
-    )
-    assert clean.loc[0, "s1"] / clean.loc[2, "s1"] == pytest.approx(5.0)
+def test_clean_tpm_rejects_alternate_compartment_contracts():
+    gt, vals = _matrix()
+    with pytest.raises(ValueError, match="one canonical 16/9/75 contract"):
+        norm.clean_tpm(vals, gt, exclude_ribosomal_proteins=False)
+    with pytest.raises(ValueError, match="fraction knobs are deprecated"):
+        norm.clean_tpm(vals, gt, other_technical_fraction=0.10)
 
 
 def test_clean_tpm_compartment_fractions_public_and_sum_to_one():
@@ -160,9 +145,9 @@ def test_clean_tpm_no_technical_mass():
 
 def test_clean_tpm_validates():
     gt, vals = _matrix()
-    with pytest.raises(ValueError, match="other_technical_fraction"):
+    with pytest.raises(ValueError, match="fraction knobs are deprecated"):
         norm.clean_tpm(vals, gt, other_technical_fraction=1.5)
-    with pytest.raises(ValueError, match="biology needs a budget"):
+    with pytest.raises(ValueError, match="fraction knobs are deprecated"):
         norm.clean_tpm(vals, gt, ribosomal_protein_fraction=0.7, other_technical_fraction=0.5)
     with pytest.raises(ValueError, match="gene_table"):
         norm.clean_tpm(vals)
@@ -304,6 +289,30 @@ def test_normalize_expression_fixed_fraction_delegates_to_clean_tpm():
     # no technical genes -> biological compartment fills 750k
     assert out["s1_TPM"].sum() == pytest.approx(750000.0, rel=1e-6)
     assert stats["mode"] == "fixed_fraction"
+
+
+def test_normalize_expression_fixed_fraction_rejects_clean_tpm_knobs():
+    df = pd.DataFrame(
+        {
+            "Symbol": ["A", "B"],
+            "Ensembl_Gene_ID": ["E1", "E2"],
+            "s1_TPM": [10.0, 30.0],
+        }
+    )
+    with pytest.raises(ValueError, match="fraction knobs are deprecated"):
+        norm.normalize_expression(
+            df,
+            value_cols=["s1_TPM"],
+            censored_fill="fixed_fraction",
+            other_technical_fraction=0.10,
+        )
+    with pytest.raises(ValueError, match="one canonical 16/9/75 contract"):
+        norm.normalize_expression(
+            df,
+            value_cols=["s1_TPM"],
+            censored_fill="fixed_fraction",
+            exclude_ribosomal_proteins=False,
+        )
 
 
 def test_normalize_long_table_groups_independently():

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -80,6 +80,29 @@ def test_clean_tpm_three_compartments():
     assert clean.loc[[2, 3], "s1"].sum() == pytest.approx(norm.BIOLOGICAL_FRACTION * 1e6)  # 750k
 
 
+def test_clean_tpm_keep_ribosomal_reallocates_omitted_budget():
+    # If ribosomal proteins are kept in biology, the 16% ribosomal budget must not
+    # remain reserved for an empty censored compartment. Strict technical RNA keeps
+    # the 9% budget and biology expands to 91%.
+    censored = gf.clean_tpm_censored_gene_ids()
+    rpl = sorted(gf.gene_family_ids("ribosomal_protein") & censored)[0]
+    mito = sorted(gf.gene_family_ids("mitochondrial") & censored)[0]
+    gt = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": [rpl, mito, "ENSG00000111111"],
+            "Symbol": ["RP", "MT", "BIO"],
+        }
+    )
+    vals = pd.DataFrame({"s1": [5000.0, 5000.0, 1000.0]}, index=gt.index)
+    clean = norm.clean_tpm(vals, gt, exclude_ribosomal_proteins=False)
+    assert clean["s1"].sum() == pytest.approx(1e6)
+    assert clean.loc[1, "s1"] == pytest.approx(norm.OTHER_TECHNICAL_FRACTION * 1e6)
+    assert clean.loc[[0, 2], "s1"].sum() == pytest.approx(
+        (1.0 - norm.OTHER_TECHNICAL_FRACTION) * 1e6
+    )
+    assert clean.loc[0, "s1"] / clean.loc[2, "s1"] == pytest.approx(5.0)
+
+
 def test_clean_tpm_compartment_fractions_public_and_sum_to_one():
     import oncoref as cd
 


### PR DESCRIPTION
## Summary

This PR addresses the expression-semantics portion of the pirlygenes migration review.

- Make `clean_tpm(...)` a single public contract: canonical 16% ribosomal protein, 9% other technical RNA, and 75% biological gene budget.
- Reject noncanonical clean-TPM fraction knobs and `exclude_ribosomal_proteins=False` during the transition instead of adding alternate clean-TPM meanings.
- Keep biology-only / technical-drop views on separately named helpers (`drop_technical_rna` / `filter_technical_rna`) rather than clean-TPM modes.
- Merge wide cancer reference expression by canonical Ensembl gene ID instead of `(Ensembl_Gene_ID, Symbol)`, so alias/symbol drift does not fragment one gene across cohorts.
- Add regression coverage for the canonical clean-TPM contract and gene-ID-only wide merge.

## Notes

The broader pirlygenes replacement remains blocked by the follow-up parity/release issues: deterministic representative sample contract, expression bundle release/verification discipline, and registry-table provenance parity for TMB/aPD1/burden. This PR intentionally keeps scope to the narrow clean-TPM delegation and expression merge semantics.

## Validation

- `git diff --check`
- `./lint.sh`
- `python -m pytest tests/test_normalization.py tests/test_expression.py`
- `./test.sh` (`485 passed, 1 warning`)