### PR TITLE
Clarify downstream package boundaries in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,39 +4,40 @@
 [![PyPI](https://img.shields.io/pypi/v/oncoref.svg)](https://pypi.org/project/oncoref/)
 
 Curated cancer reference data — cancer-type ontology, tumor mutational burden
-(TMB), incidence/mortality, checkpoint-inhibitor (ICI) response, per-cohort RNA-seq expression,
-and cancer-testis antigens — behind one small Python API, a data fetch/cache
-CLI, and a set of reference plots.
+(TMB), incidence/mortality, checkpoint-inhibitor (ICI) response, per-cohort
+RNA-seq expression, HPA normal-tissue expression, and HPA-derived
+cancer-testis antigen references — behind one small Python API, a data
+fetch/cache CLI, and a set of reference plots.
 
 ## oncoref is the base layer
 
 `oncoref` is **designed as the base layer** of the openvax/PIRL stack — the
-intended single upstream **source of truth** for cancer reference data, meant to
-become a shared dependency of
+intended upstream home for shared cancer reference mechanics and data, meant to
+become a common dependency of
 [pirlygenes](https://github.com/pirl-unc/pirlygenes),
 [trufflepig](https://github.com/pirl-unc/trufflepig), and
-[tsarina](https://github.com/pirl-unc/tsarina). Adoption is still in progress —
-most of these don't depend on it yet. Architecturally it stays at the bottom: it
-depends only on pandas / numpy / pyarrow / PyYAML, it **never imports its
-consumers** (data and logic flow only downward), and it **owns** these
-definitions rather than mirroring them from elsewhere.
+[tsarina](https://github.com/pirl-unc/tsarina). Adoption is staged: downstream
+packages can delegate parity-clean primitives while keeping their own curated
+tables, packaged artifacts, and compatibility APIs until those surfaces are
+ready to move. Architecturally oncoref stays at the bottom: it depends only on
+pandas / numpy / pyarrow / PyYAML, it **never imports its consumers** (data and
+logic flow only downward), and shared definitions should be fixed or exposed
+here rather than reimplemented separately downstream.
 
-Anything that needs to know about
+Use oncoref for shared questions about
 
 - **gene expression of cancer samples** — per-cohort RNA-seq in a normalized,
   comparable space: summary stats, tail-weighted percentiles, and medoid/exemplar
-  samples per cancer type/subtype;
+  samples per cancer type/subtype. Downstream packages may still keep packaged
+  expression artifacts and compatibility wrappers while parity checks converge;
 - **HPA protein / RNA** normal-tissue expression;
-- the **definition of cancer-testis antigens** — the HPA tissue-restriction call
-  over the candidate list (HPA-only; no MS/peptide layer);
+- the **HPA-derived cancer-testis antigen call** — the HPA tissue-restriction
+  call over the candidate list (HPA-only; no pirlygenes therapy/MS curation
+  layer);
 - the **ontology of cancer types** — codes, the parent/child hierarchy, subtypes,
   families, characteristic driver fusions, and the cross-cutting MSI/POLE/HPV
   groupings; and
-- **checkpoint-inhibitor response rates** and **TMB** per cancer type
-
-depends on `oncoref` — including `pirlygenes` (gene-set curation/analysis),
-`tsarina` (personalized target selection), `hitlist` (panel selection),
-`trufflepig` (sample classification), and anything else downstream.
+- **checkpoint-inhibitor response rates** and **TMB** per cancer type.
 
 Everything keys on the cancer-type registry. The small curated tables ship in the
 wheel; the heavy per-cohort expression bundle downloads on first use from

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,6 +5,13 @@ code should prefer the semantic submodules below. They make the domain boundary
 clear and avoid guessing whether a broad name such as `coverage` or `peptides` is
 general or CTA-specific.
 
+Package boundary: oncoref is the upstream home for shared reference mechanics
+and data that are ready to be reused across the PIRL stack. Downstream packages
+can keep package-specific curation, generated artifacts, and compatibility APIs;
+when a missing data field, gene universe, bundle-integrity rule, or source-QC
+decision affects generated artifacts, the durable fix should live or be exposed
+here rather than only in a downstream compatibility layer.
+
 ## Cancer Vocabulary
 
 - `oncoref.cancer_ontology` — cancer-type registry, aliases, parent/child tree,
@@ -82,6 +89,10 @@ ici_response.ici_response_estimates_df()
 `n_specific_9mers`; those counts are used as weights when computing
 `cta_specific_9mer_load()`.
 
+The CTA definition here is the HPA-derived tissue-restriction call. Broader
+therapy-target curation, MS evidence, and downstream prioritization rules can
+live in consumer packages while they remain package-specific.
+
 ```python
 from oncoref import cta, cta_coverage, cta_peptides
 
@@ -124,6 +135,11 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   percentiles, representatives, and within-sample summaries.
 - `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,
   log transforms, percentile ranks, and housekeeping normalization.
+
+The normalization helpers are intended to be reusable directly. Expression
+accessors and bundles are also reusable, but downstream packages may keep their
+own packaged expression artifacts until row-set, value, provenance, and QC
+contracts are parity-clean for the specific accessor they want to replace.
 
 Clean TPM has one public compartment contract:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,14 @@
 # oncoref
 
-`oncoref` is the base-layer package for curated cancer reference data: cancer
-ontology, cohorts, expression, clean-TPM normalization, TMB, incidence/mortality,
-ICI response, and cancer-testis antigen references.
+`oncoref` is the base-layer package for shared cancer reference data and
+mechanics: cancer ontology, cohorts, expression, clean-TPM normalization, TMB,
+incidence/mortality, ICI response, HPA normal-tissue expression, and HPA-derived
+cancer-testis antigen references.
+
+Downstream packages such as pirlygenes and trufflepig should delegate
+parity-clean shared primitives here, but they may keep curated package-specific
+tables, generated artifacts, and compatibility wrappers until a surface has a
+clear oncoref contract.
 
 Start with the [API guide](api.md) for the organized public modules and where to
 look for each data domain.


### PR DESCRIPTION
## Summary
- Reframe oncoref as the staged upstream home for shared reference mechanics rather than implying every downstream artifact has already migrated.
- Clarify that CTA references here are HPA-derived, while broader therapy/MS curation can stay package-specific.
- Add API/index notes explaining when downstream packages should keep compatibility layers versus fixing shared data/QC contracts in oncoref.

## Validation
- ./lint.sh
- mkdocs build --strict