### PR TITLE
[codex] Declare PyPI trusted publishing environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/oncoref/
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Summary

- Add the `pypi` deployment environment to the release publish job so GitHub OIDC tokens include a stable `environment` claim.
- Keep the environment URL pointed at the oncoref PyPI project.

Closes #215.

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`

## Notes

The PyPI project trusted-publisher entry should be configured to match repository `pirl-unc/oncoref`, workflow `.github/workflows/release.yml`, and environment `pypi`. The next GitHub Release will exercise the real trusted-publishing exchange.