### PR TITLE
[codex] Apply sample QC to expression artifact rebuilds

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -88,7 +88,11 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   defaults to `"all"` for forensic access, while live summaries such as
   `cohort_stats` and `pooled_cohort_stats` default to QC-passing samples.
 - `oncoref.expression_builders` — pure build-time cores used by data-bundle
-  generation scripts.
+  generation scripts. `scripts/rebuild_expression_artifacts.py` applies the same
+  sample-QC policy to derived shards by default (`--sample-qc pass`) and emits
+  `source-matrix-sample-qc.csv` plus `expression-artifact-build-metadata.*` in
+  the staging directory so bundle releases can record which source samples fed
+  percentiles, representatives, and within-sample summaries.
 - `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,
   log transforms, percentile ranks, and housekeeping normalization.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -79,7 +79,10 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
 
 - `oncoref.expression` — read-time accessors for per-sample expression,
   percentile vectors, representative samples, within-sample top fractions, and
-  pan-cancer reference tables.
+  pan-cancer reference tables. `sample_expression_qc` reports per-sample
+  detected-gene counts, top-gene/top-10 concentration, biological-housekeeping
+  detection, and source-type caveats so sparse source-matrix artifacts can be
+  audited before using absolute TPM floors or housekeeping normalization.
 - `oncoref.expression_builders` — pure build-time cores used by data-bundle
   generation scripts.
 - `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,

--- a/docs/api.md
+++ b/docs/api.md
@@ -81,8 +81,12 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   percentile vectors, representative samples, within-sample top fractions, and
   pan-cancer reference tables. `sample_expression_qc` reports per-sample
   detected-gene counts, top-gene/top-10 concentration, biological-housekeeping
