### PR TITLE
Improve docs homepage navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,29 +1,54 @@
 # oncoref
 
-`oncoref` is the base-layer package for shared cancer reference data and
-mechanics: cancer ontology, cohorts, expression, clean-TPM normalization, TMB,
-incidence/mortality, ICI response, HPA normal-tissue expression, and HPA-derived
-cancer-testis antigen references.
+`oncoref` is the base-layer package for shared cancer reference data:
+cancer-type ontology, cohorts, expression, clean-TPM normalization, TMB,
+incidence/mortality, ICI response, HPA normal-tissue expression, and
+HPA-derived cancer-testis antigen references.
 
 Downstream packages such as pirlygenes and trufflepig should delegate
 parity-clean shared primitives here, but they may keep curated package-specific
 tables, generated artifacts, and compatibility wrappers until a surface has a
 clear oncoref contract.
 
-Start with the [API guide](api.md) for the organized public modules and where to
-look for each data domain.
+Use this page as the quick orientation. The [API guide](api.md) is the detailed
+module map, with examples and notes about compatibility modules.
 
-## Key Entry Points
+## Start Here
 
-- `oncoref.cancer_ontology` — cancer-type registry, aliases, hierarchy, and
-  display helpers.
-- `oncoref.cohorts` — expression/source cohort IDs and aggregate cohorts.
-- `oncoref.ici_response` — anti-PD-1 and broader ICI response references.
-- `oncoref.expression` — per-sample, summary, representative, and pan-cancer
-  expression accessors.
-- `oncoref.normalization` — clean TPM, housekeeping normalization, log transforms,
-  and percentile ranks.
-- `oncoref.gene_families` — clean-TPM censored compartments, biological
-  housekeeping denominators, and gene-family reference sets.
-- `oncoref.cta`, `oncoref.cta_coverage`, and `oncoref.cta_peptides` — CTA
-  definition, patient coverage, and CTA-specific 9-mer counts/load.
+- Need cancer-type codes, hierarchy, molecular subtypes, or matched normal
+  tissues? Start with [Cancer Vocabulary](api.md#cancer-vocabulary).
+- Need expression values or clean-TPM normalization? Start with
+  [Expression And Normalization](api.md#expression-and-normalization).
+- Need anti-PD-1 or broader checkpoint-inhibitor response estimates? Start with
+  [ICI Response](api.md#ici-response).
+- Need cancer-testis antigen definitions, patient coverage, or CTA-specific
+  peptide load? Start with [CTA Antigens](api.md#cta-antigens).
+
+```python
+from oncoref import cancer_ontology, ici_response
+
+crc_msi = cancer_ontology.cancer_type_records(subtype_group="MSI", under="CRC")
+crc_msi[["code", "evidence_source_code", "normal_tissue_code"]]
+
+ici_response.best_available_ici_response("COAD_MSI")
+```
+
+## Data Domains
+
+| Domain | Public modules | Use for |
+| --- | --- | --- |
+| Cancer vocabulary | [`oncoref.cancer_ontology`](api.md#cancer-vocabulary), [`oncoref.cohorts`](api.md#cancer-vocabulary) | Registry records, aliases, hierarchy, subtype axes, cohort IDs, matched normal tissues |
+| ICI response | [`oncoref.ici_response`](api.md#ici-response) | Anti-PD-1 and broader ICI references, regimen-aware lookups, extracted endpoint estimates |
+| CTA references | [`oncoref.cta`](api.md#cta-antigens), [`oncoref.cta_coverage`](api.md#cta-antigens), [`oncoref.cta_peptides`](api.md#cta-antigens) | CTA gene sets, patient coverage, CTA-specific 9-mer counts and load |
+| Antigen panels | [`oncoref.antigen_coverage`](api.md#generic-antigen-panels) | Coverage calculations for explicit non-CTA gene panels |
+| Expression | [`oncoref.expression`](api.md#expression-and-normalization), [`oncoref.expression_builders`](api.md#expression-and-normalization) | Per-sample, percentile, representative, within-sample, and reference-expression accessors |
+| Normalization | [`oncoref.normalization`](api.md#expression-and-normalization), [`oncoref.gene_families`](api.md#expression-and-normalization) | Clean TPM, housekeeping normalization, technical-RNA filtering, gene-family panels |
+| Genes and proteoforms | [`oncoref.gene_ids`](api.md#genes-and-proteoforms), [`oncoref.genome`](api.md#genes-and-proteoforms), [`oncoref.proteoforms`](api.md#genes-and-proteoforms) | Gene ID resolution, Ensembl lookup, proteoform grouping |
+| Other references | [`oncoref.tmb`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.incidence`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.fusions`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.response_signatures`](api.md#burden-tmb-fusions-and-signatures) | TMB, incidence/mortality burden, defining fusions, response signatures |
+| Data management | [`oncoref.catalog`](api.md#data-management), [`oncoref.data_bundle`](api.md#data-management), [`oncoref.reference_data`](api.md#data-management), [`oncoref.hpa`](api.md#data-management) | Dataset inventory, download/cache status, HPA reference data |
+
+## Install
+
+```bash
+pip install oncoref
+```


### PR DESCRIPTION
## Summary

- Replace the vague Key Entry Points list with a task-oriented Start Here section.
- Link each homepage module/domain entry to the relevant API guide section.
- Clarify that the homepage is quick orientation and the API guide is the detailed module map.
- Add a small runnable example for ontology and ICI lookup without requiring the external expression bundle.

## Verification

- `mkdocs build --strict`
- `python -c 'from oncoref import cancer_ontology, ici_response; crc_msi = cancer_ontology.cancer_type_records(subtype_group="MSI", under="CRC"); print(len(crc_msi)); print(ici_response.best_available_ici_response("COAD_MSI"))'`