### PR TITLE
[codex] Organize public API facades

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ pip install oncoref
 
 ## Python API
 
+The flat `oncoref` namespace remains available for compatibility and quick
+interactive use. For new code, prefer the semantic submodules in
+[docs/api.md](docs/api.md); they make it clearer whether you are working with
+the cancer ontology, cohorts, ICI response, CTA coverage, generic antigen-panel
+coverage, or CTA-specific peptides.
+
 ```python
 import oncoref as od
 
@@ -72,18 +78,24 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
 
 ### Domains
 
-- **Ontology** — `cancer_type_registry`, `resolve_cancer_type`,
-  `cancer_type_info`, `cancer_types_in_family`, `viral_status`, `fusion_status`,
-  the cohort vocabulary (`cohort_registry`, `cohort_aggregates`).
+- **Cancer ontology** — `oncoref.cancer_ontology`: `cancer_type_registry`,
+  `resolve_cancer_type`, `cancer_type_info`, tree/family/lineage helpers,
+  `viral_status`, `fusion_status`.
+- **Cohorts** — `oncoref.cohorts`: `cohort_registry`, `cohort_aggregates`,
+  `cohort_source_version`, and mixture-cohort helpers.
 - **TMB** — `cancer_tmb`, `cancer_tmb_df` (parent-chain inheritance).
 - **Incidence / mortality** — `cancer_burden`, `burden_category` (ACS / GLOBOCAN).
-- **Checkpoint response** — `cancer_ici_response` (ORR per type/regimen: anti-PD-1,
-  anti-PD-L1, anti-PD-1+anti-CTLA-4), with `cancer_apd1_response` the PD-1 shortcut.
+- **Checkpoint response** — `oncoref.ici_response`: regimen-aware ORR anchors,
+  anti-PD-1 shortcuts, endpoint estimates, and pooled response summaries.
 - **Expression** — `cohort_gene_percentiles`, `within_sample_top_fraction`,
   `representative_cohort_samples` over the lazy-downloaded per-cohort bundle.
-- **Cancer-testis antigens** — `cta_gene_names`/`cta_gene_ids`, `cta_evidence`,
-  `synthesize_restriction` (HPA-only tissue-restriction; MS evidence stays in the
-  target-selection layer).
+- **Cancer-testis antigens** — `oncoref.cta`: `cta_gene_names`/`cta_gene_ids`,
+  `cta_evidence`, `synthesize_restriction` (HPA-only tissue-restriction; MS
+  evidence stays in the target-selection layer).
+- **CTA coverage / peptides** — `oncoref.cta_coverage` for patient coverage and
+  `oncoref.cta_peptides` for CTA-specific 9-mer count maps and load.
+- **Generic antigen-panel coverage** — `oncoref.antigen_coverage` for explicit
+  non-CTA panels.
 - **HPA normal tissue** — `hpa_rna_consensus`, `hpa_normal_tissue` (IHC),
   `hpa_single_cell`, and per-gene lookups (`gene_tissue_ntpm`,
   `gene_protein_tissues`, `gene_cell_type_ntpm`) over HPA v23, fetched on demand
@@ -94,9 +106,6 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
   package, but resolution needs a downloaded human release once:
   `pyensembl install --release 111 --species homo_sapiens` (the accessors return
   `None` until then).
-- **Peptides** — `cta_specific_9mer_counts`, `cta_specific_9mer_load` (per-cohort
-  mean per-patient CTA-specific 9-mer load): 9-mers found in a CTA protein but in no
-  non-CTA protein, enumerated from the reference proteome and cached per release.
 - **Plots** (`pip install oncoref[plots]`) — `oncoref.plots.apd1_vs_tmb`,
   `apd1_orr_bars`, `incidence_vs_mortality`, the CTA/coverage figures, and
   `oncoref.cta_curation_plots.render`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,125 @@
+# oncoref API Guide
+
+`oncoref` keeps its historical flat top-level imports for compatibility, but new
+code should prefer the semantic submodules below. They make the domain boundary
+clear and avoid guessing whether a broad name such as `coverage` or `peptides` is
+general or CTA-specific.
+
+## Cancer Vocabulary
+
+- `oncoref.cancer_ontology` — cancer-type registry, aliases, parent/child tree,
+  lineage/family groupings, and display helpers.
+- `oncoref.cohorts` — expression/source cohort IDs, computed aggregate cohorts,
+  source versions, and mixture-cohort flags.
+
+Use these when asking "what cancer type or cohort does this code mean?"
+
+```python
+from oncoref import cancer_ontology, cohorts
+
+cancer_ontology.resolve_cancer_type("prostate")
+cancer_ontology.cancer_type_tree("CRC")
+cohorts.cohort_registry_df()
+```
+
+## ICI Response
+
+- `oncoref.ici_response` — checkpoint-inhibitor response anchors, anti-PD-1
+  shortcuts, regimen-aware lookups, extracted endpoint estimates, and pooled
+  response summaries.
+
+`DEFAULT_ICI_REGIMEN_PRIORITY` is the unpinned regimen priority
+(`PD-1`, then `PD-L1`, then `PD-1+CTLA-4`). The older
+`REGIMEN_FALLBACK` name remains available in `oncoref.ici` for compatibility.
+
+```python
+from oncoref import ici_response
+
+ici_response.apd1_response("SKCM")
+ici_response.best_available_ici_response("SARC_ASPS")
+ici_response.ici_response_by_regimen("SKCM")
+ici_response.ici_response_estimates_df()
+```
+
+## CTA Antigens
+
+- `oncoref.cta` — CTA definition, HPA restriction tiers, axes, aliases, and gene
+  ID/name sets.
+- `oncoref.cta_coverage` — CTA patient coverage over per-sample expression
+  matrices.
+- `oncoref.cta_peptides` — CTA-specific 9-mer counts and load.
+
+`cta_specific_9mer_count_map()` returns a map from a join key to
+`n_specific_9mers`; those counts are used as weights when computing
+`cta_specific_9mer_load()`.
+
+```python
+from oncoref import cta, cta_coverage, cta_peptides
+
+cta.cta_gene_names()
+cta_coverage.cta_addressable_fraction("LUAD")
+cta_peptides.cta_specific_9mer_count_map(by="proteoform_key")
+```
+
+## Generic Antigen Panels
+
+- `oncoref.antigen_coverage` — explicit-gene-panel coverage helpers.
+
+Use this when the panel is not necessarily CTA. The function names require
+`gene_ids=` so a caller cannot accidentally rely on the CTA default.
+
+```python
+from oncoref import antigen_coverage
+
+antigen_coverage.addressable_antigen_fraction("LUAD", gene_ids={"ENSG00000141510"})
+antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
+```
+
+## Expression
+
+- `oncoref.expression` — read-time accessors for per-sample expression,
+  percentile vectors, representative samples, within-sample top fractions, and
+  pan-cancer reference tables.
+- `oncoref.expression_builders` — pure build-time cores used by data-bundle
+  generation scripts.
+- `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,
+  log transforms, percentile ranks, and housekeeping normalization.
+
+## Genes and Proteoforms
+
+- `oncoref.gene_ids` — bundled canonical Ensembl gene space, cross-release alias
+  resolution, symbol synonyms, and biotype checks.
+- `oncoref.genome` — pyensembl-backed gene/transcript lookup against installed
+  Ensembl releases.
+- `oncoref.proteoforms` — identical-protein paralog grouping and expression
+  collapse helpers.
+- `oncoref.gene_qc` / `oncoref.gene_families` — technical-RNA and gene-family
+  classification used by normalization.
+
+## Burden, TMB, Fusions, and Signatures
+
+- `oncoref.tmb` — tumor mutational burden reference values.
+- `oncoref.incidence` — incidence/mortality burden and burden categories.
+- `oncoref.fusions` — defining fusions and partner-family lookups.
+- `oncoref.response_signatures` — therapy-response gene signatures and scoring.
+
+## Data Management
+
+- `oncoref.catalog` — unified dataset inventory and fetch/status/path operations.
+- `oncoref.data_bundle` — heavy expression bundle cache.
+- `oncoref.reference_data` / `oncoref.hpa` — HPA reference-data cache and HPA
+  tissue/cell-type accessors.
+
+## Compatibility Modules
+
+These modules remain importable but are less discoverable than the organized
+facades above:
+
+- `oncoref.apd1` — legacy anti-PD-1 response slice; prefer
+  `oncoref.ici_response`.
+- `oncoref.ici` — core ICI implementation; prefer `oncoref.ici_response` for the
+  organized public surface.
+- `oncoref.coverage` — original mixed CTA/generic antigen-panel coverage module;
+  prefer `oncoref.cta_coverage` or `oncoref.antigen_coverage`.
+- `oncoref.peptides` — original CTA-specific 9-mer module; prefer
+  `oncoref.cta_peptides`.

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -17,6 +17,7 @@ Bottom-of-stack: depends only on pandas/numpy/pyarrow, never on the analysis
 or target-selection libraries that consume it.
 """
 
+from . import antigen_coverage, cancer_ontology, cohorts, cta_coverage, cta_peptides, ici_response
 from .apd1 import cancer_apd1_response, cancer_apd1_response_df
 from .cancer_types import (
     CANCER_TYPE_ALIASES,
@@ -298,6 +299,8 @@ __all__ = [
     "addressable_fraction_by_cohort",
     "aggregate_gene_expression",
     "aggregate_transcripts_to_genes",
+    # organized API modules
+    "antigen_coverage",
     "available_percentile_cohorts",
     "available_representative_cohorts",
     "available_within_sample_cohorts",
@@ -319,6 +322,7 @@ __all__ = [
     "cancer_lineage_group",
     "cancer_lineage_group_overrides",
     "cancer_lineage_groups",
+    "cancer_ontology",
     "cancer_reference_expression",
     "cancer_subtype_group",
     "cancer_subtype_groupings",
@@ -358,9 +362,11 @@ __all__ = [
     "cohort_registry_df",
     "cohort_source_version",
     "cohort_stats",
+    "cohorts",
     "collapse_to_proteoforms",
     "cta_by_axes",
     "cta_candidate_references",
+    "cta_coverage",
     "cta_df",
     # cancer-testis antigens
     "cta_evidence",
@@ -374,6 +380,7 @@ __all__ = [
     "cta_never_expressed_gene_ids",
     "cta_never_expressed_gene_names",
     "cta_patient_fractions",
+    "cta_peptides",
     "cta_placental_restricted_gene_ids",
     "cta_placental_restricted_gene_names",
     "cta_relaxed_reproductive_gene_ids",
@@ -422,6 +429,7 @@ __all__ = [
     "hpa_rna_consensus",
     "hpa_single_cell",
     "ici_regimens",
+    "ici_response",
     "id_columns",
     "is_canonical_gene",
     "is_expression_value_col",

--- a/oncoref/antigen_coverage.py
+++ b/oncoref/antigen_coverage.py
@@ -1,0 +1,102 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic antigen-panel patient coverage helpers.
+
+These wrappers make the gene-panel input explicit. For CTA defaults, use
+:mod:`oncoref.cta_coverage`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .coverage import (
+    DEFAULT_EXPRESSED_TPM,
+    DEFAULT_THRESHOLDS,
+    addressable_fraction,
+    greedy_coverage,
+    mean_antigens_per_patient,
+    patient_coverage,
+    resolve_gene_set,
+)
+
+
+def patient_antigen_fractions(
+    cancer_type,
+    *,
+    gene_ids: Iterable[str],
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    proteoform: bool = True,
+):
+    """Per antigen, fraction of patients expressing it above ``threshold_tpm``."""
+    from .coverage import cta_patient_fractions
+
+    return cta_patient_fractions(
+        cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
+    )
+
+
+def addressable_antigen_fraction(
+    cancer_type,
+    *,
+    gene_ids: Iterable[str],
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    proteoform: bool = True,
+) -> float:
+    """Fraction of patients expressing at least one antigen in an explicit panel."""
+    return addressable_fraction(
+        cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
+    )
+
+
+def greedy_antigen_coverage(
+    cancer_type,
+    *,
+    gene_ids: Iterable[str],
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    max_genes: int | None = None,
+    proteoform: bool = True,
+):
+    """Greedy set-cover order for an explicit antigen panel."""
+    return greedy_coverage(
+        cancer_type,
+        threshold_tpm=threshold_tpm,
+        gene_ids=gene_ids,
+        max_genes=max_genes,
+        proteoform=proteoform,
+    )
+
+
+def mean_panel_antigens_per_patient(
+    cancer_type,
+    *,
+    gene_ids: Iterable[str],
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    proteoform: bool = True,
+) -> float:
+    """Mean number of expressed antigens per patient for an explicit panel."""
+    return mean_antigens_per_patient(
+        cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
+    )
+
+
+__all__ = [
+    "DEFAULT_EXPRESSED_TPM",
+    "DEFAULT_THRESHOLDS",
+    "addressable_antigen_fraction",
+    "greedy_antigen_coverage",
+    "mean_panel_antigens_per_patient",
+    "patient_antigen_fractions",
+    "patient_coverage",
+    "resolve_gene_set",
+]

--- a/oncoref/cancer_ontology.py
+++ b/oncoref/cancer_ontology.py
@@ -1,0 +1,77 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Core cancer-type ontology and registry access.
+
+The source of truth is ``data/cancer-type-registry.csv``. Cohort vocabulary lives
+in :mod:`oncoref.cohorts`; this module keeps ontology concepts easier to find.
+"""
+
+from __future__ import annotations
+
+from .cancer_types import (
+    CANCER_TYPE_ALIASES,
+    CANCER_TYPE_NAMES,
+    cancer_lineage_group,
+    cancer_lineage_group_overrides,
+    cancer_lineage_groups,
+    cancer_subtype_group,
+    cancer_subtype_groupings,
+    cancer_type_ancestors,
+    cancer_type_descendants,
+    cancer_type_families,
+    cancer_type_info,
+    cancer_type_lineage,
+    cancer_type_registry,
+    cancer_type_subtypes_of,
+    cancer_type_synonyms,
+    cancer_type_tree,
+    cancer_types_by_tissue,
+    cancer_types_in_family,
+    canonical_cancer_code,
+    family_display_name,
+    format_cancer_code_label,
+    fusion_status,
+    resolve_cancer_type,
+    sarcoma_lineage_codes,
+    tissue_of_origin,
+    viral_status,
+)
+
+__all__ = [
+    "CANCER_TYPE_ALIASES",
+    "CANCER_TYPE_NAMES",
+    "cancer_lineage_group",
+    "cancer_lineage_group_overrides",
+    "cancer_lineage_groups",
+    "cancer_subtype_group",
+    "cancer_subtype_groupings",
+    "cancer_type_ancestors",
+    "cancer_type_descendants",
+    "cancer_type_families",
+    "cancer_type_info",
+    "cancer_type_lineage",
+    "cancer_type_registry",
+    "cancer_type_subtypes_of",
+    "cancer_type_synonyms",
+    "cancer_type_tree",
+    "cancer_types_by_tissue",
+    "cancer_types_in_family",
+    "canonical_cancer_code",
+    "family_display_name",
+    "format_cancer_code_label",
+    "fusion_status",
+    "resolve_cancer_type",
+    "sarcoma_lineage_codes",
+    "tissue_of_origin",
+    "viral_status",
+]

