### PR TITLE
[codex] Add ICI response record lookups

### DIFF
--- a/oncoref/ici.py
+++ b/oncoref/ici.py
@@ -82,6 +82,8 @@ from __future__ import annotations
 import math
 from functools import lru_cache
 
+import pandas as pd
+
 from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
 from .load_dataset import _register_derived_cache, get_data
 
@@ -266,7 +268,141 @@ def _resolve_with_fallback(code: str, maps: dict[str, dict[str, float]], order):
     return None, None
 
 
-def cancer_ici_response(cancer_type=None, *, regimen=None, fallback=True, inherit=True):
+def _parent_code(code: str, registry) -> str | None:
+    if code not in registry.index:
+        return None
+    parent = registry.loc[code].get("parent_code", "")
+    if pd.isna(parent):
+        return None
+    parent = str(parent).strip()
+    return parent or None
+
+
+def _bulk_lookup_codes() -> list[str]:
+    df = cancer_ici_response_df().dropna(subset=["orr_pct"])
+    return sorted({str(code) for code in df["cancer_code"]})
+
+
+def _matching_rows(df, code: str, order) -> dict[str, object]:
+    rows: dict[str, object] = {}
+    sub = df[df["cancer_code"] == code]
+    for regimen in order:
+        hit = sub[sub["regimen"] == regimen]
+        if not hit.empty:
+            rows[str(regimen)] = hit.iloc[0]
+    return rows
+
+
+def _public_value(value):
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if hasattr(value, "item"):
+        return value.item()
+    return value
+
+
+def _record_from_row(row, *, requested_code: str, resolved_code: str, inheritance_kind: str):
+    record = {key: _public_value(row[key]) for key in row.index}
+    record["requested_cancer_code"] = requested_code
+    record["resolved_cancer_code"] = resolved_code
+    record["selected_regimen"] = record.get("regimen")
+    record["inheritance_kind"] = inheritance_kind
+    record["is_inherited_evidence"] = requested_code != resolved_code
+    return record
+
+
+def _resolve_ici_response_source(requested_code: str, order, *, inherit: bool):
+    df = cancer_ici_response_df().dropna(subset=["orr_pct"])
+    direct = _matching_rows(df, requested_code, order)
+    if direct or not inherit:
+        return requested_code, "direct", direct
+
+    source_code = cancer_evidence_source_code(requested_code)
+    if source_code != requested_code:
+        source = _matching_rows(df, source_code, order)
+        if source:
+            return source_code, "source_scope", source
+
+    registry = cancer_type_registry().set_index("code")
+    cur = _parent_code(requested_code, registry)
+    seen = {requested_code}
+    while cur and cur not in seen:
+        seen.add(cur)
+        inherited = _matching_rows(df, cur, order)
+        if inherited:
+            return cur, "ancestor", inherited
+        cur = _parent_code(cur, registry)
+    return requested_code, "missing", {}
+
+
+def _resolve_ici_response_rows(requested_code: str, order, *, inherit: bool):
+    return _resolve_ici_response_source(requested_code, order, inherit=inherit)
+
+
+def resolve_ici_response_source(cancer_type, *, regimen=None, fallback=True, inherit=True) -> dict:
+    """Resolve the evidence source row used for an ICI response lookup.
+
+    Returns lookup metadata without forcing callers to inspect the ORR map shape:
+
+    - ``requested_cancer_code``: canonical code requested by the caller.
+    - ``resolved_cancer_code``: direct/proxy/ancestor source row, when one exists.
+    - ``inheritance_kind``: ``"direct"``, ``"source_scope"``, ``"ancestor"``, or
+      ``"missing"``.
+    - ``available_regimens``: regimens available at the resolved source row.
+    - source/provenance fields from the selected record when available.
+
+    With ``regimen=None`` and ``fallback=True`` the selected record follows
+    :data:`REGIMEN_FALLBACK`; with ``fallback=False`` the resolver still reports the
+    resolved source and all available regimens but does not choose a single regimen.
+    """
+    requested_code = resolve_cancer_type(cancer_type)
+    order = (regimen,) if regimen is not None else REGIMEN_FALLBACK
+    resolved_code, inheritance_kind, rows = _resolve_ici_response_source(
+        requested_code, order, inherit=inherit
+    )
+    selected_regimen = None
+    selected_row = None
+    if fallback or regimen is not None:
+        for key in order:
+            row = rows.get(str(key))
+            if row is not None:
+                selected_regimen = str(key)
+                selected_row = row
+                break
+    record = (
+        _record_from_row(
+            selected_row,
+            requested_code=requested_code,
+            resolved_code=resolved_code,
+            inheritance_kind=inheritance_kind,
+        )
+        if selected_row is not None
+        else {}
+    )
+    record.update(
+        {
+            "requested_cancer_code": requested_code,
+            "resolved_cancer_code": resolved_code if rows else None,
+            "inheritance_kind": inheritance_kind,
+            "is_inherited_evidence": bool(rows) and requested_code != resolved_code,
+            "selected_regimen": selected_regimen,
+            "available_regimens": tuple(rows),
+            "has_ici_response_source": bool(rows),
+        }
+    )
+    return record
+
+
+def cancer_ici_response(
+    cancer_type=None,
+    *,
+    regimen=None,
+    fallback=True,
+    inherit=True,
+):
     """ICI objective response rate (%) for a cancer type.
 
     ``regimen`` pins one of :data:`REGIMEN_FALLBACK` (``"PD-1"`` / ``"PD-L1"`` /
@@ -282,9 +418,11 @@ def cancer_ici_response(cancer_type=None, *, regimen=None, fallback=True, inheri
     the registry ``parent_code`` chain. Returns ``None`` (or ``{}``) when nothing is
     found.
 
-    With ``cancer_type=None`` returns the whole ``{code: orr}`` map under the same
-    resolution (a single regimen if pinned, else the fallback pick) — ready as a
-    per-cancer plotting axis.
+    With ``cancer_type=None`` returns the whole direct ``{code: orr}`` map (a single
+    regimen if pinned, else the fallback pick) — ready as a per-source plotting axis.
+    Source-scoped children such as ``COAD_MSI`` and ``READ_MSI`` intentionally are not
+    duplicated in bulk maps; use :func:`resolve_ici_response_source` or an individual
+    lookup for requested-code resolution metadata.
     """
     maps = _regimen_maps()
     order = (regimen,) if regimen is not None else REGIMEN_FALLBACK
