### PR TITLE
[codex] Apply sample QC to expression artifact rebuilds

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -117,7 +117,11 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   defaults to `"all"` for forensic access, while live summaries such as
   `cohort_stats` and `pooled_cohort_stats` default to QC-passing samples.
 - `oncoref.expression_builders` — pure build-time cores used by data-bundle
-  generation scripts.
+  generation scripts. `scripts/rebuild_expression_artifacts.py` applies the same
+  sample-QC policy to derived shards by default (`--sample-qc pass`) and emits
+  `source-matrix-sample-qc.csv` plus `expression-artifact-build-metadata.*` in
+  the staging directory so bundle releases can record which source samples fed
+  percentiles, representatives, and within-sample summaries.
 - `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,
   log transforms, percentile ranks, and housekeeping normalization.
 

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -274,6 +274,7 @@ def available_percentile_cohorts(*, proteoform: bool = False, scope: str = "cta"
 
 _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p", "tpm_clean_hk")
 _SAMPLE_QC_MODES = ("all", "pass", "pass_or_warn")
+SAMPLE_EXPRESSION_QC_POLICY_VERSION = "sample_expression_qc_v1"
 DEFAULT_MIN_DETECTED_GENES_FOR_QC = 5000
 DEFAULT_MIN_HOUSEKEEPING_GENES_FOR_QC = 10
 DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC = 0.20
@@ -378,25 +379,28 @@ def _apply_sample_qc_filter(
     return df[[*id_columns(df), *keep_samples]].copy()
 
 
-def sample_expression_qc(
-    cancer_type,
+def sample_expression_qc_from_matrix(
+    raw: pd.DataFrame,
     *,
-    auto_fetch: bool = True,
+    cancer_type=None,
+    source_metadata: dict[str, str | bool | None] | None = None,
     min_detected_genes: int = DEFAULT_MIN_DETECTED_GENES_FOR_QC,
     min_housekeeping_detected: int | None = None,
     max_top_gene_fraction: float = DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC,
     max_top10_gene_fraction: float = DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC,
 ) -> pd.DataFrame:
-    """Per-sample QC metrics for a cohort's raw expression matrix.
+    """Per-sample QC metrics for an already-loaded raw expression matrix.
 
-    This is an audit surface over the raw per-sample matrix before clean-TPM
-    normalization. It is designed to catch source/sample artifacts such as literal-zero
-    sparsity in otherwise universal genes, while still making source-type caveats
-    explicit (for example microarray TPM-proxy sources). It does not exclude samples by
-    itself; downstream code can use ``passes_expression_qc`` or inspect ``qc_flags``.
+    This is the shared policy core behind the public read-path QC and the offline
+    artifact rebuild. It canonicalizes gene rows before measuring sparsity so the QC
+    contract is evaluated in the same gene-ID space used by expression accessors.
     """
-    code = resolve_cancer_type(cancer_type, strict=False) or cancer_type
-    raw = per_sample_expression(code, normalize="tpm_raw", auto_fetch=auto_fetch, sample_qc="all")
+    code = (
+        resolve_cancer_type(cancer_type, strict=False) or cancer_type
+        if cancer_type is not None
+        else None
+    )
+    raw = _canonicalize_gene_rows(raw, sample_cols=sample_columns(raw)).reset_index(drop=True)
     samples = sample_columns(raw)
     if not samples:
         return pd.DataFrame()
@@ -415,7 +419,29 @@ def sample_expression_qc(
         if min_housekeeping_detected is not None
         else _min_housekeeping_detected(panel_ids)
     )
-    meta = _selected_expression_source_metadata(str(code))
+    if source_metadata is None:
+        meta = (
+            _selected_expression_source_metadata(str(code))
+            if code is not None
+            else {
+                "source_cohort": None,
+                "source_type": None,
+                "unit": None,
+                "source_scale_class": "unknown",
+                "linear_tpm_comparable": False,
+                "tpm_proxy": False,
+            }
+        )
+    else:
+        meta = {
+            "source_cohort": None,
+            "source_type": None,
+            "unit": None,
+            "source_scale_class": "unknown",
+            "linear_tpm_comparable": False,
+            "tpm_proxy": False,
+            **source_metadata,
+        }
 
     rows: list[dict] = []
     for sample in samples:
@@ -472,6 +498,7 @@ def sample_expression_qc(
         rows.append(
             {
                 "cancer_code": code,
+                "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
                 "source_cohort": meta["source_cohort"],
                 "source_type": meta["source_type"],
                 "unit": meta["unit"],
@@ -513,6 +540,35 @@ def sample_expression_qc(
             }
         )
     return pd.DataFrame(rows)
+
+
+def sample_expression_qc(
+    cancer_type,
+    *,
+    auto_fetch: bool = True,
+    min_detected_genes: int = DEFAULT_MIN_DETECTED_GENES_FOR_QC,
+    min_housekeeping_detected: int | None = None,
+    max_top_gene_fraction: float = DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC,
+    max_top10_gene_fraction: float = DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC,
+) -> pd.DataFrame:
+    """Per-sample QC metrics for a cohort's raw expression matrix.
+
+    This is an audit surface over the raw per-sample matrix before clean-TPM
+    normalization. It is designed to catch source/sample artifacts such as literal-zero
+    sparsity in otherwise universal genes, while still making source-type caveats
+    explicit (for example microarray TPM-proxy sources). It does not exclude samples by
+    itself; downstream code can use ``passes_expression_qc`` or inspect ``qc_flags``.
+    """
+    code = resolve_cancer_type(cancer_type, strict=False) or cancer_type
+    raw = per_sample_expression(code, normalize="tpm_raw", auto_fetch=auto_fetch, sample_qc="all")
+    return sample_expression_qc_from_matrix(
+        raw,
+        cancer_type=code,
+        min_detected_genes=min_detected_genes,
+        min_housekeeping_detected=min_housekeeping_detected,
+        max_top_gene_fraction=max_top_gene_fraction,
+        max_top10_gene_fraction=max_top10_gene_fraction,
+    )
 
 
 def per_sample_expression(

--- a/scripts/rebuild_expression_artifacts.py
+++ b/scripts/rebuild_expression_artifacts.py
@@ -18,6 +18,7 @@ expression bundle:
     raw per-sample TPM matrices  (candidate source cohorts per cancer code)
         -> select ONE source per code  (the source-matrices.csv choice; never pool)
         -> clean_tpm                   (two-compartment biological view)
+        -> sample QC filter            (pass by default; opt out with --sample-qc all)
         -> drop technical genes        (biology-only, matching the shipped artifact)
         -> percentile vectors / n=5 representatives / within-sample top-fractions
 
@@ -32,10 +33,12 @@ one source per code; it never pools) — so the artifacts match the shipped refe
 Outputs land under ``--out`` (a staging dir, NOT ``oncoref/data`` — the artifacts
 are large and ship via the release tarball, so they're never committed):
 
-    <out>/clean/<CODE>.parquet                                 (clean-TPM matrix, full)
+    <out>/clean/<CODE>.parquet                                 (QC-filtered clean TPM)
     <out>/cancer-reference-expression-percentiles/<CODE>.parquet      (biology-only)
     <out>/cancer-reference-expression-representatives/<CODE>.parquet + _provenance.csv
     <out>/cancer-reference-expression-within-sample-top5/<CODE>.parquet (biology-only)
+    <out>/source-matrix-sample-qc.csv                          (per-sample QC manifest)
+    <out>/expression-artifact-build-metadata.json              (QC/build policy metadata)
 
 ``--validate`` additionally correlates each rebuilt percentile vector against the
 reference artifact in ``--ref`` and prints the per-code agreement.
@@ -50,6 +53,7 @@ Run:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -60,7 +64,14 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from oncoref.cancer_types import cohort_source_version
-from oncoref.expression import SHARD_DATASETS, _canonicalize_gene_rows, sample_columns
+from oncoref.expression import (
+    SAMPLE_EXPRESSION_QC_POLICY_VERSION,
+    SHARD_DATASETS,
+    _canonicalize_gene_rows,
+    _validate_sample_qc,
+    sample_columns,
+    sample_expression_qc_from_matrix,
+)
 from oncoref.expression_builders import (
     cohort_medoids,
     cohort_percentile_vectors,
@@ -142,15 +153,19 @@ def _select_source(code: str, candidates: list[tuple[str, Path]], code_to_source
     return max(candidates, key=lambda c: pd.read_parquet(c[1]).shape[1])[1]
 
 
-def build_clean(path: Path) -> pd.DataFrame:
-    """Clean-TPM matrix for one source's per-sample matrix (genes x samples + ids).
+def read_raw(path: Path) -> pd.DataFrame:
+    """Canonical raw per-sample matrix for one source (genes x samples + ids).
 
     Canonicalize the raw matrix first (sum alt-haplotype/patch copies in LINEAR TPM,
     relabel retired ids), exactly as the runtime `_load_per_sample_matrix` does, so the
     shipped percentile/representative shards are natively dense in the canonical gene-ID
     space and match the on-the-fly recompute path (oncoref#135 item 6)."""
     raw = pd.read_parquet(path)
-    raw = _canonicalize_gene_rows(raw, sample_cols=sample_columns(raw))
+    return _canonicalize_gene_rows(raw, sample_cols=sample_columns(raw)).reset_index(drop=True)
+
+
+def build_clean(raw: pd.DataFrame) -> pd.DataFrame:
+    """Clean-TPM matrix for one source's per-sample matrix (genes x samples + ids)."""
     samples = [c for c in raw.columns if c not in _BASE]
     gene_table = raw[_BASE]
     clean = clean_tpm(raw[samples], gene_table=gene_table)
@@ -167,7 +182,35 @@ def _drop_technical(df: pd.DataFrame) -> pd.DataFrame:
     return df[~unversioned.isin(censored)].reset_index(drop=True)
 
 
-def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: bool) -> None:
+def _samples_for_qc(samples: list[str], qc: pd.DataFrame, sample_qc: str) -> list[str]:
+    mode = _validate_sample_qc(sample_qc)
+    if mode == "all":
+        return samples
+    if qc.empty:
+        return []
+    status = dict(zip(qc["sample_id"].astype(str), qc["sample_qc_status"].astype(str)))
+    if mode == "pass":
+        allowed = {"pass"}
+    else:
+        allowed = {"pass", "warn"}
+    return [s for s in samples if status.get(str(s)) in allowed]
+
+
+def _qc_counts(qc: pd.DataFrame) -> dict[str, int]:
+    counts = qc["sample_qc_status"].value_counts().to_dict() if not qc.empty else {}
+    return {f"n_qc_{name}": int(counts.get(name, 0)) for name in ("pass", "warn", "fail")}
+
+
+def rebuild(
+    cache: Path,
+    ref: Path,
+    out: Path,
+    *,
+    limit: int | None,
+    validate: bool,
+    sample_qc: str = "pass",
+) -> None:
+    sample_qc = _validate_sample_qc(sample_qc)
     by_code = discover(cache, ref)
     reg = source_registry()
     code_to_source = dict(zip(reg["cancer_code"].astype(str), reg["source_cohort"].astype(str)))
@@ -186,11 +229,23 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
         d.mkdir(parents=True, exist_ok=True)
 
     provenance: list[dict] = []
+    qc_manifest: list[pd.DataFrame] = []
+    build_rows: list[dict] = []
     corrs: list[float] = []
     for code in codes:
         source_path = _select_source(code, by_code[code], code_to_source)
-        clean_df = build_clean(source_path)
-        samples = [c for c in clean_df.columns if c not in _BASE]
+        raw_df = read_raw(source_path)
+        source_samples = [c for c in raw_df.columns if c not in _BASE]
+        qc = sample_expression_qc_from_matrix(raw_df, cancer_type=code)
+        if not qc.empty:
+            qc = qc.assign(source_matrix_path=str(source_path))
+            qc_manifest.append(qc)
+        samples = _samples_for_qc(source_samples, qc, sample_qc)
+        if not samples:
+            raise ValueError(f"{code}: sample_qc={sample_qc!r} leaves no source samples")
+
+        clean_df = build_clean(raw_df)
+        clean_df = clean_df[[*_BASE, *samples]].copy()
         clean_df.to_parquet(clean_dir / f"{code}.parquet", index=False, compression="zstd")
 
         # Biological view (technical genes dropped) for the percentile + within-sample
@@ -206,13 +261,31 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
         reps = reps.rename(columns=dict(zip(rep_cols, rep_ids)))
         reps.to_parquet(rep_dir / f"{code}.parquet", index=False, compression="zstd")
         source_version = cohort_source_version(code)
+        qc_counts = _qc_counts(qc)
+        build_row = {
+            "cancer_code": code,
+            "source_cohort": code_to_source.get(code, code),
+            "source_version": source_version,
+            "source_matrix_path": str(source_path),
+            "sample_qc": sample_qc,
+            "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
+            "n_source_samples": len(source_samples),
+            "n_cohort_samples": len(samples),
+            **qc_counts,
+        }
+        build_rows.append(build_row)
         for rep_id in rep_ids:
             provenance.append(
                 {
                     "representative_id": rep_id,
                     "source_cohort": code_to_source.get(code, code),
                     "source_version": source_version,  # harmonized Ensembl release
+                    "source_matrix_path": str(source_path),
+                    "sample_qc": sample_qc,
+                    "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
+                    "n_source_samples": len(source_samples),
                     "n_cohort_samples": len(samples),
+                    **qc_counts,
                 }
             )
 
@@ -222,7 +295,6 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
         # Proteoform key space: collapse identical-protein members per sample, then
         # build the same percentile + within-sample summaries on the reduced space so
         # every downstream read can compare/quantify/plot on one collapsed key space.
-        from oncoref.expression_builders import sample_columns
         from oncoref.proteoforms import collapse_to_proteoforms
 
         bio_pf = collapse_to_proteoforms(bio_df, scope=_PROTEOFORM_SCOPE, sample_cols=samples)
@@ -240,9 +312,37 @@ def rebuild(cache: Path, ref: Path, out: Path, *, limit: int | None, validate: b
             if corr is not None:
                 corrs.append(corr)
                 msg += f"  p95-corr={corr:.4f}"
+        if len(samples) != len(source_samples):
+            msg += f"  sample_qc={sample_qc}:{len(samples)}/{len(source_samples)}"
         print(msg, flush=True)
 
     pd.DataFrame(provenance).to_csv(rep_dir / "_provenance.csv", index=False)
+    if qc_manifest:
+        pd.concat(qc_manifest, ignore_index=True).to_csv(
+            out / "source-matrix-sample-qc.csv", index=False
+        )
+    pd.DataFrame(build_rows).to_csv(out / "expression-artifact-build-metadata.csv", index=False)
+    metadata = {
+        "artifact": "expression-derived-shards",
+        "sample_qc": sample_qc,
+        "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
+        "sample_qc_manifest": "source-matrix-sample-qc.csv",
+        "cohort_metadata": "expression-artifact-build-metadata.csv",
+        "n_cohorts": len(build_rows),
+        "n_source_samples": int(sum(row["n_source_samples"] for row in build_rows)),
+        "n_cohort_samples": int(sum(row["n_cohort_samples"] for row in build_rows)),
+        "derived_artifacts": [
+            "clean",
+            _PCT_DS.gene_dir,
+            _PCT_DS.subdir(proteoform=True, scope=_PROTEOFORM_SCOPE),
+            SHARD_DATASETS["representatives"].gene_dir,
+            _WS_DS.gene_dir,
+            _WS_DS.subdir(proteoform=True, scope=_PROTEOFORM_SCOPE),
+        ],
+    }
+    (out / "expression-artifact-build-metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n"
+    )
     if validate and corrs:
         # nan-robust: a cohort whose reference vector is constant/empty yields a
         # nan correlation that must not poison the summary.
@@ -287,6 +387,12 @@ def main(argv=None) -> None:
     p.add_argument("--out", required=True, type=Path, help="Staging output dir (not oncoref/data)")
     p.add_argument("--limit", type=int, default=None, help="Only the first N codes (a test run)")
     p.add_argument("--validate", action="store_true", help="Correlate vs the reference artifacts")
+    p.add_argument(
+        "--sample-qc",
+        choices=("pass", "pass_or_warn", "all"),
+        default="pass",
+        help="Which source-matrix samples feed rebuilt artifacts (default: pass)",
+    )
     args = p.parse_args(argv)
     rebuild(
         args.cache.expanduser(),
@@ -294,6 +400,7 @@ def main(argv=None) -> None:
         args.out.expanduser(),
         limit=args.limit,
         validate=args.validate,
+        sample_qc=args.sample_qc,
     )
 
 

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -6,6 +6,7 @@
 
 import glob
 import importlib.util
+import json
 import os
 import sys
 from pathlib import Path
@@ -212,6 +213,106 @@ def test_representatives_generator_writes_shards_and_provenance(tmp_path):
         assert col in prov.columns
     # Unregistered code -> source_cohort falls back to the code itself.
     assert (prov["source_cohort"] == "COHORT_A").all()
+
+
+def _write_rebuild_inputs(tmp_path):
+    cache = tmp_path / "cache"
+    ref = tmp_path / "ref"
+    source_dir = cache / "TEST_SOURCE" / "derived"
+    source_dir.mkdir(parents=True)
+    ref.mkdir()
+    _matrix(
+        ["ENSG000001", "ENSG000002", "ENSG000003"],
+        ["pass_sample", "warn_sample", "fail_sample"],
+        np.array(
+            [
+                [10.0, 20.0, 30.0],
+                [40.0, 50.0, 60.0],
+                [70.0, 80.0, 90.0],
+            ]
+        ),
+    ).to_parquet(source_dir / "X_per_sample_tpm.parquet", index=False)
+    _write_cohort(ref, "X", ["ENSG000001"], ["reference"], np.array([[1.0]]))
+    return cache, ref
+
+
+def _patch_rebuild_registry(monkeypatch, gen):
+    monkeypatch.setattr(
+        gen,
+        "source_registry",
+        lambda: pd.DataFrame({"cancer_code": ["X"], "source_cohort": ["TEST_SOURCE"]}),
+    )
+    monkeypatch.setattr(gen, "cohort_source_version", lambda code: "test-source-version")
+    monkeypatch.setattr(
+        gen,
+        "sample_expression_qc_from_matrix",
+        lambda raw, cancer_type: pd.DataFrame(
+            {
+                "cancer_code": [cancer_type, cancer_type, cancer_type],
+                "sample_id": ["pass_sample", "warn_sample", "fail_sample"],
+                "sample_qc_status": ["pass", "warn", "fail"],
+                "sample_qc_reasons": ["", "tpm_proxy_scale", "low_detected_genes"],
+            }
+        ),
+    )
+
+
+def test_rebuild_expression_artifacts_defaults_to_qc_passing_samples(tmp_path, monkeypatch):
+    gen = _load_script("rebuild_expression_artifacts")
+    cache, ref = _write_rebuild_inputs(tmp_path)
+    _patch_rebuild_registry(monkeypatch, gen)
+    out = tmp_path / "out"
+
+    gen.rebuild(cache, ref, out, limit=None, validate=False, sample_qc="pass")
+
+    clean = pd.read_parquet(out / "clean" / "X.parquet")
+    assert [c for c in clean.columns if c not in ("Ensembl_Gene_ID", "Symbol")] == ["pass_sample"]
+
+    reps = pd.read_parquet(out / "cancer-reference-expression-representatives" / "X.parquet")
+    assert [c for c in reps.columns if c not in ("Ensembl_Gene_ID", "Symbol")] == ["X__rep1"]
+
+    prov = pd.read_csv(out / "cancer-reference-expression-representatives" / "_provenance.csv")
+    assert prov.loc[0, "n_source_samples"] == 3
+    assert prov.loc[0, "n_cohort_samples"] == 1
+    assert prov.loc[0, "sample_qc"] == "pass"
+    assert prov.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v1"
+    assert prov.loc[0, "n_qc_pass"] == 1
+    assert prov.loc[0, "n_qc_warn"] == 1
+    assert prov.loc[0, "n_qc_fail"] == 1
+
+    qc = pd.read_csv(out / "source-matrix-sample-qc.csv")
+    assert list(qc["sample_id"]) == ["pass_sample", "warn_sample", "fail_sample"]
+
+    build_meta = pd.read_csv(out / "expression-artifact-build-metadata.csv")
+    assert build_meta.loc[0, "n_source_samples"] == 3
+    assert build_meta.loc[0, "n_cohort_samples"] == 1
+    assert build_meta.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v1"
+
+    metadata = json.loads((out / "expression-artifact-build-metadata.json").read_text())
+    assert metadata["sample_qc"] == "pass"
+    assert metadata["sample_qc_manifest"] == "source-matrix-sample-qc.csv"
+    assert metadata["n_source_samples"] == 3
+    assert metadata["n_cohort_samples"] == 1
+
+
+def test_rebuild_expression_artifacts_keeps_all_samples_when_requested(tmp_path, monkeypatch):
+    gen = _load_script("rebuild_expression_artifacts")
+    cache, ref = _write_rebuild_inputs(tmp_path)
+    _patch_rebuild_registry(monkeypatch, gen)
+    out = tmp_path / "out"
+
+    gen.rebuild(cache, ref, out, limit=None, validate=False, sample_qc="all")
+
+    clean = pd.read_parquet(out / "clean" / "X.parquet")
+    assert [c for c in clean.columns if c not in ("Ensembl_Gene_ID", "Symbol")] == [
+        "pass_sample",
+        "warn_sample",
+        "fail_sample",
+    ]
+    build_meta = pd.read_csv(out / "expression-artifact-build-metadata.csv")
+    assert build_meta.loc[0, "sample_qc"] == "all"
+    assert build_meta.loc[0, "n_source_samples"] == 3
+    assert build_meta.loc[0, "n_cohort_samples"] == 3
 
 
 # ---------- real-data parity (skipped without the maintainer's matrix cache) ----------


### PR DESCRIPTION
Replacement for closed stacked PR #216, rebased onto main after #206 merged.

Summary:
- share the sample-QC policy core between read-time QC and artifact rebuilds;
- make scripts/rebuild_expression_artifacts.py default to --sample-qc pass, with pass_or_warn and all opt-ins;
- filter clean, percentile, representative, within-sample, and proteoform derived shards to the selected samples;
- emit source-matrix-sample-qc.csv plus expression-artifact-build-metadata.{csv,json};
- record source/sample counts and QC policy metadata in representative provenance.

Context: addresses the generated-artifact part of #203 and #205. This does not regenerate or release a new data bundle; bundle publication and checksum/release discipline remain tracked in #14/#21/#209 and parity/data coverage issues #191/#193/#207/#208/#210.

Validation:
- python -m pytest tests/test_build_generators.py tests/test_expression.py::test_sample_expression_qc_flags_sparse_samples tests/test_expression.py::test_per_sample_expression_filters_by_sample_qc -q (17 passed)
- mkdocs build --strict
- ./lint.sh
- ./test.sh (523 passed, 1 existing matplotlib open-figure warning)