--- a/oncoref/cohorts.py
+++ b/oncoref/cohorts.py
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Expression/source cohort vocabulary and computed aggregate cohorts."""
+
+from __future__ import annotations
+
+from .cancer_types import (
+    cohort_aggregate_members,
+    cohort_aggregates,
+    cohort_aggregates_df,
+    cohort_kind,
+    cohort_registry,
+    cohort_registry_df,
+    cohort_source_version,
+    is_mixture_cohort,
+    known_cohort_ids,
+    mixture_cohort_codes,
+)
+
+__all__ = [
+    "cohort_aggregate_members",
+    "cohort_aggregates",
+    "cohort_aggregates_df",
+    "cohort_kind",
+    "cohort_registry",
+    "cohort_registry_df",
+    "cohort_source_version",
+    "is_mixture_cohort",
+    "known_cohort_ids",
+    "mixture_cohort_codes",
+]

--- a/oncoref/cta_coverage.py
+++ b/oncoref/cta_coverage.py
@@ -1,0 +1,83 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CTA antigen-coverage helpers over per-sample expression matrices."""
+
+from __future__ import annotations
+
+from .coverage import (
+    DEFAULT_EXPRESSED_TPM,
+    addressable_fraction,
+    addressable_fraction_by_cohort,
+    cta_patient_fractions,
+    greedy_coverage,
+    mean_antigens_per_patient,
+    mean_antigens_per_patient_by_cohort,
+)
+
+
+def cta_addressable_fraction(
+    cancer_type, *, threshold_tpm: float = DEFAULT_EXPRESSED_TPM, proteoform: bool = True
+) -> float:
+    """Fraction of patients expressing at least one CTA above ``threshold_tpm``."""
+    return addressable_fraction(cancer_type, threshold_tpm=threshold_tpm, proteoform=proteoform)
+
+
+def cta_greedy_coverage(
+    cancer_type,
+    *,
+    threshold_tpm: float = DEFAULT_EXPRESSED_TPM,
+    max_genes: int | None = None,
+    proteoform: bool = True,
+):
+    """Greedy CTA set-cover order for a cohort."""
+    return greedy_coverage(
+        cancer_type, threshold_tpm=threshold_tpm, max_genes=max_genes, proteoform=proteoform
+    )
+
+
+def cta_mean_antigens_per_patient(
+    cancer_type, *, threshold_tpm: float = DEFAULT_EXPRESSED_TPM, proteoform: bool = True
+) -> float:
+    """Mean number of CTAs expressed per patient in a cohort."""
+    return mean_antigens_per_patient(
+        cancer_type, threshold_tpm=threshold_tpm, proteoform=proteoform
+    )
+
+
+def cta_addressable_fraction_by_cohort(
+    cohorts=None, *, threshold_tpm: float = DEFAULT_EXPRESSED_TPM, proteoform: bool = True
+):
+    """CTA addressable fraction for each cached or requested cohort."""
+    return addressable_fraction_by_cohort(
+        cohorts, threshold_tpm=threshold_tpm, proteoform=proteoform
+    )
+
+
+def cta_mean_antigens_per_patient_by_cohort(
+    cohorts=None, *, threshold_tpm: float = DEFAULT_EXPRESSED_TPM, proteoform: bool = True
+):
+    """Mean number of expressed CTAs per patient for each cached or requested cohort."""
+    return mean_antigens_per_patient_by_cohort(
+        cohorts, threshold_tpm=threshold_tpm, proteoform=proteoform
+    )
+
+
+__all__ = [
+    "DEFAULT_EXPRESSED_TPM",
+    "cta_addressable_fraction",
+    "cta_addressable_fraction_by_cohort",
+    "cta_greedy_coverage",
+    "cta_mean_antigens_per_patient",
+    "cta_mean_antigens_per_patient_by_cohort",
+    "cta_patient_fractions",
+]

