### PR TITLE
[codex] Expose ICI anchor evidence schema

### DIFF
--- a/oncoref/apd1.py
+++ b/oncoref/apd1.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
+from .ici import response_anchor_evidence_df
 from .load_dataset import get_data
 
 
@@ -28,8 +29,14 @@ def cancer_apd1_response_df():
     vs aPD1 ORR). Values are representative anchors, not exact reproducible
     constants — they shift with data cutoff, line of therapy, and biomarker
     selection (PD-L1 / MSI / MMR); the ``setting`` and ``notes`` columns record
-    that context."""
-    return get_data("cancer-apd1-response")
+    that context. Evidence/provenance fields are joined from the audited ICI estimates
+    table, keyed by ``drug_target`` (``PD-1`` / ``PD-L1`` / ``PD-1+CTLA-4``), so
+    non-monotherapy fallback anchors remain explicit."""
+    return response_anchor_evidence_df(
+        get_data("cancer-apd1-response"),
+        value_col="apd1_orr_pct",
+        regimen_col="drug_target",
+    )
 
 
 def cancer_apd1_response(cancer_type=None, *, inherit=True):

--- a/oncoref/ici.py
+++ b/oncoref/ici.py
@@ -104,14 +104,140 @@ REGIMEN_LABELS = {
     "PD-1+CTLA-4": "anti-PD-1 + anti-CTLA-4",
 }
 