-  detection, and source-type caveats so sparse source-matrix artifacts can be
-  audited before using absolute TPM floors or housekeeping normalization.
+  detection, source-scale class, and source-type caveats so sparse source-matrix
+  artifacts can be audited before using absolute TPM floors or housekeeping
+  normalization. `per_sample_expression(..., sample_qc="pass" | "pass_or_warn"
+  | "all")` filters sample columns at read time; the raw per-sample accessor
+  defaults to `"all"` for forensic access, while live summaries such as
+  `cohort_stats` and `pooled_cohort_stats` default to QC-passing samples.
 - `oncoref.expression_builders` — pure build-time cores used by data-bundle
   generation scripts.
 - `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -135,6 +135,7 @@ from .expression import (
     proteoform_representative_samples,
     proteoform_within_sample_top_fraction,
     representative_cohort_samples,
+    sample_expression_qc,
     within_sample_top_fraction,
 )
 from .expression_engine import aggregate_transcripts_to_genes, id_columns, sample_columns
@@ -488,6 +489,7 @@ __all__ = [
     "response_signatures_df",
     "sample_columns",
     "sample_counts_by_cancer_code",
+    "sample_expression_qc",
     "sample_manifest",
     "samples_for_cancer_code",
     "samples_for_cohort",

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -273,6 +273,159 @@ def available_percentile_cohorts(*, proteoform: bool = False, scope: str = "cta"
 
 
 _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p", "tpm_clean_hk")
+DEFAULT_MIN_DETECTED_GENES_FOR_QC = 5000
+DEFAULT_MIN_HOUSEKEEPING_GENES_FOR_QC = 10
+DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC = 0.20
+DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC = 0.50
+
+
+def _clean_tpm_housekeeping_panel_ids() -> frozenset[str]:
+    from .gene_families import clean_tpm_biological_housekeeping_gene_ids
+
+    return clean_tpm_biological_housekeeping_gene_ids()
+
+
+def _min_housekeeping_detected(panel_ids) -> int | None:
+    n = len(panel_ids)
+    return min(DEFAULT_MIN_HOUSEKEEPING_GENES_FOR_QC, n) if n else None
+
+
+def _selected_expression_source_metadata(code: str) -> dict[str, str | bool | None]:
+    source_type = unit = None
+    try:
+        info = source_matrices.cohort_info(code)
+        source_cohort = str(info.get("source_cohort") or "")
+    except source_matrices.SourceMatrixError:
+        source_cohort = ""
+
+    from .expression_registry import sources_for_cancer_code
+
+    sources = sources_for_cancer_code(code)
+    selected = next(
+        (s for s in sources if source_cohort and s.source_cohort == source_cohort),
+        sources[0] if sources else None,
+    )
+    if selected is not None:
+        source_type = selected.source_type
+        unit = selected.unit
+        if not source_cohort:
+            source_cohort = selected.source_cohort or ""
+        special = selected.special_handling or ""
+    else:
+        special = ""
+    text = " ".join(str(x or "") for x in (source_type, unit, special)).lower()
+    return {
+        "source_cohort": source_cohort or None,
+        "source_type": source_type,
+        "unit": unit,
+        "tpm_proxy": "microarray" in text or "tpm-proxy" in text or "tpm proxy" in text,
+    }
+
+
+def sample_expression_qc(
+    cancer_type,
+    *,
+    auto_fetch: bool = True,
+    min_detected_genes: int = DEFAULT_MIN_DETECTED_GENES_FOR_QC,
+    min_housekeeping_detected: int | None = None,
+    max_top_gene_fraction: float = DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC,
+    max_top10_gene_fraction: float = DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC,
+) -> pd.DataFrame:
+    """Per-sample QC metrics for a cohort's raw expression matrix.
+
+    This is an audit surface over the raw per-sample matrix before clean-TPM
+    normalization. It is designed to catch source/sample artifacts such as literal-zero
+    sparsity in otherwise universal genes, while still making source-type caveats
+    explicit (for example microarray TPM-proxy sources). It does not exclude samples by
+    itself; downstream code can use ``passes_expression_qc`` or inspect ``qc_flags``.
+    """
+    code = resolve_cancer_type(cancer_type, strict=False) or cancer_type
+    raw = per_sample_expression(code, normalize="tpm_raw", auto_fetch=auto_fetch)
+    samples = sample_columns(raw)
+    if not samples:
+        return pd.DataFrame()
+
+    ids = raw["Ensembl_Gene_ID"].astype(str).map(unversioned)
+    panel_ids = _clean_tpm_housekeeping_panel_ids()
+    panel = {str(g).split(".")[0] for g in panel_ids}
+    hk_rows = ids.isin(panel)
+    min_hk = (
+        min_housekeeping_detected
+        if min_housekeeping_detected is not None
+        else _min_housekeeping_detected(panel_ids)
+    )
+    meta = _selected_expression_source_metadata(str(code))
+
+    rows: list[dict] = []
+    for sample in samples:
+        vals = pd.to_numeric(raw[sample], errors="coerce")
+        measured = vals.notna()
+        positive = vals > 0
+        n_measured = int(measured.sum())
+        n_detected = int(positive.sum())
+        total = float(vals.sum(skipna=True))
+        top_idx = vals.idxmax(skipna=True) if n_measured else None
+        top_tpm = float(vals.loc[top_idx]) if top_idx is not None and pd.notna(top_idx) else 0.0
+        top10_tpm = float(vals.nlargest(min(10, n_measured)).sum()) if n_measured else 0.0
+        hk_vals = vals[hk_rows]
+        hk_measured = int(hk_vals.notna().sum())
+        hk_detected = int((hk_vals > 0).sum())
+        hk_zero = int((hk_vals == 0).sum())
+        top_fraction = top_tpm / total if total > 0 else np.nan
+        top10_fraction = top10_tpm / total if total > 0 else np.nan
+        detected_fraction = n_detected / n_measured if n_measured else np.nan
+        hk_zero_fraction = hk_zero / hk_measured if hk_measured else np.nan
+
+        flags: list[str] = []
+        if n_detected < min_detected_genes:
+            flags.append("low_detected_genes")
+        if min_hk is not None and hk_detected < min_hk:
+            flags.append("low_housekeeping_detection")
+        if pd.notna(top_fraction) and top_fraction > max_top_gene_fraction:
+            flags.append("high_top_gene_fraction")
+        if (
+            n_measured > 10
+            and pd.notna(top10_fraction)
+            and top10_fraction > max_top10_gene_fraction
+        ):
+            flags.append("high_top10_gene_fraction")
+        if meta["tpm_proxy"]:
+            flags.append("tpm_proxy_scale")
+
+        blocking = {
+            "low_detected_genes",
+            "low_housekeeping_detection",
+            "high_top_gene_fraction",
+            "high_top10_gene_fraction",
+        }
+        rows.append(
+            {
+                "cancer_code": code,
+                "source_cohort": meta["source_cohort"],
+                "source_type": meta["source_type"],
+                "unit": meta["unit"],
+                "sample_id": sample,
+                "n_measured_genes": n_measured,
+                "n_detected_genes": n_detected,
+                "detected_gene_fraction": detected_fraction,
+                "total_tpm": total,
+                "top_gene_id": raw.loc[top_idx, "Ensembl_Gene_ID"] if top_idx is not None else None,
+                "top_gene_symbol": raw.loc[top_idx, "Symbol"] if top_idx is not None else None,
+                "top_gene_tpm": top_tpm,
+                "top_gene_fraction": top_fraction,
+                "top10_tpm": top10_tpm,
+                "top10_fraction": top10_fraction,
+                "housekeeping_genes_present": hk_measured,
+                "housekeeping_genes_detected": hk_detected,
+                "housekeeping_zero_fraction": hk_zero_fraction,
+                "tpm_proxy": bool(meta["tpm_proxy"]),
+                "qc_flags": ";".join(flags),
+                "passes_expression_qc": not bool(set(flags) & blocking),
+                "recommended_for_absolute_tpm_floor": not bool(set(flags) & blocking)
+                and not bool(meta["tpm_proxy"]),
+            }
+        )
+    return pd.DataFrame(rows)
 
 
 def per_sample_expression(
@@ -379,14 +532,17 @@ def _housekeeping_normalize(df: pd.DataFrame, sample_cols) -> pd.DataFrame:
     """Divide each clean-TPM sample column by the biological housekeeping-panel geometric
     mean. Commutes with the proteoform sum (the denominator is per-column), so it can
     be applied before or after collapse."""
-    from .gene_families import clean_tpm_biological_housekeeping_gene_ids
     from .normalization import tpm_to_housekeeping_normalized
 
+    panel_ids = _clean_tpm_housekeeping_panel_ids()
     out, _ = tpm_to_housekeeping_normalized(
         df,
         value_cols=list(sample_cols),
-        panel_ids=clean_tpm_biological_housekeeping_gene_ids(),
+        panel_ids=panel_ids,
         panel_name="clean_tpm_biological_housekeeping",
+        min_panel_detected=_min_housekeeping_detected(panel_ids),
+        drop_zero_panel_values=True,
+        warn_on_unreliable=True,
     )
     return out
 
@@ -1230,13 +1386,15 @@ def pan_cancer_expression(
     if modes & {"housekeeping", "hk"}:
         hk_input_cols = clean_cols or raw_cols
         hk_input = out[id_cols + hk_input_cols].copy()
-        from .gene_families import clean_tpm_biological_housekeeping_gene_ids
-
+        panel_ids = _clean_tpm_housekeeping_panel_ids()
         hk, _ = tpm_to_housekeeping_normalized(
             hk_input,
             value_cols=hk_input_cols,
-            panel_ids=clean_tpm_biological_housekeeping_gene_ids(),
+            panel_ids=panel_ids,
             panel_name="clean_tpm_biological_housekeeping",
+            min_panel_detected=_min_housekeeping_detected(panel_ids),
+            drop_zero_panel_values=True,
+            warn_on_unreliable=True,
         )
         for col in hk_input_cols:
             target = col.rsplit("_", 1)[0] + "_hk"

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -274,6 +274,7 @@ def available_percentile_cohorts(*, proteoform: bool = False, scope: str = "cta"
 
 _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p", "tpm_clean_hk")
 _SAMPLE_QC_MODES = ("all", "pass", "pass_or_warn")
+SAMPLE_EXPRESSION_QC_POLICY_VERSION = "sample_expression_qc_v1"
 DEFAULT_MIN_DETECTED_GENES_FOR_QC = 5000
 DEFAULT_MIN_HOUSEKEEPING_GENES_FOR_QC = 10
 DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC = 0.20
@@ -378,25 +379,28 @@ def _apply_sample_qc_filter(
     return df[[*id_columns(df), *keep_samples]].copy()
 
 
-def sample_expression_qc(
-    cancer_type,
+def sample_expression_qc_from_matrix(
+    raw: pd.DataFrame,
     *,
-    auto_fetch: bool = True,
+    cancer_type=None,
+    source_metadata: dict[str, str | bool | None] | None = None,
     min_detected_genes: int = DEFAULT_MIN_DETECTED_GENES_FOR_QC,
     min_housekeeping_detected: int | None = None,
     max_top_gene_fraction: float = DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC,
     max_top10_gene_fraction: float = DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC,
 ) -> pd.DataFrame:
-    """Per-sample QC metrics for a cohort's raw expression matrix.
+    """Per-sample QC metrics for an already-loaded raw expression matrix.
 
-    This is an audit surface over the raw per-sample matrix before clean-TPM
-    normalization. It is designed to catch source/sample artifacts such as literal-zero
-    sparsity in otherwise universal genes, while still making source-type caveats
-    explicit (for example microarray TPM-proxy sources). It does not exclude samples by
-    itself; downstream code can use ``passes_expression_qc`` or inspect ``qc_flags``.
+    This is the shared policy core behind the public read-path QC and the offline
+    artifact rebuild. It canonicalizes gene rows before measuring sparsity so the QC
+    contract is evaluated in the same gene-ID space used by expression accessors.
     """
-    code = resolve_cancer_type(cancer_type, strict=False) or cancer_type
-    raw = per_sample_expression(code, normalize="tpm_raw", auto_fetch=auto_fetch, sample_qc="all")
+    code = (
+        resolve_cancer_type(cancer_type, strict=False) or cancer_type
+        if cancer_type is not None
+        else None
+    )
+    raw = _canonicalize_gene_rows(raw, sample_cols=sample_columns(raw)).reset_index(drop=True)
     samples = sample_columns(raw)
     if not samples:
         return pd.DataFrame()
@@ -415,7 +419,29 @@ def sample_expression_qc(
         if min_housekeeping_detected is not None
         else _min_housekeeping_detected(panel_ids)
     )
-    meta = _selected_expression_source_metadata(str(code))
+    if source_metadata is None:
+        meta = (
+            _selected_expression_source_metadata(str(code))
+            if code is not None
+            else {
+                "source_cohort": None,
+                "source_type": None,
+                "unit": None,
+                "source_scale_class": "unknown",
+                "linear_tpm_comparable": False,
+                "tpm_proxy": False,
+            }
+        )
+    else:
+        meta = {
+            "source_cohort": None,
+            "source_type": None,
+            "unit": None,
+            "source_scale_class": "unknown",
+            "linear_tpm_comparable": False,
+            "tpm_proxy": False,
+            **source_metadata,
+        }
 
     rows: list[dict] = []
     for sample in samples:
@@ -472,6 +498,7 @@ def sample_expression_qc(
         rows.append(
             {
                 "cancer_code": code,
+                "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
                 "source_cohort": meta["source_cohort"],
                 "source_type": meta["source_type"],
                 "unit": meta["unit"],
@@ -513,6 +540,35 @@ def sample_expression_qc(
             }
         )
     return pd.DataFrame(rows)
+
+
+def sample_expression_qc(
+    cancer_type,
+    *,
+    auto_fetch: bool = True,
+    min_detected_genes: int = DEFAULT_MIN_DETECTED_GENES_FOR_QC,
+    min_housekeeping_detected: int | None = None,
+    max_top_gene_fraction: float = DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC,
+    max_top10_gene_fraction: float = DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC,
+) -> pd.DataFrame:
+    """Per-sample QC metrics for a cohort's raw expression matrix.
+
+    This is an audit surface over the raw per-sample matrix before clean-TPM
+    normalization. It is designed to catch source/sample artifacts such as literal-zero
+    sparsity in otherwise universal genes, while still making source-type caveats
+    explicit (for example microarray TPM-proxy sources). It does not exclude samples by
+    itself; downstream code can use ``passes_expression_qc`` or inspect ``qc_flags``.
+    """
+    code = resolve_cancer_type(cancer_type, strict=False) or cancer_type
+    raw = per_sample_expression(code, normalize="tpm_raw", auto_fetch=auto_fetch, sample_qc="all")
+    return sample_expression_qc_from_matrix(
+        raw,
+        cancer_type=code,
+        min_detected_genes=min_detected_genes,
+        min_housekeeping_detected=min_housekeeping_detected,
+        max_top_gene_fraction=max_top_gene_fraction,
+        max_top10_gene_fraction=max_top10_gene_fraction,
+    )
 
 
 def per_sample_expression(

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -273,10 +273,19 @@ def available_percentile_cohorts(*, proteoform: bool = False, scope: str = "cta"
 
 
 _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p", "tpm_clean_hk")
+_SAMPLE_QC_MODES = ("all", "pass", "pass_or_warn")
 DEFAULT_MIN_DETECTED_GENES_FOR_QC = 5000
 DEFAULT_MIN_HOUSEKEEPING_GENES_FOR_QC = 10
 DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC = 0.20
 DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC = 0.50
+_BLOCKING_SAMPLE_QC_REASONS = frozenset(
+    {
+        "low_detected_genes",
+        "low_housekeeping_detection",
+        "high_top_gene_fraction",
+        "high_top10_gene_fraction",
+    }
+)
 
 
 def _clean_tpm_housekeeping_panel_ids() -> frozenset[str]:
@@ -314,12 +323,59 @@ def _selected_expression_source_metadata(code: str) -> dict[str, str | bool | No
     else:
         special = ""
     text = " ".join(str(x or "") for x in (source_type, unit, special)).lower()
+    tpm_proxy = "microarray" in text or "tpm-proxy" in text or "tpm proxy" in text
+    if tpm_proxy:
+        source_scale_class = "microarray_tpm_proxy"
+        linear_tpm_comparable = False
+    elif selected is not None:
+        source_scale_class = "linear_rnaseq_tpm"
+        linear_tpm_comparable = True
+    else:
+        source_scale_class = "unknown"
+        linear_tpm_comparable = False
     return {
         "source_cohort": source_cohort or None,
         "source_type": source_type,
         "unit": unit,
-        "tpm_proxy": "microarray" in text or "tpm-proxy" in text or "tpm proxy" in text,
+        "source_scale_class": source_scale_class,
+        "linear_tpm_comparable": linear_tpm_comparable,
+        "tpm_proxy": tpm_proxy,
     }
+
+
+def _sample_qc_status(reasons: list[str]) -> str:
+    if set(reasons) & _BLOCKING_SAMPLE_QC_REASONS:
+        return "fail"
+    return "warn" if reasons else "pass"
+
+
+def _validate_sample_qc(sample_qc: str) -> str:
+    mode = str(sample_qc).lower()
+    if mode not in _SAMPLE_QC_MODES:
+        raise ValueError(f"sample_qc must be one of {_SAMPLE_QC_MODES}")
+    return mode
+
+
+def _apply_sample_qc_filter(
+    df: pd.DataFrame, code: str, *, sample_qc: str, auto_fetch: bool
+) -> pd.DataFrame:
+    mode = _validate_sample_qc(sample_qc)
+    if mode == "all":
+        return df
+    samples = sample_columns(df)
+    if not samples:
+        return df
+    qc = sample_expression_qc(code, auto_fetch=auto_fetch)
+    if qc.empty:
+        return df[id_columns(df)].copy()
+    if mode == "pass":
+        allowed = set(qc.loc[qc["sample_qc_status"] == "pass", "sample_id"].astype(str))
+    else:
+        allowed = set(
+            qc.loc[qc["sample_qc_status"].isin(["pass", "warn"]), "sample_id"].astype(str)
+        )
+    keep_samples = [s for s in samples if s in allowed]
+    return df[[*id_columns(df), *keep_samples]].copy()
 
 
 def sample_expression_qc(
@@ -340,15 +396,20 @@ def sample_expression_qc(
     itself; downstream code can use ``passes_expression_qc`` or inspect ``qc_flags``.
     """
     code = resolve_cancer_type(cancer_type, strict=False) or cancer_type
-    raw = per_sample_expression(code, normalize="tpm_raw", auto_fetch=auto_fetch)
+    raw = per_sample_expression(code, normalize="tpm_raw", auto_fetch=auto_fetch, sample_qc="all")
     samples = sample_columns(raw)
     if not samples:
         return pd.DataFrame()
 
+    id_cols = id_columns(raw)
     ids = raw["Ensembl_Gene_ID"].astype(str).map(unversioned)
     panel_ids = _clean_tpm_housekeeping_panel_ids()
     panel = {str(g).split(".")[0] for g in panel_ids}
     hk_rows = ids.isin(panel)
+    from .gene_families import clean_tpm_censored_gene_ids
+
+    biological_rows = ~ids.isin(clean_tpm_censored_gene_ids())
+    clean = clean_tpm(raw[samples], gene_table=raw[id_cols])
     min_hk = (
         min_housekeeping_detected
         if min_housekeeping_detected is not None
@@ -359,21 +420,36 @@ def sample_expression_qc(
     rows: list[dict] = []
     for sample in samples:
         vals = pd.to_numeric(raw[sample], errors="coerce")
+        clean_vals = pd.to_numeric(clean[sample], errors="coerce")
         measured = vals.notna()
         positive = vals > 0
         n_measured = int(measured.sum())
         n_detected = int(positive.sum())
+        n_zero = int((vals == 0).sum())
+        n_missing = int(vals.isna().sum())
+        n_detected_clean = int((clean_vals > 0).sum())
+        n_detected_clean_biological = int((clean_vals[biological_rows] > 0).sum())
         total = float(vals.sum(skipna=True))
         top_idx = vals.idxmax(skipna=True) if n_measured else None
         top_tpm = float(vals.loc[top_idx]) if top_idx is not None and pd.notna(top_idx) else 0.0
         top10_tpm = float(vals.nlargest(min(10, n_measured)).sum()) if n_measured else 0.0
+        clean_total = float(clean_vals.sum(skipna=True))
+        clean_top_tpm = float(clean_vals.max(skipna=True)) if n_measured else 0.0
+        clean_top10_tpm = (
+            float(clean_vals.nlargest(min(10, n_measured)).sum()) if n_measured else 0.0
+        )
         hk_vals = vals[hk_rows]
         hk_measured = int(hk_vals.notna().sum())
         hk_detected = int((hk_vals > 0).sum())
         hk_zero = int((hk_vals == 0).sum())
+        hk_floor_count = int((hk_vals >= 30).sum())
         top_fraction = top_tpm / total if total > 0 else np.nan
         top10_fraction = top10_tpm / total if total > 0 else np.nan
+        clean_top_fraction = clean_top_tpm / clean_total if clean_total > 0 else np.nan
+        clean_top10_fraction = clean_top10_tpm / clean_total if clean_total > 0 else np.nan
         detected_fraction = n_detected / n_measured if n_measured else np.nan
+        zero_fraction = n_zero / n_measured if n_measured else np.nan
+        parse_missing_fraction = n_missing / len(vals) if len(vals) else np.nan
         hk_zero_fraction = hk_zero / hk_measured if hk_measured else np.nan
 
         flags: list[str] = []
@@ -392,37 +468,48 @@ def sample_expression_qc(
         if meta["tpm_proxy"]:
             flags.append("tpm_proxy_scale")
 
-        blocking = {
-            "low_detected_genes",
-            "low_housekeeping_detection",
-            "high_top_gene_fraction",
-            "high_top10_gene_fraction",
-        }
+        status = _sample_qc_status(flags)
         rows.append(
             {
                 "cancer_code": code,
                 "source_cohort": meta["source_cohort"],
                 "source_type": meta["source_type"],
                 "unit": meta["unit"],
+                "source_scale_class": meta["source_scale_class"],
+                "linear_tpm_comparable": bool(meta["linear_tpm_comparable"]),
                 "sample_id": sample,
                 "n_measured_genes": n_measured,
                 "n_detected_genes": n_detected,
+                "n_detected_raw": n_detected,
+                "n_detected_clean": n_detected_clean,
+                "n_detected_clean_biological": n_detected_clean_biological,
                 "detected_gene_fraction": detected_fraction,
+                "zero_fraction_raw": zero_fraction,
+                "parse_missing_fraction": parse_missing_fraction,
                 "total_tpm": total,
                 "top_gene_id": raw.loc[top_idx, "Ensembl_Gene_ID"] if top_idx is not None else None,
                 "top_gene_symbol": raw.loc[top_idx, "Symbol"] if top_idx is not None else None,
                 "top_gene_tpm": top_tpm,
                 "top_gene_fraction": top_fraction,
+                "top1_fraction_raw": top_fraction,
                 "top10_tpm": top10_tpm,
                 "top10_fraction": top10_fraction,
+                "top10_fraction_raw": top10_fraction,
+                "top1_fraction_clean": clean_top_fraction,
+                "top10_fraction_clean": clean_top10_fraction,
                 "housekeeping_genes_present": hk_measured,
                 "housekeeping_genes_detected": hk_detected,
+                "housekeeping_genes_above_30": hk_floor_count,
                 "housekeeping_zero_fraction": hk_zero_fraction,
                 "tpm_proxy": bool(meta["tpm_proxy"]),
                 "qc_flags": ";".join(flags),
-                "passes_expression_qc": not bool(set(flags) & blocking),
-                "recommended_for_absolute_tpm_floor": not bool(set(flags) & blocking)
-                and not bool(meta["tpm_proxy"]),
+                "qc_status": status,
+                "qc_reasons": ";".join(flags),
+                "sample_qc_status": status,
+                "sample_qc_reasons": ";".join(flags),
+                "passes_expression_qc": status != "fail",
+                "recommended_for_absolute_tpm_floor": status != "fail"
+                and bool(meta["linear_tpm_comparable"]),
             }
         )
     return pd.DataFrame(rows)
@@ -435,6 +522,7 @@ def per_sample_expression(
     auto_fetch: bool = True,
     proteoform: bool = False,
     scope: str = "cta",
+    sample_qc: str = "all",
 ) -> pd.DataFrame:
     """Full per-sample expression matrix (genes x **every** sample) for a cohort —
     the raw **TPM values** at gene level (default) or proteoform level.
@@ -466,11 +554,15 @@ def per_sample_expression(
     (``scope`` is ignored when ``proteoform=False``.)
 
     ``auto_fetch=False`` raises instead of downloading if the matrix isn't cached.
+    ``sample_qc`` can be ``"all"`` (default), ``"pass"``, or ``"pass_or_warn"``; the
+    latter two use :func:`sample_expression_qc` to drop failing sample columns while
+    retaining the gene rows.
     Returns ``Ensembl_Gene_ID``, ``Symbol`` and one column per sample (plus the
     proteoform identity columns when collapsed).
     """
     if normalize not in _PER_SAMPLE_NORMALIZE:
         raise ValueError(f"normalize must be one of {_PER_SAMPLE_NORMALIZE}")
+    sample_qc = _validate_sample_qc(sample_qc)
     code = resolve_cancer_type(cancer_type, strict=False) or cancer_type
     if auto_fetch:
         path = source_matrices.ensure(code)
@@ -487,7 +579,8 @@ def per_sample_expression(
     # The mtime in the key self-invalidates the cache if the matrix is re-fetched.
     mtime = os.path.getmtime(path)
     if not proteoform:
-        return _load_per_sample_matrix(str(path), mtime, normalize).copy()
+        out = _load_per_sample_matrix(str(path), mtime, normalize).copy()
+        return _apply_sample_qc_filter(out, str(code), sample_qc=sample_qc, auto_fetch=auto_fetch)
     # Proteoform level: sum members in LINEAR TPM, then apply the requested transform.
     from .proteoforms import collapse_to_proteoforms
 
@@ -498,7 +591,7 @@ def per_sample_expression(
         out[samples] = np.log1p(out[samples].to_numpy(dtype=float))
     elif normalize == "tpm_clean_hk":
         out = _housekeeping_normalize(out, samples)
-    return out
+    return _apply_sample_qc_filter(out, str(code), sample_qc=sample_qc, auto_fetch=auto_fetch)
 
 
 @lru_cache(maxsize=_PER_SAMPLE_CACHE_SIZE)
@@ -558,6 +651,7 @@ def cohort_mean_expression(
     auto_fetch: bool = True,
     proteoform: bool = False,
     scope: str = "cta",
+    sample_qc: str = "pass",
 ) -> pd.DataFrame:
     """Per-gene **across-patient summary** of a cohort's expression (one value per
     gene, collapsed over all patients).
@@ -573,7 +667,9 @@ def cohort_mean_expression(
     (:func:`oncoref.proteoforms.collapse_to_proteoforms`) **before** the
     across-patient reduction, so the summary is over the reduced proteoform key space
     (rows carry ``proteoform_key`` — a **proteoform-level** frame, see
-    :func:`oncoref.proteoforms.expression_level`). ``scope`` selects the gene
+    :func:`oncoref.proteoforms.expression_level`). ``sample_qc`` defaults to
+    ``"pass"`` so live summaries exclude source/sample QC failures; pass ``"all"`` for
+    forensic parity with the current source matrix. ``scope`` selects the gene
     universe to collapse: ``"cta"`` (focused) or ``"genome"`` (every protein-coding
     gene). Returns ``Ensembl_Gene_ID``, ``Symbol`` (plus the proteoform identity
     columns when collapsed) and one ``expression`` column."""
@@ -585,6 +681,7 @@ def cohort_mean_expression(
         auto_fetch=auto_fetch,
         proteoform=proteoform,
         scope=scope,
+        sample_qc=sample_qc,
     )
     id_cols = id_columns(df)
     samples = sample_columns(df)
@@ -754,6 +851,7 @@ def cohort_stats(
     auto_fetch: bool = True,
     proteoform: bool = False,
     scope: str = "cta",
+    sample_qc: str = "pass",
 ) -> pd.DataFrame:
     """Per-gene **summary statistics** across a cohort's samples, in one pass —
     ``mean``, ``std`` and a uniform percentile ladder ``min, p1, p5, p10, p15, p20,
@@ -769,9 +867,15 @@ def cohort_stats(
     ``proteoform=True`` summarizes the reduced proteoform key space (members summed per
     sample first, ``scope`` ``"cta"``/``"genome"``) — a proteoform-level frame carrying
     ``proteoform_key`` (see :func:`oncoref.proteoforms.expression_level`). Returns the
-    id columns plus one column per statistic."""
+    id columns plus one column per statistic. ``sample_qc`` defaults to ``"pass"``
+    for live summaries; use ``"all"`` to include every source-matrix sample."""
     df = per_sample_expression(
-        cancer_type, normalize=normalize, auto_fetch=auto_fetch, proteoform=proteoform, scope=scope
+        cancer_type,
+        normalize=normalize,
+        auto_fetch=auto_fetch,
+        proteoform=proteoform,
+        scope=scope,
+        sample_qc=sample_qc,
     )
     id_cols = id_columns(df)
     samples = sample_columns(df)
@@ -952,7 +1056,7 @@ def representative_cohort_samples(
 
 
 def _biological_per_sample(
-    code, *, proteoform: bool, auto_fetch: bool, scope: str = "cta"
+    code, *, proteoform: bool, auto_fetch: bool, scope: str = "cta", sample_qc: str = "pass"
 ) -> pd.DataFrame:
     """Clean-TPM per-sample matrix with technical/censored genes dropped — the
     biological view the summary artifacts are built on — collapsed to proteoform level
@@ -961,7 +1065,9 @@ def _biological_per_sample(
     (no shard). ``scope`` is ignored when ``proteoform`` is False."""
     from .gene_families import clean_tpm_censored_gene_ids
 
-    clean = per_sample_expression(code, normalize="tpm_clean", auto_fetch=auto_fetch)
+    clean = per_sample_expression(
+        code, normalize="tpm_clean", auto_fetch=auto_fetch, sample_qc=sample_qc
+    )
     censored = clean_tpm_censored_gene_ids()
     unversioned = clean["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
     bio = clean[~unversioned.isin(censored)].reset_index(drop=True)
@@ -973,7 +1079,13 @@ def _biological_per_sample(
 
 
 def _read_shard_or_recompute(
-    dataset: ShardDataset, code: str, *, proteoform: bool, auto_fetch: bool, scope: str = "cta"
+    dataset: ShardDataset,
+    code: str,
+    *,
+    proteoform: bool,
+    auto_fetch: bool,
+    scope: str = "cta",
+    sample_qc: str = "pass",
 ) -> pd.DataFrame:
     """Read ``code``'s shard for ``dataset`` (the ``scope``-specific one at proteoform
     level); if no shard is present, recompute it on the fly from the per-sample matrix
@@ -989,7 +1101,11 @@ def _read_shard_or_recompute(
         return pd.read_parquet(shard)
     try:
         bio = _biological_per_sample(
-            code, proteoform=proteoform, auto_fetch=auto_fetch, scope=scope
+            code,
+            proteoform=proteoform,
+            auto_fetch=auto_fetch,
+            scope=scope,
+            sample_qc=sample_qc,
         )
     except FileNotFoundError as e:
         variant = "proteoform-summed " if proteoform else ""
@@ -1154,30 +1270,51 @@ def proteoform_representative_samples(
 
 
 def gene_per_sample_expression(
-    cancer_type, *, normalize: str = "tpm_clean", auto_fetch: bool = True
+    cancer_type, *, normalize: str = "tpm_clean", auto_fetch: bool = True, sample_qc: str = "all"
 ) -> pd.DataFrame:
     """Gene-level per-sample **TPM values** (one row per Ensembl gene). Proteoform
     counterpart: :func:`proteoform_per_sample_expression`."""
-    return per_sample_expression(cancer_type, normalize=normalize, auto_fetch=auto_fetch)
+    return per_sample_expression(
+        cancer_type, normalize=normalize, auto_fetch=auto_fetch, sample_qc=sample_qc
+    )
 
 
 def proteoform_per_sample_expression(
-    cancer_type, *, normalize: str = "tpm_clean", auto_fetch: bool = True, scope: str = "cta"
+    cancer_type,
+    *,
+    normalize: str = "tpm_clean",
+    auto_fetch: bool = True,
+    scope: str = "cta",
+    sample_qc: str = "all",
 ) -> pd.DataFrame:
     """Proteoform-level per-sample **TPM values** — identical-protein paralogs summed
     per sample. Gene-level counterpart: :func:`gene_per_sample_expression`."""
     return per_sample_expression(
-        cancer_type, normalize=normalize, auto_fetch=auto_fetch, proteoform=True, scope=scope
+        cancer_type,
+        normalize=normalize,
+        auto_fetch=auto_fetch,
+        proteoform=True,
+        scope=scope,
+        sample_qc=sample_qc,
     )
 
 
 def gene_cohort_mean_expression(
-    cancer_type, *, normalize: str = "tpm_clean", statistic: str = "mean", auto_fetch: bool = True
+    cancer_type,
+    *,
+    normalize: str = "tpm_clean",
+    statistic: str = "mean",
+    auto_fetch: bool = True,
+    sample_qc: str = "pass",
 ) -> pd.DataFrame:
     """Gene-level across-patient **TPM** summary. Proteoform counterpart:
     :func:`proteoform_cohort_mean_expression`."""
     return cohort_mean_expression(
-        cancer_type, normalize=normalize, statistic=statistic, auto_fetch=auto_fetch
+        cancer_type,
+        normalize=normalize,
+        statistic=statistic,
+        auto_fetch=auto_fetch,
+        sample_qc=sample_qc,
     )
 
 
@@ -1188,6 +1325,7 @@ def proteoform_cohort_mean_expression(
     statistic: str = "mean",
     auto_fetch: bool = True,
     scope: str = "cta",
+    sample_qc: str = "pass",
 ) -> pd.DataFrame:
     """Proteoform-level across-patient **TPM** summary. Gene-level counterpart:
     :func:`gene_cohort_mean_expression`."""
@@ -1198,35 +1336,57 @@ def proteoform_cohort_mean_expression(
         auto_fetch=auto_fetch,
         proteoform=True,
         scope=scope,
+        sample_qc=sample_qc,
     )
 
 
 def gene_cohort_stats(
-    cancer_type, *, normalize: str = "tpm_clean", auto_fetch: bool = True
+    cancer_type, *, normalize: str = "tpm_clean", auto_fetch: bool = True, sample_qc: str = "pass"
 ) -> pd.DataFrame:
     """Gene-level per-gene cohort **summary statistics** (mean/std + the percentile ladder
     min/p1/p5/p10/p15/p20/p25/p50/p75/p80/p85/p90/p95/p99/max). Proteoform counterpart:
     :func:`proteoform_cohort_stats`."""
-    return cohort_stats(cancer_type, normalize=normalize, auto_fetch=auto_fetch)
+    return cohort_stats(
+        cancer_type, normalize=normalize, auto_fetch=auto_fetch, sample_qc=sample_qc
+    )
 
 
 def proteoform_cohort_stats(
-    cancer_type, *, normalize: str = "tpm_clean", auto_fetch: bool = True, scope: str = "cta"
+    cancer_type,
+    *,
+    normalize: str = "tpm_clean",
+    auto_fetch: bool = True,
+    scope: str = "cta",
+    sample_qc: str = "pass",
 ) -> pd.DataFrame:
     """Proteoform-level per-gene cohort **summary statistics**. Gene-level counterpart:
     :func:`gene_cohort_stats`."""
     return cohort_stats(
-        cancer_type, normalize=normalize, auto_fetch=auto_fetch, proteoform=True, scope=scope
+        cancer_type,
+        normalize=normalize,
+        auto_fetch=auto_fetch,
+        proteoform=True,
+        scope=scope,
+        sample_qc=sample_qc,
     )
 
 
 def gene_pooled_cohort_stats(
-    cancer_types, *, normalize: str = "tpm_clean", auto_fetch: bool = True, min_cohorts: int = 1
+    cancer_types,
+    *,
+    normalize: str = "tpm_clean",
+    auto_fetch: bool = True,
+    min_cohorts: int = 1,
+    sample_qc: str = "pass",
 ) -> pd.DataFrame:
     """Gene-level heterogeneity-safe cross-cohort pool. Proteoform counterpart:
     :func:`proteoform_pooled_cohort_stats`. (Alias of :func:`pooled_cohort_stats`.)"""
     return pooled_cohort_stats(
-        cancer_types, normalize=normalize, auto_fetch=auto_fetch, min_cohorts=min_cohorts
+        cancer_types,
+        normalize=normalize,
+        auto_fetch=auto_fetch,
+        min_cohorts=min_cohorts,
+        sample_qc=sample_qc,
     )
 
 
@@ -1237,6 +1397,7 @@ def proteoform_pooled_cohort_stats(
     auto_fetch: bool = True,
     scope: str = "cta",
     min_cohorts: int = 1,
+    sample_qc: str = "pass",
 ) -> pd.DataFrame:
     """Proteoform-level heterogeneity-safe cross-cohort pool. Gene-level counterpart:
     :func:`gene_pooled_cohort_stats`."""
@@ -1247,6 +1408,7 @@ def proteoform_pooled_cohort_stats(
         proteoform=True,
         scope=scope,
         min_cohorts=min_cohorts,
+        sample_qc=sample_qc,
     )
 
 
@@ -1468,6 +1630,7 @@ def pooled_cohort_stats(
     proteoform: bool = False,
     scope: str = "cta",
     min_cohorts: int = 1,
+    sample_qc: str = "pass",
 ) -> pd.DataFrame:
     """**Heterogeneity-safe** per-gene summary pooled across several cohorts.
 
@@ -1494,11 +1657,12 @@ def pooled_cohort_stats(
     - ``n_cohorts`` — how many of the pooled cohorts measured the gene.
 
     ``min_cohorts`` drops genes measured by fewer than that many cohorts (default
-    ``1`` keeps everything). ``normalize`` selects the pooling space (linear clean
-    TPM by default; see :func:`per_sample_expression`). ``proteoform=True`` pools
-    the reduced proteoform key space (``scope`` ``"cta"``/``"genome"``). An aggregate
-    code (e.g. ``"SARC"``) expands to its member subtypes — pooling them is exactly
-    what a rollup cohort means."""
+    ``1`` keeps everything). ``sample_qc`` defaults to ``"pass"`` so QC-failed
+    sample columns do not affect live pooled summaries. ``normalize`` selects the
+    pooling space (linear clean TPM by default; see :func:`per_sample_expression`).
+    ``proteoform=True`` pools the reduced proteoform key space (``scope`` ``"cta"``/
+    ``"genome"``). An aggregate code (e.g. ``"SARC"``) expands to its member subtypes
+    — pooling them is exactly what a rollup cohort means."""
     codes = _resolve_cancer_types(cancer_types, expand_aggregates=True)
     codes = list(dict.fromkeys(codes or []))
     if not codes:
@@ -1513,7 +1677,12 @@ def pooled_cohort_stats(
     # can't stand as a separate sparse row here — no extra canonicalization needed.
     for code in codes:
         df = per_sample_expression(
-            code, normalize=normalize, auto_fetch=auto_fetch, proteoform=proteoform, scope=scope
+            code,
+            normalize=normalize,
+            auto_fetch=auto_fetch,
+            proteoform=proteoform,
+            scope=scope,
+            sample_qc=sample_qc,
         )
         id_cols = id_columns(df)
         samples = sample_columns(df)

--- a/oncoref/normalization.py
+++ b/oncoref/normalization.py
@@ -53,6 +53,8 @@ housekeeping/log/rank transforms. Censored-gene and gene-family lists come from
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -556,6 +558,9 @@ def tpm_to_housekeeping_normalized(
     panel_ids=None,
     panel_name: str | None = None,
     pseudocount: float = 0.1,
+    min_panel_detected: int | None = None,
+    drop_zero_panel_values: bool = False,
+    warn_on_unreliable: bool = False,
 ) -> tuple[pd.DataFrame, dict]:
     """Divide each expression column by the **geometric mean** of a housekeeping
     panel, putting expression on a unit-free ratio-to-baseline scale that survives
@@ -579,7 +584,12 @@ def tpm_to_housekeeping_normalized(
     explicitly or use :func:`normalize_to_housekeeping` (which defaults to all sample
     columns). Returns ``(normalized_df, stats)`` with per-column denominator + panel
     coverage; a column with no measurable panel gene is blanked to NaN (never left on
-    the input scale beside normalized siblings)."""
+    the input scale beside normalized siblings).
+
+    For source matrices where literal zeros may represent sample/source sparsity rather
+    than credible absence, callers can set ``drop_zero_panel_values=True`` and require a
+    minimum number of nonzero panel genes via ``min_panel_detected``. Columns that fail
+    that reliability gate are blanked to NaN and optionally warn."""
     if df is None:
         return None, {"applied": False, "reason": "no table", "columns": {}}
     out = df.copy()
@@ -616,8 +626,35 @@ def tpm_to_housekeeping_normalized(
     applied = False
     for col in value_cols:
         vals = pd.to_numeric(out.loc[panel_rows, col], errors="coerce").dropna()
-        denom = float(np.exp(np.log(vals.to_numpy() + pseudocount).mean())) if len(vals) else 0.0
-        columns[col] = {"denominator": denom, "panel_genes_present": n_panel}
+        detected = vals[vals > 0]
+        denominator_vals = detected if drop_zero_panel_values else vals
+        n_detected = len(detected)
+        n_zero = int((vals == 0).sum())
+        reliable = min_panel_detected is None or n_detected >= int(min_panel_detected)
+        denom = (
+            float(np.exp(np.log(denominator_vals.to_numpy() + pseudocount).mean()))
+            if reliable and len(denominator_vals)
+            else 0.0
+        )
+        reason = (
+            "divided by housekeeping geometric mean"
+            if denom > 0
+            else (
+                f"only {n_detected} nonzero housekeeping panel genes"
+                if not reliable
+                else "panel denominator <= 0"
+            )
+        )
+        columns[col] = {
+            "denominator": denom,
+            "panel_genes_present": n_panel,
+            "panel_genes_measured": len(vals),
+            "panel_genes_detected": n_detected,
+            "panel_genes_zero": n_zero,
+            "min_panel_detected": min_panel_detected,
+            "drop_zero_panel_values": bool(drop_zero_panel_values),
+            "reason": reason,
+        }
         if denom > 0:
             out[col] = pd.to_numeric(out[col], errors="coerce") / denom
             applied = True
@@ -627,6 +664,13 @@ def tpm_to_housekeeping_normalized(
             # it on the raw-TPM scale alongside normalized siblings (the scale-mixing
             # trap).
             out[col] = np.nan
+            if warn_on_unreliable and not reliable:
+                warnings.warn(
+                    f"{col}: housekeeping normalization skipped; only {n_detected} "
+                    f"nonzero genes in {panel_name} panel (minimum {min_panel_detected})",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
     return out, {
         "applied": applied,
         "reason": "divided by housekeeping geometric mean" if applied else "panel denominator <= 0",

--- a/scripts/rebuild_expression_artifacts.py
+++ b/scripts/rebuild_expression_artifacts.py
@@ -18,6 +18,7 @@ expression bundle:
     raw per-sample TPM matrices  (candidate source cohorts per cancer code)
         -> select ONE source per code  (the source-matrices.csv choice; never pool)
         -> clean_tpm                   (two-compartment biological view)
+        -> sample QC filter            (pass by default; opt out with --sample-qc all)
         -> drop technical genes        (biology-only, matching the shipped artifact)
         -> percentile vectors / n=5 representatives / within-sample top-fractions
 
@@ -32,10 +33,12 @@ one source per code; it never pools) — so the artifacts match the shipped refe
 Outputs land under ``--out`` (a staging dir, NOT ``oncoref/data`` — the artifacts
 are large and ship via the release tarball, so they're never committed):
 
-    <out>/clean/<CODE>.parquet                                 (clean-TPM matrix, full)
+    <out>/clean/<CODE>.parquet                                 (QC-filtered clean TPM)
     <out>/cancer-reference-expression-percentiles/<CODE>.parquet      (biology-only)
     <out>/cancer-reference-expression-representatives/<CODE>.parquet + _provenance.csv
     <out>/cancer-reference-expression-within-sample-top5/<CODE>.parquet (biology-only)
+    <out>/source-matrix-sample-qc.csv                          (per-sample QC manifest)
+    <out>/expression-artifact-build-metadata.json              (QC/build policy metadata)
 
 ``--validate`` additionally correlates each rebuilt percentile vector against the
 reference artifact in ``--ref`` and prints the per-code agreement.
@@ -50,6 +53,7 @@ Run:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -60,7 +64,14 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from oncoref.cancer_types import cohort_source_version
-from oncoref.expression import SHARD_DATASETS, _canonicalize_gene_rows, sample_columns
+from oncoref.expression import (
+    SAMPLE_EXPRESSION_QC_POLICY_VERSION,
+    SHARD_DATASETS,
+    _canonicalize_gene_rows,
+    _validate_sample_qc,
+    sample_columns,
+    sample_expression_qc_from_matrix,
+)
 from oncoref.expression_builders import (
     cohort_medoids,
     cohort_percentile_vectors,
@@ -142,15 +153,19 @@ def _select_source(code: str, candidates: list[tuple[str, Path]], code_to_source
     return max(candidates, key=lambda c: pd.read_parquet(c[1]).shape[1])[1]
 
 
-def build_clean(path: Path) -> pd.DataFrame:
-    """Clean-TPM matrix for one source's per-sample matrix (genes x samples + ids).
+def read_raw(path: Path) -> pd.DataFrame:
+    """Canonical raw per-sample matrix for one source (genes x samples + ids).
 
     Canonicalize the raw matrix first (sum alt-haplotype/patch copies in LINEAR TPM,
     relabel retired ids), exactly as the runtime `_load_per_sample_matrix` does, so the
     shipped percentile/representative shards are natively dense in the canonical gene-ID
     space and match the on-the-fly recompute path (oncoref#135 item 6)."""
     raw = pd.read_parquet(path)
-    raw = _canonicalize_gene_rows(raw, sample_cols=sample_columns(raw))
+    return _canonicalize_gene_rows(raw, sample_cols=sample_columns(raw)).reset_index(drop=True)
+
+
+def build_clean(raw: pd.DataFrame) -> pd.DataFrame:
+    """Clean-TPM matrix for one source's per-sample matrix (genes x samples + ids)."""
     samples = [c for c in raw.columns if c not in _BASE]
     gene_table = raw[_BASE]
     clean = clean_tpm(raw[samples], gene_table=gene_table)
@@ -167,7 +182,35 @@ def _drop_technical(df: pd.DataFrame) -> pd.DataFrame:
     return df[~unversioned.isin(censored)].reset_index(drop=True)
 
 
-def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: bool) -> None:
+def _samples_for_qc(samples: list[str], qc: pd.DataFrame, sample_qc: str) -> list[str]:
+    mode = _validate_sample_qc(sample_qc)
+    if mode == "all":
+        return samples
+    if qc.empty:
+        return []
+    status = dict(zip(qc["sample_id"].astype(str), qc["sample_qc_status"].astype(str)))
+    if mode == "pass":
+        allowed = {"pass"}
+    else:
+        allowed = {"pass", "warn"}
+    return [s for s in samples if status.get(str(s)) in allowed]
+
+
+def _qc_counts(qc: pd.DataFrame) -> dict[str, int]:
+    counts = qc["sample_qc_status"].value_counts().to_dict() if not qc.empty else {}
+    return {f"n_qc_{name}": int(counts.get(name, 0)) for name in ("pass", "warn", "fail")}
+
+
+def rebuild(
+    cache: Path,
+    ref: Path,
+    out: Path,
+    *,
+    limit: int | None,
+    validate: bool,
+    sample_qc: str = "pass",
+) -> None:
+    sample_qc = _validate_sample_qc(sample_qc)
     by_code = discover(cache, ref)
     reg = source_registry()
     code_to_source = dict(zip(reg["cancer_code"].astype(str), reg["source_cohort"].astype(str)))
@@ -186,11 +229,23 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
         d.mkdir(parents=True, exist_ok=True)
 
     provenance: list[dict] = []
+    qc_manifest: list[pd.DataFrame] = []
+    build_rows: list[dict] = []
     corrs: list[float] = []
     for code in codes:
         source_path = _select_source(code, by_code[code], code_to_source)
-        clean_df = build_clean(source_path)
-        samples = [c for c in clean_df.columns if c not in _BASE]
+        raw_df = read_raw(source_path)
+        source_samples = [c for c in raw_df.columns if c not in _BASE]
+        qc = sample_expression_qc_from_matrix(raw_df, cancer_type=code)
+        if not qc.empty:
+            qc = qc.assign(source_matrix_path=str(source_path))
+            qc_manifest.append(qc)
+        samples = _samples_for_qc(source_samples, qc, sample_qc)
+        if not samples:
+            raise ValueError(f"{code}: sample_qc={sample_qc!r} leaves no source samples")
+
+        clean_df = build_clean(raw_df)
+        clean_df = clean_df[[*_BASE, *samples]].copy()
         clean_df.to_parquet(clean_dir / f"{code}.parquet", index=False, compression="zstd")
 
         # Biological view (technical genes dropped) for the percentile + within-sample
@@ -206,13 +261,31 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
         reps = reps.rename(columns=dict(zip(rep_cols, rep_ids)))
         reps.to_parquet(rep_dir / f"{code}.parquet", index=False, compression="zstd")
         source_version = cohort_source_version(code)
+        qc_counts = _qc_counts(qc)
+        build_row = {
+            "cancer_code": code,
+            "source_cohort": code_to_source.get(code, code),
+            "source_version": source_version,
+            "source_matrix_path": str(source_path),
+            "sample_qc": sample_qc,
+            "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
+            "n_source_samples": len(source_samples),
+            "n_cohort_samples": len(samples),
+            **qc_counts,
+        }
+        build_rows.append(build_row)
         for rep_id in rep_ids:
             provenance.append(
                 {
                     "representative_id": rep_id,
                     "source_cohort": code_to_source.get(code, code),
                     "source_version": source_version,  # harmonized Ensembl release
+                    "source_matrix_path": str(source_path),
+                    "sample_qc": sample_qc,
+                    "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
+                    "n_source_samples": len(source_samples),
                     "n_cohort_samples": len(samples),
+                    **qc_counts,
                 }
             )
 
@@ -222,7 +295,6 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
         # Proteoform key space: collapse identical-protein members per sample, then
         # build the same percentile + within-sample summaries on the reduced space so
         # every downstream read can compare/quantify/plot on one collapsed key space.
-        from oncoref.expression_builders import sample_columns
         from oncoref.proteoforms import collapse_to_proteoforms
 
         bio_pf = collapse_to_proteoforms(bio_df, scope=_PROTEOFORM_SCOPE, sample_cols=samples)
@@ -240,9 +312,37 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
             if corr is not None:
                 corrs.append(corr)
                 msg += f"  p95-corr={corr:.4f}"
+        if len(samples) != len(source_samples):
+            msg += f"  sample_qc={sample_qc}:{len(samples)}/{len(source_samples)}"
         print(msg, flush=True)
 
     pd.DataFrame(provenance).to_csv(rep_dir / "_provenance.csv", index=False)
+    if qc_manifest:
+        pd.concat(qc_manifest, ignore_index=True).to_csv(
+            out / "source-matrix-sample-qc.csv", index=False
+        )
+    pd.DataFrame(build_rows).to_csv(out / "expression-artifact-build-metadata.csv", index=False)
+    metadata = {
+        "artifact": "expression-derived-shards",
+        "sample_qc": sample_qc,
+        "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
+        "sample_qc_manifest": "source-matrix-sample-qc.csv",
+        "cohort_metadata": "expression-artifact-build-metadata.csv",
+        "n_cohorts": len(build_rows),
+        "n_source_samples": int(sum(row["n_source_samples"] for row in build_rows)),
+        "n_cohort_samples": int(sum(row["n_cohort_samples"] for row in build_rows)),
+        "derived_artifacts": [
+            "clean",
+            _PCT_DS.gene_dir,
+            _PCT_DS.subdir(proteoform=True, scope=_PROTEOFORM_SCOPE),
+            SHARD_DATASETS["representatives"].gene_dir,
+            _WS_DS.gene_dir,
+            _WS_DS.subdir(proteoform=True, scope=_PROTEOFORM_SCOPE),
+        ],
+    }
+    (out / "expression-artifact-build-metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n"
+    )
     if validate and corrs:
         # nan-robust: a cohort whose reference vector is constant/empty yields a
         # nan correlation that must not poison the summary.
@@ -287,6 +387,12 @@ def main(argv=None) -> None:
     p.add_argument("--out", required=True, type=Path, help="Staging output dir (not oncoref/data)")
     p.add_argument("--limit", type=int, default=None, help="Only the first N codes (a test run)")
     p.add_argument("--validate", action="store_true", help="Correlate vs the reference artifacts")
+    p.add_argument(
+        "--sample-qc",
+        choices=("pass", "pass_or_warn", "all"),
+        default="pass",
+        help="Which source-matrix samples feed rebuilt artifacts (default: pass)",
+    )
     args = p.parse_args(argv)
     rebuild(
         args.cache.expanduser(),
@@ -294,6 +400,7 @@ def main(argv=None) -> None:
         args.out.expanduser(),
         limit=args.limit,
         validate=args.validate,
+        sample_qc=args.sample_qc,
     )
 
 

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -6,6 +6,7 @@
 
 import glob
 import importlib.util
+import json
 import os
 import sys
 from pathlib import Path
@@ -212,6 +213,106 @@ def test_representatives_generator_writes_shards_and_provenance(tmp_path):
         assert col in prov.columns
     # Unregistered code -> source_cohort falls back to the code itself.
     assert (prov["source_cohort"] == "COHORT_A").all()
+
+
+def _write_rebuild_inputs(tmp_path):
+    cache = tmp_path / "cache"
+    ref = tmp_path / "ref"
+    source_dir = cache / "TEST_SOURCE" / "derived"
+    source_dir.mkdir(parents=True)
+    ref.mkdir()
+    _matrix(
+        ["ENSG000001", "ENSG000002", "ENSG000003"],
+        ["pass_sample", "warn_sample", "fail_sample"],
+        np.array(
+            [
+                [10.0, 20.0, 30.0],
+                [40.0, 50.0, 60.0],
+                [70.0, 80.0, 90.0],
+            ]
+        ),
+    ).to_parquet(source_dir / "X_per_sample_tpm.parquet", index=False)
+    _write_cohort(ref, "X", ["ENSG000001"], ["reference"], np.array([[1.0]]))
+    return cache, ref
+
+
+def _patch_rebuild_registry(monkeypatch, gen):
+    monkeypatch.setattr(
+        gen,
+        "source_registry",
+        lambda: pd.DataFrame({"cancer_code": ["X"], "source_cohort": ["TEST_SOURCE"]}),
+    )
+    monkeypatch.setattr(gen, "cohort_source_version", lambda code: "test-source-version")
+    monkeypatch.setattr(
+        gen,
+        "sample_expression_qc_from_matrix",
+        lambda raw, cancer_type: pd.DataFrame(
+            {
+                "cancer_code": [cancer_type, cancer_type, cancer_type],
+                "sample_id": ["pass_sample", "warn_sample", "fail_sample"],
+                "sample_qc_status": ["pass", "warn", "fail"],
+                "sample_qc_reasons": ["", "tpm_proxy_scale", "low_detected_genes"],
+            }
+        ),
+    )
+
+
+def test_rebuild_expression_artifacts_defaults_to_qc_passing_samples(tmp_path, monkeypatch):
+    gen = _load_script("rebuild_expression_artifacts")
+    cache, ref = _write_rebuild_inputs(tmp_path)
+    _patch_rebuild_registry(monkeypatch, gen)
+    out = tmp_path / "out"
+
+    gen.rebuild(cache, ref, out, limit=None, validate=False, sample_qc="pass")
+
+    clean = pd.read_parquet(out / "clean" / "X.parquet")
+    assert [c for c in clean.columns if c not in ("Ensembl_Gene_ID", "Symbol")] == ["pass_sample"]
+
+    reps = pd.read_parquet(out / "cancer-reference-expression-representatives" / "X.parquet")
+    assert [c for c in reps.columns if c not in ("Ensembl_Gene_ID", "Symbol")] == ["X__rep1"]
+
+    prov = pd.read_csv(out / "cancer-reference-expression-representatives" / "_provenance.csv")
+    assert prov.loc[0, "n_source_samples"] == 3
+    assert prov.loc[0, "n_cohort_samples"] == 1
+    assert prov.loc[0, "sample_qc"] == "pass"
+    assert prov.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v1"
+    assert prov.loc[0, "n_qc_pass"] == 1
+    assert prov.loc[0, "n_qc_warn"] == 1
+    assert prov.loc[0, "n_qc_fail"] == 1
+
+    qc = pd.read_csv(out / "source-matrix-sample-qc.csv")
+    assert list(qc["sample_id"]) == ["pass_sample", "warn_sample", "fail_sample"]
+
+    build_meta = pd.read_csv(out / "expression-artifact-build-metadata.csv")
+    assert build_meta.loc[0, "n_source_samples"] == 3
+    assert build_meta.loc[0, "n_cohort_samples"] == 1
+    assert build_meta.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v1"
+
+    metadata = json.loads((out / "expression-artifact-build-metadata.json").read_text())
+    assert metadata["sample_qc"] == "pass"
+    assert metadata["sample_qc_manifest"] == "source-matrix-sample-qc.csv"
+    assert metadata["n_source_samples"] == 3
+    assert metadata["n_cohort_samples"] == 1
+
+
+def test_rebuild_expression_artifacts_keeps_all_samples_when_requested(tmp_path, monkeypatch):
+    gen = _load_script("rebuild_expression_artifacts")
+    cache, ref = _write_rebuild_inputs(tmp_path)
+    _patch_rebuild_registry(monkeypatch, gen)
+    out = tmp_path / "out"
+
+    gen.rebuild(cache, ref, out, limit=None, validate=False, sample_qc="all")
+
+    clean = pd.read_parquet(out / "clean" / "X.parquet")
+    assert [c for c in clean.columns if c not in ("Ensembl_Gene_ID", "Symbol")] == [
+        "pass_sample",
+        "warn_sample",
+        "fail_sample",
+    ]
+    build_meta = pd.read_csv(out / "expression-artifact-build-metadata.csv")
+    assert build_meta.loc[0, "sample_qc"] == "all"
+    assert build_meta.loc[0, "n_source_samples"] == 3
+    assert build_meta.loc[0, "n_cohort_samples"] == 3
 
 
 # ---------- real-data parity (skipped without the maintainer's matrix cache) ----------

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -463,6 +463,65 @@ def test_housekeeping_normalize_divides_by_panel_geomean(monkeypatch):
     assert out.loc[1, "s1"] / out.loc[0, "s1"] == pytest.approx(0.5)
 
 
+def test_housekeeping_normalize_blanks_sparse_housekeeping_denominator(monkeypatch):
+    import oncoref.gene_families as gf
+
+    panel = frozenset({"HK1", "HK2", "HK3"})
+    monkeypatch.setattr(gf, "clean_tpm_biological_housekeeping_gene_ids", lambda: panel)
+    df = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["HK1", "HK2", "HK3", "ENSG_X"],
+            "Symbol": ["HK1", "HK2", "HK3", "X"],
+            "good": [100.0, 120.0, 80.0, 50.0],
+            "sparse": [0.0, 0.0, 100.0, 50.0],
+        }
+    )
+
+    with pytest.warns(RuntimeWarning, match="housekeeping normalization skipped"):
+        out = expression._housekeeping_normalize(df, ["good", "sparse"])
+
+    assert out.loc[out["Symbol"] == "X", "good"].iloc[0] > 0
+    assert out["sparse"].isna().all()
+
+
+def test_sample_expression_qc_flags_sparse_samples(tmp_path, monkeypatch):
+    import oncoref.gene_families as gf
+
+    panel = frozenset({"HK1", "HK2", "HK3"})
+    monkeypatch.setattr(gf, "clean_tpm_biological_housekeeping_gene_ids", lambda: panel)
+    raw = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["HK1", "HK2", "HK3", "ENSG_A", "ENSG_B", "ENSG_C"],
+            "Symbol": ["HK1", "HK2", "HK3", "A", "B", "C"],
+            "good": [100.0, 120.0, 80.0, 100.0, 100.0, 100.0],
+            "sparse": [0.0, 0.0, 20.0, 1000.0, 0.0, 0.0],
+        }
+    )
+    path = tmp_path / "X.parquet"
+    raw.to_parquet(path, index=False)
+    monkeypatch.setattr(expression.source_matrices, "ensure", lambda code: path)
+    monkeypatch.setattr(
+        expression.source_matrices,
+        "cohort_info",
+        lambda code: {"source_cohort": "TEST_SOURCE", "n_samples": 2},
+    )
+
+    qc = expression.sample_expression_qc(
+        "X",
+        min_detected_genes=3,
+        min_housekeeping_detected=2,
+        max_top_gene_fraction=0.8,
+    ).set_index("sample_id")
+
+    assert bool(qc.loc["good", "passes_expression_qc"]) is True
+    assert qc.loc["good", "housekeeping_genes_detected"] == 3
+    assert bool(qc.loc["sparse", "passes_expression_qc"]) is False
+    assert qc.loc["sparse", "n_detected_genes"] == 2
+    assert qc.loc["sparse", "housekeeping_genes_detected"] == 1
+    assert "low_housekeeping_detection" in qc.loc["sparse", "qc_flags"]
+    assert "high_top_gene_fraction" in qc.loc["sparse", "qc_flags"]
+
+
 def test_per_sample_expression_gene_and_proteoform_levels(tmp_path, monkeypatch):
     # ENSG1+ENSG2 are an identical-protein group; per_sample_expression(proteoform=True)
     # sums them per sample. Gene-level and proteoform-level are both available.

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -486,6 +486,7 @@ def test_housekeeping_normalize_blanks_sparse_housekeeping_denominator(monkeypat
 
 def test_sample_expression_qc_flags_sparse_samples(tmp_path, monkeypatch):
     import oncoref.gene_families as gf
+    from oncoref import expression_registry
 
     panel = frozenset({"HK1", "HK2", "HK3"})
     monkeypatch.setattr(gf, "clean_tpm_biological_housekeeping_gene_ids", lambda: panel)
@@ -505,6 +506,20 @@ def test_sample_expression_qc_flags_sparse_samples(tmp_path, monkeypatch):
         "cohort_info",
         lambda code: {"source_cohort": "TEST_SOURCE", "n_samples": 2},
     )
+    monkeypatch.setattr(
+        expression_registry,
+        "sources_for_cancer_code",
+        lambda code: [
+            expression_registry.ExpressionSource(
+                id="test-source",
+                category="expression",
+                cancer_codes=("X",),
+                source_type="gdc",
+                unit="TPM",
+                source_cohort="TEST_SOURCE",
+            )
+        ],
+    )
 
     qc = expression.sample_expression_qc(
         "X",
@@ -514,12 +529,56 @@ def test_sample_expression_qc_flags_sparse_samples(tmp_path, monkeypatch):
     ).set_index("sample_id")
 
     assert bool(qc.loc["good", "passes_expression_qc"]) is True
+    assert qc.loc["good", "sample_qc_status"] == "pass"
+    assert qc.loc["good", "source_scale_class"] == "linear_rnaseq_tpm"
+    assert bool(qc.loc["good", "linear_tpm_comparable"]) is True
     assert qc.loc["good", "housekeeping_genes_detected"] == 3
     assert bool(qc.loc["sparse", "passes_expression_qc"]) is False
+    assert qc.loc["sparse", "sample_qc_status"] == "fail"
+    assert qc.loc["sparse", "n_detected_raw"] == 2
+    assert qc.loc["sparse", "n_detected_clean_biological"] == 2
     assert qc.loc["sparse", "n_detected_genes"] == 2
     assert qc.loc["sparse", "housekeeping_genes_detected"] == 1
     assert "low_housekeeping_detection" in qc.loc["sparse", "qc_flags"]
+    assert "low_housekeeping_detection" in qc.loc["sparse", "sample_qc_reasons"]
     assert "high_top_gene_fraction" in qc.loc["sparse", "qc_flags"]
+
+
+def test_per_sample_expression_filters_by_sample_qc(tmp_path, monkeypatch):
+    raw = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG1", "ENSG2"],
+            "Symbol": ["A", "B"],
+            "pass_sample": [10.0, 20.0],
+            "warn_sample": [30.0, 40.0],
+            "fail_sample": [50.0, 60.0],
+        }
+    )
+    path = tmp_path / "X.parquet"
+    raw.to_parquet(path, index=False)
+    expression._load_per_sample_matrix.cache_clear()
+    monkeypatch.setattr(expression.source_matrices, "ensure", lambda code: path)
+    monkeypatch.setattr(
+        expression,
+        "sample_expression_qc",
+        lambda code, **k: pd.DataFrame(
+            {
+                "sample_id": ["pass_sample", "warn_sample", "fail_sample"],
+                "sample_qc_status": ["pass", "warn", "fail"],
+            }
+        ),
+    )
+
+    passed = expression.per_sample_expression("X", normalize="tpm_raw", sample_qc="pass")
+    assert expression.sample_columns(passed) == ["pass_sample"]
+
+    pass_or_warn = expression.per_sample_expression(
+        "X", normalize="tpm_raw", sample_qc="pass_or_warn"
+    )
+    assert expression.sample_columns(pass_or_warn) == ["pass_sample", "warn_sample"]
+
+    all_samples = expression.per_sample_expression("X", normalize="tpm_raw", sample_qc="all")
+    assert expression.sample_columns(all_samples) == ["pass_sample", "warn_sample", "fail_sample"]
 
 
 def test_per_sample_expression_gene_and_proteoform_levels(tmp_path, monkeypatch):
@@ -612,8 +671,8 @@ def test_cohort_mean_expression_threads_proteoform_and_scope(monkeypatch):
 
     seen = {}
 
-    def fake_per_sample(code, *, normalize, auto_fetch, proteoform, scope):
-        seen.update(proteoform=proteoform, scope=scope)
+    def fake_per_sample(code, *, normalize, auto_fetch, proteoform, scope, sample_qc):
+        seen.update(proteoform=proteoform, scope=scope, sample_qc=sample_qc)
         return pd.DataFrame(
             {
                 "proteoform_key": ["E1"],
@@ -627,7 +686,7 @@ def test_cohort_mean_expression_threads_proteoform_and_scope(monkeypatch):
 
     monkeypatch.setattr(expression, "per_sample_expression", fake_per_sample)
     out = expression.cohort_mean_expression("X", proteoform=True, scope="genome")
-    assert seen == {"proteoform": True, "scope": "genome"}
+    assert seen == {"proteoform": True, "scope": "genome", "sample_qc": "pass"}
     assert expression_level(out) == "proteoform"  # proteoform_key carried through
 
 
@@ -968,9 +1027,9 @@ def test_pooled_cohort_stats_merges_alt_haplotype_aliases(tmp_path, monkeypatch)
     monkeypatch.setattr(expression.source_matrices, "ensure", lambda code: paths[code])
     monkeypatch.setattr(expression, "_resolve_cancer_types", lambda ct, **k: list(ct))
 
-    out = expression.pooled_cohort_stats(["A", "B"], normalize="tpm_raw").set_index(
-        "Ensembl_Gene_ID"
-    )
+    out = expression.pooled_cohort_stats(
+        ["A", "B"], normalize="tpm_raw", sample_qc="all"
+    ).set_index("Ensembl_Gene_ID")
     assert list(out.index) == [primary]  # one canonical row, the primary id
     assert alt not in set(out.index)
     # both cohorts pooled onto it (mean of the two single-sample cohorts)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -391,3 +391,35 @@ def test_tpm_to_housekeeping_normalized_blanks_column_with_no_panel():
     )
     assert out["empty_TPM"].isna().all()
     assert stats["columns"]["empty_TPM"]["denominator"] == 0.0
+
+
+def test_tpm_to_housekeeping_normalized_gates_sparse_detected_panel():
+    hk = ["HK1", "HK2", "HK3"]
+    df = pd.DataFrame(
+        {
+            "Symbol": ["HK1", "HK2", "HK3", "GENE"],
+            "Ensembl_Gene_ID": [*hk, "ENSG_X"],
+            "good_TPM": [0.0, 100.0, 100.0, 50.0],
+            "sparse_TPM": [0.0, 0.0, 100.0, 50.0],
+        }
+    )
+
+    with pytest.warns(RuntimeWarning, match="housekeeping normalization skipped"):
+        out, stats = norm.tpm_to_housekeeping_normalized(
+            df,
+            value_cols=["good_TPM", "sparse_TPM"],
+            panel_ids=hk,
+            panel_name="test_housekeeping",
+            min_panel_detected=2,
+            drop_zero_panel_values=True,
+            warn_on_unreliable=True,
+        )
+
+    assert out.loc[out["Symbol"] == "GENE", "good_TPM"].iloc[0] == pytest.approx(
+        50 / 100.1, rel=1e-3
+    )
+    assert out["sparse_TPM"].isna().all()
+    assert stats["columns"]["good_TPM"]["panel_genes_detected"] == 2
+    assert stats["columns"]["good_TPM"]["panel_genes_zero"] == 1
+    assert stats["columns"]["sparse_TPM"]["panel_genes_detected"] == 1
+    assert stats["columns"]["sparse_TPM"]["reason"] == "only 1 nonzero housekeeping panel genes"


### PR DESCRIPTION
## Summary

Stacked on #206. This wires the sample-QC contract into the offline expression artifact rebuild path so regenerated derived shards no longer silently use all source samples.

- factors `sample_expression_qc_from_matrix(...)` out of `sample_expression_qc(...)` so read-time QC and rebuild-time QC share one policy core;
- adds `SAMPLE_EXPRESSION_QC_POLICY_VERSION = "sample_expression_qc_v1"`;
- makes `scripts/rebuild_expression_artifacts.py` default to `--sample-qc pass`, with explicit `pass_or_warn` and `all` modes;
- filters the rebuilt clean, percentile, representative, within-sample, and proteoform summary shards to the selected samples;
- emits `source-matrix-sample-qc.csv`, `expression-artifact-build-metadata.csv`, and `expression-artifact-build-metadata.json` in the staging directory;
- records source-sample counts, selected cohort-sample counts, QC policy/version, and pass/warn/fail counts in representative provenance and build metadata;
- documents the rebuild QC behavior in the API guide.

## Context

Addresses the generated-artifact part of #203 and #205: #206 adds runtime/read-path sample QC, but pirlygenes cannot delegate representative samples, percentiles, within-sample summaries, or `cancer_reference_expression` until the generator defaults to QC-passing source samples and release artifacts carry the QC policy/manifest.

This PR deliberately does not regenerate or release a new data bundle. After #206 and this stacked PR land, the remaining release work is: rebuild the expression bundle under this policy, publish the bundle with manifest/checksum per #14/#21/#209, and run parity checks for gene universe, cohort coverage, representatives, percentiles, and `cancer_reference_expression` (#191/#193/#207/#208/#210).

## Validation

- `python -m pytest tests/test_build_generators.py tests/test_expression.py::test_sample_expression_qc_flags_sparse_samples tests/test_expression.py::test_per_sample_expression_filters_by_sample_qc`
- `./lint.sh`
- `./test.sh` (504 passed; existing matplotlib open-figure warning)
- `mkdocs build --strict`