--- a/oncoref/cta_peptides.py
+++ b/oncoref/cta_peptides.py
@@ -1,0 +1,46 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CTA-specific 9-mer peptide specificity helpers.
+
+The older :mod:`oncoref.peptides` module is intentionally still importable, but the
+functions exported here make the CTA-specific scope explicit.
+"""
+
+from __future__ import annotations
+
+from .peptides import (
+    DEFAULT_K,
+    cta_specific_9mer_counts,
+    cta_specific_9mer_load,
+    cta_specific_9mer_weights,
+)
+
+
+def cta_specific_9mer_count_map(*, k: int = DEFAULT_K, by: str = "proteoform_key"):
+    """Map each CTA key to its ``n_specific_9mers`` count.
+
+    ``by`` accepts ``"proteoform_key"`` (default), ``"ensembl_gene_id"``, or
+    ``"symbol"``. This is the clearer name for the historical
+    ``cta_specific_9mer_weights`` helper; the values are counts used as weights in
+    ``cta_specific_9mer_load``.
+    """
+    return cta_specific_9mer_weights(k=k, by=by)
+
+
+__all__ = [
+    "DEFAULT_K",
+    "cta_specific_9mer_count_map",
+    "cta_specific_9mer_counts",
+    "cta_specific_9mer_load",
+    "cta_specific_9mer_weights",
+]

--- a/oncoref/ici_response.py
+++ b/oncoref/ici_response.py
@@ -1,0 +1,112 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Discoverable immune-checkpoint-inhibitor response API.
+
+This module is the organized public entry point for ICI response data:
+
+- ``apd1_*`` helpers are the anti-PD-1 monotherapy compatibility slice.
+- ``ici_*`` helpers cover the multi-regimen ICI tables.
+- ``DEFAULT_ICI_REGIMEN_PRIORITY`` names the regimen preference order explicitly.
+
+The older :mod:`oncoref.apd1` and :mod:`oncoref.ici` modules remain compatibility
+facades for existing callers.
+"""
+
+from __future__ import annotations
+
+from .apd1 import (
+    cancer_apd1_response,
+    cancer_apd1_response_df,
+)
+from .ici import (
+    PROPORTION_METRICS,
+    REGIMEN_FALLBACK,
+    REGIMEN_LABELS,
+    cancer_ici_regimen,
+    cancer_ici_response,
+    cancer_ici_response_df,
+    cancer_ici_response_estimates_df,
+    ici_regimens,
+    pooled_ici_response,
+)
+
+DEFAULT_ICI_REGIMEN_PRIORITY = REGIMEN_FALLBACK
+"""Regimen priority for unpinned ICI response lookup: PD-1, then PD-L1, then combo."""
+
+ICI_REGIMEN_LABELS = REGIMEN_LABELS
+"""Human-readable labels for the ICI regimen tags."""
+
+RESPONSE_PROPORTION_METRICS = PROPORTION_METRICS
+"""Response metrics that can be responder-weighted pooled."""
+
+
+def apd1_response(cancer_type=None, *, inherit: bool = True):
+    """Anti-PD-1 monotherapy ORR (%) for one cancer type, or the full code map."""
+    return cancer_apd1_response(cancer_type, inherit=inherit)
+
+
+def apd1_response_df():
+    """Curated anti-PD-1 monotherapy ORR anchor table."""
+    return cancer_apd1_response_df()
+
+
+def ici_response_anchor_df():
+    """Curated representative ICI ORR anchor table, one row per cancer/regimen."""
+    return cancer_ici_response_df()
+
+
+def ici_response_estimates_df():
+    """Audited ICI endpoint evidence table with metrics, CIs, denominators, and refs."""
+    return cancer_ici_response_estimates_df()
+
+
+def best_available_ici_response(cancer_type=None, *, inherit: bool = True):
+    """Best-available ICI ORR (%) using ``DEFAULT_ICI_REGIMEN_PRIORITY``.
+
+    This is a clearer name for ``cancer_ici_response(..., regimen=None,
+    fallback=True)``. It chooses anti-PD-1 monotherapy when present, then anti-PD-L1,
+    then anti-PD-1 + anti-CTLA-4.
+    """
+    return cancer_ici_response(cancer_type, inherit=inherit)
+
+
+def ici_response_by_regimen(cancer_type=None, *, inherit: bool = True):
+    """ICI ORR values grouped by regimen instead of using regimen priority."""
+    return cancer_ici_response(cancer_type, fallback=False, inherit=inherit)
+
+
+def selected_ici_regimen(cancer_type):
+    """Regimen selected by ``best_available_ici_response`` for one cancer type."""
+    return cancer_ici_regimen(cancer_type)
+
+
+__all__ = [
+    "DEFAULT_ICI_REGIMEN_PRIORITY",
+    "ICI_REGIMEN_LABELS",
+    "RESPONSE_PROPORTION_METRICS",
+    "apd1_response",
+    "apd1_response_df",
+    "best_available_ici_response",
+    "cancer_apd1_response",
+    "cancer_apd1_response_df",
+    "cancer_ici_regimen",
+    "cancer_ici_response",
+    "cancer_ici_response_df",
+    "cancer_ici_response_estimates_df",
+    "ici_regimens",
+    "ici_response_anchor_df",
+    "ici_response_by_regimen",
+    "ici_response_estimates_df",
+    "pooled_ici_response",
+    "selected_ici_regimen",
+]