+REGIMEN_CLASSES = {
+    "PD-1": "anti_pd1_monotherapy",
+    "PD-L1": "anti_pdl1_monotherapy",
+    "PD-1+CTLA-4": "anti_pd1_ctla4_combination",
+}
+
+
+def _mixture_cohort_code_set() -> frozenset[str]:
+    """Registry codes whose evidence rows represent aggregate/source-scope cohorts."""
+    reg = cancer_type_registry()
+    if "mixture_cohort" not in reg.columns:
+        return frozenset()
+    flag = reg["mixture_cohort"].astype(str).str.strip().str.lower().isin({"true", "1", "yes"})
+    return frozenset(reg.loc[flag, "code"].astype(str))
+
+
+def _evidence_type(value_basis) -> str:
+    basis = str(value_basis).strip()
+    if basis == "derived_blend":
+        return "derived_blend"
+    if basis == "reported_context":
+        return "reported_context"
+    return "direct_reported"
+
+
+def _source_scope(code, value_basis, mixture_codes: frozenset[str]) -> str:
+    if str(value_basis).strip() == "derived_blend":
+        return "derived_blend"
+    if str(code) in mixture_codes:
+        return "aggregate_source"
+    return "direct_source"
+
+
+def response_anchor_evidence_df(
+    anchors,
+    *,
+    value_col: str,
+    regimen_col: str = "regimen",
+):
+    """Append evidence/provenance fields to compact representative ICI anchors.
+
+    The compact ICI and aPD1 tables intentionally keep only the plotting anchor fields.
+    The richer audit table (``cancer-ici-response-estimates.csv``) has one primary ORR
+    row for every compact anchor. This helper joins that source row back onto the
+    anchor table so public accessors expose both oncoref's trial identity and
+    pirlygenes-style denominator/evidence semantics without duplicating curation.
+    """
+    df = anchors.copy()
+    estimates = cancer_ici_response_estimates_df()
+    primary_orr = estimates[
+        (estimates["metric"].astype(str).str.upper() == "ORR")
+        & (estimates["role"].astype(str) == "primary")
+    ].copy()
+    primary_orr = primary_orr[
+        [
+            "cancer_code",
+            "regimen",
+            "ref",
+            "setting",
+            "source_n",
+            "metric",
+            "value",
+            "unit",
+            "ci_low",
+            "ci_high",
+            "metric_n",
+            "responders",
+            "source_verified",
+            "value_basis",
+        ]
+    ].rename(
+        columns={
+            "ref": "source_anchor",
+            "setting": "endpoint_population",
+            "source_n": "source_n",
+            "metric": "response_metric",
+            "value": "_response_value",
+            "unit": "response_unit",
+            "ci_low": "response_ci_low",
+            "ci_high": "response_ci_high",
+            "metric_n": "response_denominator",
+            "responders": "response_numerator",
+        }
+    )
+    merged = df.merge(
+        primary_orr,
+        how="left",
+        left_on=["cancer_code", regimen_col],
+        right_on=["cancer_code", "regimen"],
+        suffixes=("", "_evidence"),
+        validate="one_to_one",
+    )
+    if regimen_col != "regimen":
+        merged = merged.drop(columns=["regimen"])
+    missing = merged["response_metric"].isna()
+    if missing.any():
+        cells = merged.loc[missing, ["cancer_code", regimen_col]].astype(str).agg("/".join, axis=1)
+        raise ValueError(f"missing primary ORR evidence rows for: {', '.join(cells)}")
+
+    mixture_codes = _mixture_cohort_code_set()
+    merged["source_anchor"] = merged["source_anchor"].where(merged["source_anchor"].notna(), None)
+    merged["response_metric"] = merged["response_metric"].astype(str).str.upper()
+    merged["response_value_matches_anchor"] = (
+        merged[value_col].astype(float) - merged["_response_value"].astype(float)
+    ).abs() <= 2.0
+    merged["therapy_regimen_class"] = (
+        merged[regimen_col].map(REGIMEN_CLASSES).fillna("other_ici_regimen")
+    )
+    merged["evidence_type"] = merged["value_basis"].map(_evidence_type)
+    merged["histology_match"] = merged["evidence_type"].map(
+        {
+            "direct_reported": "direct",
+            "reported_context": "context",
+            "derived_blend": "derived",
+        }
+    )
+    merged["is_direct_cancer_code_evidence"] = merged["evidence_type"].eq("direct_reported")
+    merged["evidence_source_code"] = merged["cancer_code"].astype(str)
+    merged["source_scope"] = [
+        _source_scope(code, basis, mixture_codes)
+        for code, basis in zip(merged["cancer_code"], merged["value_basis"])
+    ]
+    merged["missing_reason"] = None
+    return merged.drop(columns=["_response_value"])
+
 
 def cancer_ici_response_df():
     """The curated ``cancer-ici-response.csv`` long table: one row per
     (``cancer_code``, ``regimen``) with the representative ORR (%), drug, pivotal trial
     (split into ``trial_name`` / ``trial_alias`` / ``trial_nct`` — the acronym, the
     distinct protocol/sponsor code if any, and the ClinicalTrials.gov id), setting,
-    source PMID/DOI, and confidence. A cancer type may appear under several regimens."""
-    return get_data("cancer-ici-response")
+    source PMID/DOI, confidence, and evidence/provenance fields joined from the
+    audited estimates table. A cancer type may appear under several regimens."""
+    return response_anchor_evidence_df(get_data("cancer-ici-response"), value_col="orr_pct")
 
 
 def ici_regimens() -> tuple[str, ...]:

--- a/tests/test_ici.py
+++ b/tests/test_ici.py
@@ -4,7 +4,9 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-from oncoref import ici
+import pandas as pd
+
+from oncoref import apd1, ici
 
 
 def test_regimens_and_table():
@@ -14,6 +16,71 @@ def test_regimens_and_table():
     # all three regimens are actually present (not just PD-1)
     assert set(df["regimen"]) == {"PD-1", "PD-L1", "PD-1+CTLA-4"}
     assert (df["regimen"] == "PD-L1").sum() >= 10  # anti-PD-L1 is well-represented
+
+
+def test_ici_anchor_table_exposes_evidence_schema():
+    df = ici.cancer_ici_response_df()
+    expected = {
+        "response_metric",
+        "response_unit",
+        "response_ci_low",
+        "response_ci_high",
+        "response_numerator",
+        "response_denominator",
+        "source_n",
+        "source_verified",
+        "value_basis",
+        "source_anchor",
+        "endpoint_population",
+        "therapy_regimen_class",
+        "evidence_type",
+        "histology_match",
+        "is_direct_cancer_code_evidence",
+        "evidence_source_code",
+        "source_scope",
+        "missing_reason",
+    }
+    assert expected <= set(df.columns)
+
+    crc = df[(df["cancer_code"] == "CRC_MSI") & (df["regimen"] == "PD-1")].iloc[0]
+    assert crc["response_metric"] == "ORR"
+    assert crc["response_numerator"] == 67
+    assert crc["response_denominator"] == 153
+    assert crc["response_ci_low"] == 35.8
+    assert crc["response_ci_high"] == 52.0
+    assert crc["therapy_regimen_class"] == "anti_pd1_monotherapy"
+    assert crc["evidence_type"] == "direct_reported"
+    assert crc["histology_match"] == "direct"
+    assert bool(crc["is_direct_cancer_code_evidence"]) is True
+    assert crc["source_scope"] == "aggregate_source"
+    assert crc["source_anchor"] == "PMID:33264544"
+
+    coad = df[(df["cancer_code"] == "COAD") & (df["regimen"] == "PD-1")].iloc[0]
+    assert coad["evidence_type"] == "derived_blend"
+    assert coad["histology_match"] == "derived"
+    assert bool(coad["is_direct_cancer_code_evidence"]) is False
+    assert coad["source_scope"] == "derived_blend"
+    assert pd.isna(coad["response_denominator"])
+    assert pd.isna(coad["source_anchor"])
+
+
+def test_apd1_anchor_table_uses_same_evidence_schema_for_fallback_targets():
+    df = apd1.cancer_apd1_response_df()
+    assert {
+        "response_metric",
+        "response_numerator",
+        "response_denominator",
+        "therapy_regimen_class",
+        "evidence_type",
+        "source_scope",
+    } <= set(df.columns)
+
+    acc = df[df["cancer_code"] == "ACC"].iloc[0]
+    assert acc["drug_target"] == "PD-1+CTLA-4"
+    assert acc["therapy_regimen_class"] == "anti_pd1_ctla4_combination"
+    assert acc["response_numerator"] == 3
+    assert acc["response_denominator"] == 21
+    assert acc["evidence_type"] == "direct_reported"
 
 
 def test_per_regimen_and_pin():


### PR DESCRIPTION
## Summary

- enrich `cancer_ici_response_df()` by joining each representative anchor to its primary ORR row in `cancer-ici-response-estimates.csv`
- enrich `cancer_apd1_response_df()` through the same path, keyed by `drug_target`, so PD-L1 and PD-1+CTLA-4 fallback anchors stay explicit
- expose denominator and provenance fields: `response_numerator`, `response_denominator`, `endpoint_population`, `response_ci_low`, `response_ci_high`, `source_anchor`, `source_verified`, `value_basis`, `therapy_regimen_class`, `evidence_type`, `histology_match`, `is_direct_cancer_code_evidence`, `source_scope`, and `missing_reason`
- mark `CRC_MSI` as an aggregate source row and the COAD/READ/UCEC all-comer rows as derived blends instead of direct source-reported ORR values

## Scope

This is the first PR in the migration series. It starts the ICI schema union requested in #212 and the broader registry parity gate in #196. It does not close #212 yet because metadata-bearing lookup helpers and explicit COAD_MSI/READ_MSI inherited-record access should land as the next focused PR.

Related follow-on buckets now explicitly owned upstream in oncoref:

- ICI schema union and CRC_MSI inheritance: #212, #196
- NBL denominator/zero handling: #177
- Representative selection contract: #195
- TMB/burden parity gate: #196
- Gene universe and remaps: #191 (https://github.com/pirl-unc/oncoref/issues/191#issuecomment-4792647135), #193 (https://github.com/pirl-unc/oncoref/issues/193#issuecomment-4792647087)
- Bundle/data-version integrity: #21 (https://github.com/pirl-unc/oncoref/issues/21#issuecomment-4792647103), #209 (https://github.com/pirl-unc/oncoref/issues/209#issuecomment-4792647090)
- Source QC policy: #203 (https://github.com/pirl-unc/oncoref/issues/203#issuecomment-4792648366), #205 (https://github.com/pirl-unc/oncoref/issues/205#issuecomment-4792648387), #210 (https://github.com/pirl-unc/oncoref/issues/210#issuecomment-4792648374)
- Missing expression/reference data: #207 (https://github.com/pirl-unc/oncoref/issues/207#issuecomment-4792648371), #208 (https://github.com/pirl-unc/oncoref/issues/208#issuecomment-4792649184)

## Validation

- `python -m pytest tests/test_ici.py tests/test_ici_estimates.py tests/test_apd1.py tests/test_api_structure.py`
- `./lint.sh`
- `./test.sh`