@@ -325,9 +463,7 @@ def cancer_ici_response(cancer_type=None, *, regimen=None, fallback=True, inheri
             hit = {r: maps[r][cur] for r in REGIMEN_FALLBACK if cur in maps.get(r, {})}
             if hit:
                 return hit
-            if cur not in reg.index:
-                break
-            cur = str(reg.loc[cur].get("parent_code", "") or "").strip() or None
+            cur = _parent_code(cur, reg)
         return {}
 
     val, _ = _resolve_with_fallback(code, maps, order)
@@ -345,9 +481,84 @@ def cancer_ici_response(cancer_type=None, *, regimen=None, fallback=True, inheri
         val, _ = _resolve_with_fallback(cur, maps, order)
         if val is not None:
             return val
-        if cur not in reg.index:
-            break
-        cur = str(reg.loc[cur].get("parent_code", "") or "").strip() or None
+        cur = _parent_code(cur, reg)
+    return None
+
+
+def cancer_ici_response_record(
+    cancer_type=None,
+    *,
+    regimen=None,
+    fallback=True,
+    inherit=True,
+):
+    """Metadata-bearing ICI objective response lookup.
+
+    This mirrors :func:`cancer_ici_response`, but returns the resolved anchor row as a
+    dict instead of only the ORR value. The record includes the joined evidence fields
+    from :func:`cancer_ici_response_df` plus lookup metadata:
+
+    - ``requested_cancer_code``: canonical code requested by the caller.
+    - ``resolved_cancer_code``: source row used for the returned evidence.
+    - ``inheritance_kind``: ``"direct"``, ``"source_scope"``, ``"ancestor"``, or
+      ``"missing"``.
+    - ``is_inherited_evidence``: whether the requested code differs from the resolved
+      source row.
+
+    Source-scoped biomarker cohorts such as ``COAD_MSI`` and ``READ_MSI`` therefore
+    resolve through the curated ``CRC_MSI`` row while preserving the fact that the trial
+    source is metastatic MSI-H/dMMR colorectal cancer rather than a colon- or
+    rectum-specific estimate. With ``cancer_type=None`` the returned bulk map is direct
+    source rows only; use :func:`resolve_ici_response_source` for explicit requested-code
+    source/proxy resolution.
+    """
+    order = (regimen,) if regimen is not None else REGIMEN_FALLBACK
+
+    if cancer_type is None:
+        codes = _bulk_lookup_codes()
+        if regimen is not None:
+            return {
+                code: record
+                for code in codes
+                if (record := cancer_ici_response_record(code, regimen=regimen, inherit=False))
+            }
+        if not fallback:
+            return {
+                code: records
+                for code in codes
+                if (records := cancer_ici_response_record(code, fallback=False, inherit=False))
+            }
+        return {
+            code: record
+            for code in codes
+            if (record := cancer_ici_response_record(code, inherit=False))
+        }
+
+    requested_code = resolve_cancer_type(cancer_type)
+    resolved_code, inheritance_kind, rows = _resolve_ici_response_rows(
+        requested_code, order, inherit=inherit
+    )
+
+    if not fallback and regimen is None:
+        return {
+            key: _record_from_row(
+                row,
+                requested_code=requested_code,
+                resolved_code=resolved_code,
+                inheritance_kind=inheritance_kind,
+            )
+            for key, row in rows.items()
+        }
+
+    for key in order:
+        row = rows.get(str(key))
+        if row is not None:
+            return _record_from_row(
+                row,
+                requested_code=requested_code,
+                resolved_code=resolved_code,
+                inheritance_kind=inheritance_kind,
+            )
     return None
 
 

--- a/oncoref/ici_response.py
+++ b/oncoref/ici_response.py
@@ -36,8 +36,10 @@ from .ici import (
     cancer_ici_response,
     cancer_ici_response_df,
     cancer_ici_response_estimates_df,
+    cancer_ici_response_record,
     ici_regimens,
     pooled_ici_response,
+    resolve_ici_response_source,
 )
 
 DEFAULT_ICI_REGIMEN_PRIORITY = REGIMEN_FALLBACK
@@ -80,9 +82,26 @@ def best_available_ici_response(cancer_type=None, *, inherit: bool = True):
     return cancer_ici_response(cancer_type, inherit=inherit)
 
 
+def best_available_ici_response_record(cancer_type=None, *, inherit: bool = True):
+    """Best-available ICI response with source/evidence metadata."""
+    return cancer_ici_response_record(cancer_type, inherit=inherit)
+
+
 def ici_response_by_regimen(cancer_type=None, *, inherit: bool = True):
     """ICI ORR values grouped by regimen instead of using regimen priority."""
     return cancer_ici_response(cancer_type, fallback=False, inherit=inherit)
+
+
+def ici_response_records_by_regimen(cancer_type=None, *, inherit: bool = True):
+    """ICI response records grouped by regimen instead of using regimen priority."""
+    return cancer_ici_response_record(cancer_type, fallback=False, inherit=inherit)
+
+
+def ici_response_source(cancer_type, *, regimen=None, fallback: bool = True, inherit: bool = True):
+    """Direct/proxy/ancestor evidence-source resolution for one requested cancer type."""
+    return resolve_ici_response_source(
+        cancer_type, regimen=regimen, fallback=fallback, inherit=inherit
+    )
 
 
 def selected_ici_regimen(cancer_type):
@@ -97,16 +116,21 @@ __all__ = [
     "apd1_response",
     "apd1_response_df",
     "best_available_ici_response",
+    "best_available_ici_response_record",
     "cancer_apd1_response",
     "cancer_apd1_response_df",
     "cancer_ici_regimen",
     "cancer_ici_response",
     "cancer_ici_response_df",
     "cancer_ici_response_estimates_df",
+    "cancer_ici_response_record",
     "ici_regimens",
     "ici_response_anchor_df",
     "ici_response_by_regimen",
     "ici_response_estimates_df",
+    "ici_response_records_by_regimen",
+    "ici_response_source",
     "pooled_ici_response",
+    "resolve_ici_response_source",
     "selected_ici_regimen",
 ]

--- a/tests/test_api_structure.py
+++ b/tests/test_api_structure.py
@@ -35,8 +35,17 @@ def test_ici_response_facade_delegates_to_compatibility_api():
 
     assert ici_response.apd1_response("SKCM") == apd1.cancer_apd1_response("SKCM")
     assert ici_response.best_available_ici_response("SKCM") == ici.cancer_ici_response("SKCM")
+    assert ici_response.best_available_ici_response_record("SKCM") == (
+        ici.cancer_ici_response_record("SKCM")
+    )
+    assert ici_response.ici_response_source("COAD_MSI") == ici.resolve_ici_response_source(
+        "COAD_MSI"
+    )
     assert ici_response.ici_response_by_regimen("SKCM") == ici.cancer_ici_response(
         "SKCM", fallback=False
+    )
+    assert ici_response.ici_response_records_by_regimen("SKCM") == (
+        ici.cancer_ici_response_record("SKCM", fallback=False)
     )
     assert ici_response.selected_ici_regimen("SKCM") == ici.cancer_ici_regimen("SKCM")
     pd.testing.assert_frame_equal(

--- a/tests/test_ici.py
+++ b/tests/test_ici.py
@@ -136,6 +136,92 @@ def test_crc_msi_ici_is_single_source_scope_row():
     assert ici.cancer_ici_regimen("READ_MSI") == "PD-1"
 
 
+def test_crc_msi_ici_record_preserves_inheritance_metadata():
+    record = ici.cancer_ici_response_record("COAD_MSI")
+    assert record["requested_cancer_code"] == "COAD_MSI"
+    assert record["resolved_cancer_code"] == "CRC_MSI"
+    assert record["inheritance_kind"] == "source_scope"
+    assert record["is_inherited_evidence"] is True
+    assert record["regimen"] == "PD-1"
+    assert record["selected_regimen"] == "PD-1"
+    assert record["orr_pct"] == 43.8
+    assert record["response_numerator"] == 67
+    assert record["response_denominator"] == 153
+    assert record["response_ci_low"] == 35.8
+    assert record["response_ci_high"] == 52.0
+    assert record["source_anchor"] == "PMID:33264544"
+    assert record["source_scope"] == "aggregate_source"
+    assert record["endpoint_population"] == (
+        "first-line metastatic MSI-H/dMMR colorectal (pembrolizumab arm)"
+    )
+
+    per_regimen = ici.cancer_ici_response_record("READ_MSI", fallback=False)
+    assert set(per_regimen) == {"PD-1", "PD-1+CTLA-4"}
+    assert per_regimen["PD-1"]["requested_cancer_code"] == "READ_MSI"
+    assert per_regimen["PD-1"]["resolved_cancer_code"] == "CRC_MSI"
+    assert per_regimen["PD-1+CTLA-4"]["response_denominator"] == 119
+    assert per_regimen["PD-1+CTLA-4"]["source_anchor"] == "PMID:29355075"
+
+    assert ici.cancer_ici_response_record("READ_MSI", inherit=False) is None
+    assert ici.cancer_ici_response_record("READ_MSI", fallback=False, inherit=False) == {}
+
+
+def test_resolve_ici_response_source_reports_direct_proxy_and_missing():
+    direct = ici.resolve_ici_response_source("SKCM")
+    assert direct["requested_cancer_code"] == "SKCM"
+    assert direct["resolved_cancer_code"] == "SKCM"
+    assert direct["inheritance_kind"] == "direct"
+    assert direct["is_inherited_evidence"] is False
+    assert direct["selected_regimen"] == "PD-1"
+    assert direct["available_regimens"] == ("PD-1", "PD-1+CTLA-4")
+    assert direct["has_ici_response_source"] is True
+    assert direct["source_anchor"] == "PMID:28889792"
+
+    proxy = ici.resolve_ici_response_source("COAD_MSI")
+    assert proxy["requested_cancer_code"] == "COAD_MSI"
+    assert proxy["resolved_cancer_code"] == "CRC_MSI"
+    assert proxy["inheritance_kind"] == "source_scope"
+    assert proxy["is_inherited_evidence"] is True
+    assert proxy["selected_regimen"] == "PD-1"
+    assert proxy["available_regimens"] == ("PD-1", "PD-1+CTLA-4")
+    assert proxy["source_anchor"] == "PMID:33264544"
+    assert proxy["source_scope"] == "aggregate_source"
+
+    per_regimen = ici.resolve_ici_response_source("READ_MSI", fallback=False)
+    assert per_regimen["resolved_cancer_code"] == "CRC_MSI"
+    assert per_regimen["selected_regimen"] is None
+    assert per_regimen["available_regimens"] == ("PD-1", "PD-1+CTLA-4")
+
+    missing = ici.resolve_ici_response_source("NBL")
+    assert missing == {
+        "requested_cancer_code": "NBL",
+        "resolved_cancer_code": None,
+        "inheritance_kind": "missing",
+        "is_inherited_evidence": False,
+        "selected_regimen": None,
+        "available_regimens": (),
+        "has_ici_response_source": False,
+    }
+
+
+def test_ici_response_record_whole_table_matches_value_maps():
+    records = ici.cancer_ici_response_record()
+    values = ici.cancer_ici_response()
+    assert set(records) == set(values)
+    assert {code: record["orr_pct"] for code, record in records.items()} == values
+    assert "COAD_MSI" not in records
+    assert records["CRC_MSI"]["inheritance_kind"] == "direct"
+
+    pdl1_records = ici.cancer_ici_response_record(regimen="PD-L1")
+    pdl1_values = ici.cancer_ici_response(regimen="PD-L1")
+    assert {code: record["orr_pct"] for code, record in pdl1_records.items()} == pdl1_values
+
+
+def test_parent_code_helper_treats_nan_parent_as_missing():
+    registry = ici.cancer_type_registry().set_index("code")
+    assert ici._parent_code("CRC", registry) is None
+
+
 def test_regimen_maps_cached():
     # _regimen_maps is memoized (same object back from the cache).
     assert ici._regimen_maps() is ici._regimen_maps()


### PR DESCRIPTION
## Summary

Adds metadata-bearing ICI response lookup helpers on top of the existing numeric API:

- `cancer_ici_response_record(...)` mirrors `cancer_ici_response(...)` but returns the resolved anchor row plus evidence/provenance metadata.
- `best_available_ici_response_record(...)` and `ici_response_records_by_regimen(...)` expose the same capability through the organized `oncoref.ici_response` facade.
- `resolve_ici_response_source(...)` / `ici_response.ici_response_source(...)` explicitly resolve an individual requested cancer type to its direct/proxy/ancestor evidence source.
- `COAD_MSI` and `READ_MSI` individual lookups resolve through the curated `CRC_MSI` source-scope row with explicit `requested_cancer_code`, `resolved_cancer_code`, `inheritance_kind`, and `is_inherited_evidence` fields.
- Whole-map value and record helpers remain direct evidence-anchor maps, so `CRC_MSI` appears once and `COAD_MSI` / `READ_MSI` are not duplicated in bulk output.
- Parent traversal is null-safe for blank/NaN `parent_code` values.

## Context

This follows the ICI schema-union work in #212 and addresses the lookup-inheritance part of #196 without reopening the broader TMB/burden/source-audit scope. It is also part of the pirlygenes migration series where oncoref should own upstream semantics rather than relying on downstream shims.

Related follow-up buckets remain separate:

- #191 / #193 for gene universe and unmapped ID parity.
- #21 / #209 for data-version release and cache integrity.
- #203 / #205 / #210 for source-matrix QC and generated-artifact policy.
- #207 / #208 for missing expression/reference data that should be represented upstream.

## Validation

- `./lint.sh`
- `python -m pytest tests/test_ici.py tests/test_api_structure.py`
- `./test.sh`