--- a/tests/test_api_structure.py
+++ b/tests/test_api_structure.py
@@ -1,0 +1,82 @@
+import pandas as pd
+
+import oncoref
+from oncoref import antigen_coverage, apd1, cta_coverage, cta_peptides, ici, ici_response
+
+
+def test_semantic_modules_are_top_level_facades():
+    for name in (
+        "antigen_coverage",
+        "cancer_ontology",
+        "cohorts",
+        "cta_coverage",
+        "cta_peptides",
+        "ici_response",
+    ):
+        assert hasattr(oncoref, name)
+        assert name in oncoref.__all__
+
+
+def test_clearer_names_stay_in_semantic_modules_not_flat_namespace():
+    for name in (
+        "best_available_ici_response",
+        "ici_response_by_regimen",
+        "cta_specific_9mer_count_map",
+        "cta_addressable_fraction",
+        "addressable_antigen_fraction",
+    ):
+        assert not hasattr(oncoref, name)
+
+
+def test_ici_response_facade_delegates_to_compatibility_api():
+    assert ici_response.DEFAULT_ICI_REGIMEN_PRIORITY == ici.REGIMEN_FALLBACK
+    assert ici_response.ICI_REGIMEN_LABELS == ici.REGIMEN_LABELS
+    assert ici_response.RESPONSE_PROPORTION_METRICS == ici.PROPORTION_METRICS
+
+    assert ici_response.apd1_response("SKCM") == apd1.cancer_apd1_response("SKCM")
+    assert ici_response.best_available_ici_response("SKCM") == ici.cancer_ici_response("SKCM")
+    assert ici_response.ici_response_by_regimen("SKCM") == ici.cancer_ici_response(
+        "SKCM", fallback=False
+    )
+    assert ici_response.selected_ici_regimen("SKCM") == ici.cancer_ici_regimen("SKCM")
+    pd.testing.assert_frame_equal(
+        ici_response.ici_response_anchor_df(), ici.cancer_ici_response_df()
+    )
+
+
+def test_cta_peptides_clear_count_map_name(monkeypatch):
+    monkeypatch.setattr(
+        cta_peptides,
+        "cta_specific_9mer_weights",
+        lambda *, k=9, by="proteoform_key": {f"{by}:{k}": 7},
+    )
+    assert cta_peptides.cta_specific_9mer_count_map(k=3, by="symbol") == {"symbol:3": 7}
+
+
+def test_cta_coverage_names_make_cta_default_explicit(monkeypatch):
+    calls = []
+
+    def fake_addressable(cancer_type, *, threshold_tpm, proteoform, **kwargs):
+        calls.append((cancer_type, threshold_tpm, proteoform, kwargs))
+        return 0.5
+
+    monkeypatch.setattr(cta_coverage, "addressable_fraction", fake_addressable)
+    assert cta_coverage.cta_addressable_fraction("LUAD", threshold_tpm=5) == 0.5
+    assert calls == [("LUAD", 5, True, {})]
+
+
+def test_antigen_coverage_requires_explicit_gene_panel(monkeypatch):
+    calls = []
+
+    def fake_addressable(cancer_type, *, threshold_tpm, gene_ids, proteoform):
+        calls.append((cancer_type, threshold_tpm, gene_ids, proteoform))
+        return 0.25
+
+    monkeypatch.setattr(antigen_coverage, "addressable_fraction", fake_addressable)
+    assert (
+        antigen_coverage.addressable_antigen_fraction(
+            "LUAD", gene_ids={"ENSG00000141510"}, threshold_tpm=2
+        )
+        == 0.25
+    )
+    assert calls == [("LUAD", 2, {"ENSG00000141510"}, True)]


### PR DESCRIPTION
## Summary

- Add semantic public submodules for the major API domains: cancer ontology, cohorts, ICI response, CTA coverage, CTA peptides, and generic antigen coverage.
- Keep the historical flat `oncoref` namespace intact for compatibility, while exposing only the new module facades at top level.
- Add an API guide and README pointers so users know where to look instead of guessing from broad modules like `coverage` or `peptides`.
- Add tests that verify the new facades delegate to the existing implementation without expanding the flat namespace with more alias functions.

## Validation

- `./lint.sh`
- `python -m pytest tests/test_api_structure.py tests/test_apd1.py tests/test_ici.py tests/test_peptides.py tests/test_coverage.py`
- `./test.sh` (`491 passed, 1 warning`)
