### PR TITLE
Fail visibly for skipped housekeeping normalization

### DIFF
--- a/oncoref/normalization.py
+++ b/oncoref/normalization.py
@@ -235,7 +235,17 @@ def filter_technical_rna(df: pd.DataFrame) -> pd.DataFrame:
     return df.loc[~mask].reset_index(drop=True)
 
 
-def normalize_to_housekeeping(df: pd.DataFrame, value_cols=None) -> pd.DataFrame:
+def normalize_to_housekeeping(
+    df: pd.DataFrame,
+    value_cols=None,
+    *,
+    panel_ids=None,
+    panel_name: str | None = None,
+    pseudocount: float = 0.1,
+    min_panel_detected: int | None = None,
+    drop_zero_panel_values: bool = False,
+    errors: str = "raise",
+) -> pd.DataFrame:
     """Rescale each value column to its housekeeping-panel baseline (unitless: 1.0 =
     panel level). The df-only convenience over :func:`tpm_to_housekeeping_normalized`
     (the canonical normalizer, which also returns per-column diagnostics) — both use the
@@ -244,12 +254,55 @@ def normalize_to_housekeeping(df: pd.DataFrame, value_cols=None) -> pd.DataFrame
     becomes NaN rather than silently staying on the input scale.
 
     ``value_cols`` defaults to every per-sample value column (not just named-TPM
-    columns), so a plain ``genes × samples`` frame normalizes as expected. A frame
-    without an ``Ensembl_Gene_ID`` column (no way to locate the panel) passes through
-    **unchanged** — call :func:`tpm_to_housekeeping_normalized` directly for the stats
-    dict that reports whether normalization was applied."""
-    out, _ = tpm_to_housekeeping_normalized(df, value_cols=_value_cols(df, value_cols))
+    columns), so a plain ``genes × samples`` frame normalizes as expected.
+
+    Use ``panel_ids`` / ``min_panel_detected`` / ``drop_zero_panel_values`` to apply
+    the same panel and reliability policy as the low-level normalizer.
+
+    ``errors="raise"`` (default) raises when any requested value column cannot be put
+    on the housekeeping ratio scale. ``errors="nan"`` blanks failed requested value
+    columns to ``NaN`` and returns the frame. ``errors="ignore"`` preserves the
+    lower-level passthrough behavior for explicit diagnostic/migration callers. Call
+    :func:`tpm_to_housekeeping_normalized` directly when the per-column record is
+    needed."""
+    if errors not in {"raise", "nan", "ignore"}:
+        raise ValueError("errors must be 'raise', 'nan', or 'ignore'")
+    cols = _value_cols(df, value_cols)
+    out, record = tpm_to_housekeeping_normalized(
+        df,
+        value_cols=cols,
+        panel_ids=panel_ids,
+        panel_name=panel_name,
+        pseudocount=pseudocount,
+        min_panel_detected=min_panel_detected,
+        drop_zero_panel_values=drop_zero_panel_values,
+    )
+    failed = _housekeeping_failed_columns(cols, record)
+    if failed and errors == "raise":
+        reason = record.get("reason") or "housekeeping normalization was not applied"
+        formatted = ", ".join(failed)
+        raise ValueError(
+            f"housekeeping normalization failed for requested value columns: {formatted}; {reason}"
+        )
+    if failed and errors == "nan":
+        out = out.copy()
+        for col in failed:
+            if col in out.columns:
+                out[col] = np.nan
     return out
+
+
+def _housekeeping_failed_columns(value_cols: list[str], record: dict) -> list[str]:
+    cols = [str(c) for c in value_cols]
+    if not cols:
+        return ["<none>"]
+    col_records = record.get("columns") or {}
+    failed: list[str] = []
+    for col in cols:
+        info = col_records.get(col)
+        if not info or float(info.get("denominator") or 0.0) <= 0.0:
+            failed.append(col)
+    return failed
 
 
 def log2_transform(df: pd.DataFrame, value_cols=None, *, pseudocount: float = 1.0) -> pd.DataFrame:

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -217,6 +217,58 @@ def test_normalize_to_housekeeping():
     assert np.allclose(out["s1"], np.array([10.0, 30.0, 100.0]) / denom)
 
 
+def test_normalize_to_housekeeping_raises_when_no_panel_rows():
+    df = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG00000999998", "ENSG00000999999"],
+            "Symbol": ["X1", "X2"],
+            "s1": [10.0, 20.0],
+        }
+    )
+    with pytest.raises(ValueError, match="no housekeeping panel genes present"):
+        norm.normalize_to_housekeeping(df)
+
+    out = norm.normalize_to_housekeeping(df, errors="nan")
+    assert out["s1"].isna().all()
+
+
+def test_normalize_to_housekeeping_raises_without_id_column():
+    df = pd.DataFrame({"Symbol": ["H1", "X"], "s1": [10.0, 20.0]})
+    with pytest.raises(ValueError, match="no id column for housekeeping panel"):
+        norm.normalize_to_housekeeping(df)
+
+    out = norm.normalize_to_housekeeping(df, errors="ignore")
+    assert out.equals(df)
+
+
+def test_normalize_to_housekeeping_raises_for_mixed_failed_columns():
+    hk = list(gf.housekeeping_gene_ids())[:2]
+    gt = pd.DataFrame({"Ensembl_Gene_ID": [*hk, "ENSG00000999999"], "Symbol": ["H1", "H2", "X"]})
+    df = gt.assign(good=[10.0, 30.0, 100.0], failed=[0.0, 0.0, 100.0])
+
+    with pytest.raises(ValueError, match="failed"):
+        norm.normalize_to_housekeeping(
+            df,
+            drop_zero_panel_values=True,
+            min_panel_detected=1,
+        )
+
+    out = norm.normalize_to_housekeeping(
+        df,
+        drop_zero_panel_values=True,
+        min_panel_detected=1,
+        errors="nan",
+    )
+    denom = np.exp(np.mean(np.log(np.array([10.0, 30.0]) + 0.1)))
+    assert np.allclose(out["good"], np.array([10.0, 30.0, 100.0]) / denom)
+    assert out["failed"].isna().all()
+
+
+def test_normalize_to_housekeeping_bad_errors_mode():
+    with pytest.raises(ValueError, match="errors must be"):
+        norm.normalize_to_housekeeping(pd.DataFrame({"s1": [1.0]}), errors="warn")
+
+
 # ---- FPKM->TPM / renormalize-to-million ----
 
 


### PR DESCRIPTION
## Summary

- Make `normalize_to_housekeeping()` raise by default when any requested value column cannot be put on the housekeeping ratio scale.
- Add explicit `errors="nan"` and `errors="ignore"` modes for visible blanking or migration-only passthrough.
- Let the df-only helper pass through the same panel/reliability knobs as `tpm_to_housekeeping_normalized()` so sparse/all-zero HK-panel cases can be enforced without switching APIs.
- Cover missing panel rows, missing `Ensembl_Gene_ID`, mixed success/failure columns, and invalid error modes.

Closes #224.

## Verification

- `python -m pytest tests/test_normalization.py`
- `./lint.sh`
- `./test.sh` (`531 passed`, one existing matplotlib open-figure warning)