### PR TITLE
Expose source gene mapping audit primitives

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -133,6 +133,13 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   `source-matrix-sample-qc.csv` plus `expression-artifact-build-metadata.*` in
   the staging directory so bundle releases can record which source samples fed
   percentiles, representatives, and within-sample summaries.
+- `oncoref.expression_engine` — reusable low-level builder primitives for
+  expression tables: identity/value column detection, transcript-to-gene
+  aggregation, source row ID-type detection, source gene-row mapping audits,
+  missing-vs-non-parsing numeric diagnostics, and canonical ENSG aggregation in
+  linear expression space. Use these in builders before committing a source
+  matrix so unresolved high-expression rows and duplicate canonical IDs are
+  explicit artifacts rather than hidden cleanup.
 - `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,
   log transforms, percentile ranks, and housekeeping normalization.
 

--- a/oncoref/expression_engine.py
+++ b/oncoref/expression_engine.py
@@ -223,8 +223,10 @@ def _extra_transcript_gene_index() -> dict[str, tuple[str, str]]:
         raw_gid = _nonempty_text(gid)
         if raw_gid is not None:
             gene_id = resolve_ensembl_id(raw_gid)
-            out.setdefault(tx_key, (unversioned(gene_id), str(sym)))
-            continue
+            hit = _canonical_gene_index().get(unversioned(gene_id))
+            if hit is not None:
+                out.setdefault(tx_key, hit)
+                continue
         hit_id, hit_symbol, _, _ = _resolve_symbol(str(sym))
         if hit_id is not None and hit_symbol is not None:
             out.setdefault(tx_key, (hit_id, hit_symbol))
@@ -323,7 +325,9 @@ def map_source_gene_rows(
             reason = "unsupported_entrez_id"
 
         if canonical_id is None:
-            symbol_candidate = source_symbol or (raw_id if raw_id is not None else None)
+            symbol_candidate = source_symbol
+            if symbol_candidate is None and row_type == "symbol":
+                symbol_candidate = raw_id
             if symbol_candidate is not None:
                 canonical_id, canonical_symbol, method, reason = _resolve_symbol(symbol_candidate)
 
@@ -359,14 +363,26 @@ def map_source_gene_rows(
 
 
 def coerce_source_expression_values(
-    df: pd.DataFrame, value_cols=None
+    df: pd.DataFrame,
+    value_cols=None,
+    *,
+    row_id_col: str | None = None,
+    symbol_col: str | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Coerce source expression values to numeric and report parse/missing diagnostics.
 
     Literal zeros, input missing values, and non-parsing cells are counted separately so
     builders do not have to collapse missingness into measured zero before QC.
     """
-    cols = list(value_cols) if value_cols is not None else sample_columns(df)
+    if value_cols is None:
+        row_id_col = row_id_col or _find_optional_column(df, _DEFAULT_GENE_ROW_ID_COLUMN_CANDIDATES)
+        if symbol_col is None:
+            symbol_col = _find_optional_column(df, _DEFAULT_GENE_SYMBOL_COLUMN_CANDIDATES)
+            if symbol_col == row_id_col:
+                symbol_col = None
+        cols = _source_value_columns(df, row_id_col, symbol_col, None)
+    else:
+        cols = list(value_cols)
     out = df.copy()
     rows: list[dict] = []
     for col in cols:

--- a/oncoref/expression_engine.py
+++ b/oncoref/expression_engine.py
@@ -271,10 +271,10 @@ def _extra_transcript_gene_index() -> dict[str, tuple[str, str]]:
     df = extra_transcript_mappings()
     out: dict[str, tuple[str, str]] = {}
     for tx, gid, sym in zip(df["transcript_id"], df["ensembl_gene_id"], df["gene_symbol"]):
-        tx_key = str(tx).split(".", 1)[0]
+        tx_key = str(tx).split(".", 1)[0].upper()
         raw_gid = _nonempty_text(gid)
         if raw_gid is not None:
-            gene_id = resolve_ensembl_id(raw_gid)
+            gene_id = resolve_ensembl_id(raw_gid.upper())
             hit = _canonical_gene_index().get(unversioned(gene_id))
             if hit is not None:
                 out.setdefault(tx_key, hit)
@@ -289,7 +289,11 @@ def _source_value_columns(
     df: pd.DataFrame, row_id_col: str | None, symbol_col: str | None, value_cols
 ) -> list[str]:
     if value_cols is not None:
-        return [str(c) for c in value_cols if str(c) in df.columns]
+        cols = [str(c) for c in value_cols]
+        missing = [c for c in cols if c not in df.columns]
+        if missing:
+            raise ValueError(f"requested source expression value columns are missing: {missing}")
+        return cols
     excluded = {c for c in (row_id_col, symbol_col) if c is not None}
     return [c for c in df.columns if c not in excluded]
 
@@ -297,7 +301,7 @@ def _source_value_columns(
 def _resolve_gene_id(raw_id: str) -> tuple[str | None, str | None, str, str | None]:
     from .gene_ids import resolve_ensembl_id, unversioned
 
-    raw = unversioned(raw_id)
+    raw = unversioned(raw_id).upper()
     canonical = resolve_ensembl_id(raw)
     hit = _canonical_gene_index().get(canonical)
     if hit is None:
@@ -360,7 +364,7 @@ def map_source_gene_rows(
         if raw_id is not None and row_type == "ensembl_gene_id":
             canonical_id, canonical_symbol, method, reason = _resolve_gene_id(raw_id)
         elif raw_id is not None and row_type == "ensembl_transcript_id":
-            tx = transcript_index.get(str(raw_id).split(".", 1)[0])
+            tx = transcript_index.get(str(raw_id).split(".", 1)[0].upper())
             if tx is not None and tx[0] in _canonical_gene_index():
                 canonical_id, canonical_symbol = tx
                 method = "extra_transcript_mapping"
@@ -427,7 +431,7 @@ def coerce_source_expression_values(
         )
         cols = _source_value_columns(df, row_id_col, symbol_col, None)
     else:
-        cols = list(value_cols)
+        cols = _source_value_columns(df, None, None, value_cols)
     out = df.copy()
     rows: list[dict] = []
     for col in cols:

--- a/oncoref/expression_engine.py
+++ b/oncoref/expression_engine.py
@@ -140,6 +140,34 @@ def _find_optional_column(df: pd.DataFrame, candidates) -> str | None:
     return None
 
 
+def _source_row_columns(
+    df: pd.DataFrame,
+    row_id_col: str | None,
+    symbol_col: str | None,
+    *,
+    require_row_id: bool,
+) -> tuple[str | None, str | None]:
+    if row_id_col is not None and row_id_col not in df.columns:
+        raise ValueError(f"source row ID column {row_id_col!r} is not in expression data")
+    if symbol_col is not None and symbol_col not in df.columns:
+        raise ValueError(f"source symbol column {symbol_col!r} is not in expression data")
+
+    detected_symbol = symbol_col or _find_optional_column(
+        df, _DEFAULT_GENE_SYMBOL_COLUMN_CANDIDATES
+    )
+    detected_id = row_id_col or _find_optional_column(df, _DEFAULT_GENE_ROW_ID_COLUMN_CANDIDATES)
+    if detected_id is None:
+        detected_id = detected_symbol
+    if detected_id is None and require_row_id:
+        raise ValueError(
+            "no source gene row ID or symbol column in expression data; "
+            f"available: {list(df.columns)}"
+        )
+    if detected_symbol == detected_id:
+        detected_symbol = None
+    return detected_id, detected_symbol
+
+
 def _nonempty_text(value) -> str | None:
     if value is None or pd.isna(value):
         return None
@@ -189,7 +217,8 @@ def _canonical_gene_index() -> dict[str, tuple[str, str]]:
 
 @lru_cache(maxsize=1)
 def _symbol_to_gene_index() -> tuple[dict[str, tuple[str, str]], set[str]]:
-    from .gene_ids import canonical_gene_space, resolve_symbol, symbol_synonyms, unversioned
+    from .gene_ids import canonical_gene_space, unversioned
+    from .load_dataset import get_data
 
     df = canonical_gene_space()
     by_symbol: dict[str, list[tuple[str, str]]] = {}
@@ -204,11 +233,34 @@ def _symbol_to_gene_index() -> tuple[dict[str, tuple[str, str]], set[str]]:
             unique[key] = hits[0]
         else:
             ambiguous.add(key)
-    for alias in symbol_synonyms():
-        official = resolve_symbol(alias)
-        hit = unique.get(str(official).upper())
-        if hit is not None:
-            unique.setdefault(str(alias).upper(), hit)
+
+    synonyms = get_data("ncbi-symbol-synonyms", copy=False)
+    alias_to_officials: dict[str, set[str]] = {}
+    for alias, official in zip(synonyms["alias"], synonyms["official_symbol"]):
+        alias_key = _nonempty_text(alias)
+        official_key = _nonempty_text(official)
+        if alias_key is None or official_key is None:
+            continue
+        alias_to_officials.setdefault(alias_key.upper(), set()).add(official_key.upper())
+    for alias_key, official_keys in alias_to_officials.items():
+        if len(official_keys) != 1:
+            ambiguous.add(alias_key)
+            unique.pop(alias_key, None)
+            continue
+        official_key = next(iter(official_keys))
+        if official_key in ambiguous:
+            ambiguous.add(alias_key)
+            unique.pop(alias_key, None)
+            continue
+        hit = unique.get(official_key)
+        if hit is None:
+            continue
+        existing = unique.get(alias_key)
+        if existing is not None and existing[0] != hit[0]:
+            ambiguous.add(alias_key)
+            unique.pop(alias_key, None)
+        else:
+            unique.setdefault(alias_key, hit)
     return unique, ambiguous
 
 
@@ -287,25 +339,20 @@ def map_source_gene_rows(
     through the bundled canonical gene space, and unresolved/ambiguous rows remain
     visible in the audit rather than disappearing.
     """
-    row_id_col = row_id_col or find_column(
-        df, _DEFAULT_GENE_ROW_ID_COLUMN_CANDIDATES, "source gene row ID"
-    )
-    if symbol_col is None:
-        symbol_col = _find_optional_column(df, _DEFAULT_GENE_SYMBOL_COLUMN_CANDIDATES)
-        if symbol_col == row_id_col:
-            symbol_col = None
+    row_id_col, symbol_col = _source_row_columns(df, row_id_col, symbol_col, require_row_id=True)
     cols = _source_value_columns(df, row_id_col, symbol_col, value_cols)
     numeric = (
         df[cols].apply(pd.to_numeric, errors="coerce") if cols else pd.DataFrame(index=df.index)
     )
     row_sums = numeric.sum(axis=1, skipna=True) if cols else pd.Series(0.0, index=df.index)
+    row_sum_values = row_sums.to_numpy(dtype=float)
     id_type = detect_source_row_id_type(df[row_id_col])
     transcript_index = _extra_transcript_gene_index()
 
     rows: list[dict] = []
-    for idx, raw_value in df[row_id_col].items():
+    for pos, (idx, raw_value) in enumerate(df[row_id_col].items()):
         raw_id = _nonempty_text(raw_value)
-        source_symbol = _nonempty_text(df.at[idx, symbol_col]) if symbol_col is not None else None
+        source_symbol = _nonempty_text(df[symbol_col].iloc[pos]) if symbol_col is not None else None
         row_type = detect_source_row_id_type([raw_id])
         canonical_id = canonical_symbol = method = reason = None
         status = "unresolved"
@@ -341,7 +388,7 @@ def map_source_gene_rows(
             method = method or "unresolved"
             reason = reason or "missing_row_identifier"
 
-        source_value_sum = float(row_sums.loc[idx]) if idx in row_sums.index else 0.0
+        source_value_sum = float(row_sum_values[pos]) if pos < len(row_sum_values) else 0.0
         rows.append(
             {
                 "source_row_index": idx,
@@ -375,11 +422,9 @@ def coerce_source_expression_values(
     builders do not have to collapse missingness into measured zero before QC.
     """
     if value_cols is None:
-        row_id_col = row_id_col or _find_optional_column(df, _DEFAULT_GENE_ROW_ID_COLUMN_CANDIDATES)
-        if symbol_col is None:
-            symbol_col = _find_optional_column(df, _DEFAULT_GENE_SYMBOL_COLUMN_CANDIDATES)
-            if symbol_col == row_id_col:
-                symbol_col = None
+        row_id_col, symbol_col = _source_row_columns(
+            df, row_id_col, symbol_col, require_row_id=False
+        )
         cols = _source_value_columns(df, row_id_col, symbol_col, None)
     else:
         cols = list(value_cols)
@@ -424,13 +469,7 @@ def canonicalize_source_gene_matrix(
     row-level mapping table from :func:`map_source_gene_rows`, including unresolved
     high-expression rows for builder QC reports.
     """
-    row_id_col = row_id_col or find_column(
-        df, _DEFAULT_GENE_ROW_ID_COLUMN_CANDIDATES, "source gene row ID"
-    )
-    if symbol_col is None:
-        symbol_col = _find_optional_column(df, _DEFAULT_GENE_SYMBOL_COLUMN_CANDIDATES)
-        if symbol_col == row_id_col:
-            symbol_col = None
+    row_id_col, symbol_col = _source_row_columns(df, row_id_col, symbol_col, require_row_id=True)
     cols = _source_value_columns(df, row_id_col, symbol_col, value_cols)
     coerced, parse_diagnostics = coerce_source_expression_values(df, cols)
     audit = map_source_gene_rows(

--- a/oncoref/expression_engine.py
+++ b/oncoref/expression_engine.py
@@ -28,6 +28,7 @@ complete ``tx_to_gene_name`` (e.g. built from pyensembl on its side).
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from functools import lru_cache
 
 import pandas as pd
@@ -69,6 +70,48 @@ _DEFAULT_TX_COLUMN_CANDIDATES = (
     "name",
 )
 _DEFAULT_TPM_COLUMN_CANDIDATES = ("tpm",)
+_DEFAULT_GENE_ROW_ID_COLUMN_CANDIDATES = (
+    "Ensembl_Gene_ID",
+    "ensembl_gene_id",
+    "gene_id",
+    "gene",
+    "Gene",
+    "id",
+    "ID",
+    "target_id",
+    "name",
+)
+_DEFAULT_GENE_SYMBOL_COLUMN_CANDIDATES = (
+    "Symbol",
+    "symbol",
+    "gene_symbol",
+    "gene_name",
+    "external_gene_name",
+)
+
+SOURCE_GENE_MAPPING_AUDIT_COLUMNS = (
+    "source_row_index",
+    "source_row_id",
+    "source_row_id_type",
+    "source_symbol",
+    "mapping_status",
+    "mapping_method",
+    "canonical_ensembl_gene_id",
+    "canonical_symbol",
+    "unresolved_reason",
+    "source_value_sum",
+    "high_expression_unresolved",
+)
+
+SOURCE_VALUE_PARSE_DIAGNOSTIC_COLUMNS = (
+    "value_col",
+    "n_values",
+    "n_input_missing",
+    "n_parse_missing",
+    "n_literal_zero",
+    "parse_missing_fraction",
+    "literal_zero_fraction",
+)
 
 
 def find_column(df: pd.DataFrame, candidates, column_name: str) -> str:
@@ -86,6 +129,338 @@ def find_column(df: pd.DataFrame, candidates, column_name: str) -> str:
     raise ValueError(
         f"no column for {column_name} in expression data; available: {list(df.columns)}"
     )
+
+
+def _find_optional_column(df: pd.DataFrame, candidates) -> str | None:
+    by_lower = {str(col).lower(): col for col in df.columns}
+    for cand in candidates:
+        col = by_lower.get(str(cand).lower())
+        if col is not None:
+            return col
+    return None
+
+
+def _nonempty_text(value) -> str | None:
+    if value is None or pd.isna(value):
+        return None
+    text = str(value).strip()
+    if not text or text.lower() == "nan":
+        return None
+    return text
+
+
+def detect_source_row_id_type(values: Iterable) -> str:
+    """Classify source expression row identifiers.
+
+    Returns one of ``"ensembl_gene_id"``, ``"ensembl_transcript_id"``,
+    ``"entrez_id"``, ``"symbol"``, ``"mixed"``, or ``"unknown"``. The detector is
+    deliberately conservative: it is used to annotate builder audit rows, not to
+    silently decide a lossy mapping path.
+    """
+    s = pd.Series(list(values), dtype="object").map(_nonempty_text).dropna()
+    if s.empty:
+        return "unknown"
+    upper = s.str.upper()
+    ensg = upper.str.match(r"^ENSG\d+(?:\.\d+)?$")
+    enst = upper.str.match(r"^ENST\d+(?:\.\d+)?$")
+    entrez = upper.str.match(r"^\d+$")
+    symbol = upper.str.match(r"^[A-Z][A-Z0-9_.-]*$") & ~(ensg | enst | entrez)
+    patterns = {
+        "ensembl_gene_id": ensg,
+        "ensembl_transcript_id": enst,
+        "entrez_id": entrez,
+        "symbol": symbol,
+    }
+    fractions = {name: float(mask.mean()) for name, mask in patterns.items()}
+    best, frac = max(fractions.items(), key=lambda kv: kv[1])
+    return best if frac >= 0.8 else "mixed"
+
+
+@lru_cache(maxsize=1)
+def _canonical_gene_index() -> dict[str, tuple[str, str]]:
+    from .gene_ids import canonical_gene_space, unversioned
+
+    df = canonical_gene_space()
+    return {
+        unversioned(gid): (unversioned(gid), str(sym))
+        for gid, sym in zip(df["ensembl_gene_id"], df["symbol"])
+    }
+
+
+@lru_cache(maxsize=1)
+def _symbol_to_gene_index() -> tuple[dict[str, tuple[str, str]], set[str]]:
+    from .gene_ids import canonical_gene_space, resolve_symbol, symbol_synonyms, unversioned
+
+    df = canonical_gene_space()
+    by_symbol: dict[str, list[tuple[str, str]]] = {}
+    for gid, sym in zip(df["ensembl_gene_id"], df["symbol"]):
+        key = str(sym).upper()
+        by_symbol.setdefault(key, []).append((unversioned(gid), str(sym)))
+    unique: dict[str, tuple[str, str]] = {}
+    ambiguous: set[str] = set()
+    for key, hits in by_symbol.items():
+        ids = {gid for gid, _ in hits}
+        if len(ids) == 1:
+            unique[key] = hits[0]
+        else:
+            ambiguous.add(key)
+    for alias in symbol_synonyms():
+        official = resolve_symbol(alias)
+        hit = unique.get(str(official).upper())
+        if hit is not None:
+            unique.setdefault(str(alias).upper(), hit)
+    return unique, ambiguous
+
+
+@lru_cache(maxsize=1)
+def _extra_transcript_gene_index() -> dict[str, tuple[str, str]]:
+    from .gene_ids import extra_transcript_mappings, resolve_ensembl_id, unversioned
+
+    df = extra_transcript_mappings()
+    out: dict[str, tuple[str, str]] = {}
+    for tx, gid, sym in zip(df["transcript_id"], df["ensembl_gene_id"], df["gene_symbol"]):
+        tx_key = str(tx).split(".", 1)[0]
+        raw_gid = _nonempty_text(gid)
+        if raw_gid is not None:
+            gene_id = resolve_ensembl_id(raw_gid)
+            out.setdefault(tx_key, (unversioned(gene_id), str(sym)))
+            continue
+        hit_id, hit_symbol, _, _ = _resolve_symbol(str(sym))
+        if hit_id is not None and hit_symbol is not None:
+            out.setdefault(tx_key, (hit_id, hit_symbol))
+    return out
+
+
+def _source_value_columns(
+    df: pd.DataFrame, row_id_col: str | None, symbol_col: str | None, value_cols
+) -> list[str]:
+    if value_cols is not None:
+        return [str(c) for c in value_cols if str(c) in df.columns]
+    excluded = {c for c in (row_id_col, symbol_col) if c is not None}
+    return [c for c in df.columns if c not in excluded]
+
+
+def _resolve_gene_id(raw_id: str) -> tuple[str | None, str | None, str, str | None]:
+    from .gene_ids import resolve_ensembl_id, unversioned
+
+    raw = unversioned(raw_id)
+    canonical = resolve_ensembl_id(raw)
+    hit = _canonical_gene_index().get(canonical)
+    if hit is None:
+        return None, None, "unresolved", "unknown_ensembl_gene_id"
+    method = "ensembl_gene_id" if canonical == raw else "ensembl_gene_id_alias"
+    return hit[0], hit[1], method, None
+
+
+def _resolve_symbol(symbol: str) -> tuple[str | None, str | None, str, str | None]:
+    from .gene_ids import resolve_symbol
+
+    symbol_index, ambiguous = _symbol_to_gene_index()
+    raw = str(symbol).strip()
+    key = raw.upper()
+    official = resolve_symbol(raw)
+    official_key = str(official).upper()
+    if key in ambiguous or official_key in ambiguous:
+        return None, None, "ambiguous", "ambiguous_symbol"
+    hit = symbol_index.get(key) or symbol_index.get(official_key)
+    if hit is None:
+        return None, None, "unresolved", "unknown_symbol"
+    method = "symbol_synonym" if official_key != key else "symbol"
+    return hit[0], hit[1], method, None
+
+
+def map_source_gene_rows(
+    df: pd.DataFrame,
+    *,
+    row_id_col: str | None = None,
+    symbol_col: str | None = None,
+    value_cols=None,
+    high_expression_threshold: float = 1.0,
+) -> pd.DataFrame:
+    """Return a row-level mapping audit for a source gene-expression matrix.
+
+    Builders can use this before aggregation to make identifier handling explicit:
+    versioned/alt Ensembl IDs are migrated to the canonical gene space, known
+    transcript IDs use oncoref's supplemental transcript map, symbols/synonyms map
+    through the bundled canonical gene space, and unresolved/ambiguous rows remain
+    visible in the audit rather than disappearing.
+    """
+    row_id_col = row_id_col or find_column(
+        df, _DEFAULT_GENE_ROW_ID_COLUMN_CANDIDATES, "source gene row ID"
+    )
+    if symbol_col is None:
+        symbol_col = _find_optional_column(df, _DEFAULT_GENE_SYMBOL_COLUMN_CANDIDATES)
+        if symbol_col == row_id_col:
+            symbol_col = None
+    cols = _source_value_columns(df, row_id_col, symbol_col, value_cols)
+    numeric = (
+        df[cols].apply(pd.to_numeric, errors="coerce") if cols else pd.DataFrame(index=df.index)
+    )
+    row_sums = numeric.sum(axis=1, skipna=True) if cols else pd.Series(0.0, index=df.index)
+    id_type = detect_source_row_id_type(df[row_id_col])
+    transcript_index = _extra_transcript_gene_index()
+
+    rows: list[dict] = []
+    for idx, raw_value in df[row_id_col].items():
+        raw_id = _nonempty_text(raw_value)
+        source_symbol = _nonempty_text(df.at[idx, symbol_col]) if symbol_col is not None else None
+        row_type = detect_source_row_id_type([raw_id])
+        canonical_id = canonical_symbol = method = reason = None
+        status = "unresolved"
+
+        if raw_id is not None and row_type == "ensembl_gene_id":
+            canonical_id, canonical_symbol, method, reason = _resolve_gene_id(raw_id)
+        elif raw_id is not None and row_type == "ensembl_transcript_id":
+            tx = transcript_index.get(str(raw_id).split(".", 1)[0])
+            if tx is not None and tx[0] in _canonical_gene_index():
+                canonical_id, canonical_symbol = tx
+                method = "extra_transcript_mapping"
+            else:
+                method = "unresolved"
+                reason = "unknown_ensembl_transcript_id"
+        elif raw_id is not None and row_type == "entrez_id":
+            method = "unresolved"
+            reason = "unsupported_entrez_id"
+
+        if canonical_id is None:
+            symbol_candidate = source_symbol or (raw_id if raw_id is not None else None)
+            if symbol_candidate is not None:
+                canonical_id, canonical_symbol, method, reason = _resolve_symbol(symbol_candidate)
+
+        if canonical_id is not None:
+            status = "resolved"
+            reason = None
+        elif method == "ambiguous":
+            status = "ambiguous"
+        else:
+            status = "unresolved"
+            method = method or "unresolved"
+            reason = reason or "missing_row_identifier"
+
+        source_value_sum = float(row_sums.loc[idx]) if idx in row_sums.index else 0.0
+        rows.append(
+            {
+                "source_row_index": idx,
+                "source_row_id": raw_id,
+                "source_row_id_type": row_type if row_type != "unknown" else id_type,
+                "source_symbol": source_symbol,
+                "mapping_status": status,
+                "mapping_method": method,
+                "canonical_ensembl_gene_id": canonical_id,
+                "canonical_symbol": canonical_symbol,
+                "unresolved_reason": reason,
+                "source_value_sum": source_value_sum,
+                "high_expression_unresolved": bool(
+                    status != "resolved" and source_value_sum >= high_expression_threshold
+                ),
+            }
+        )
+    return pd.DataFrame(rows, columns=SOURCE_GENE_MAPPING_AUDIT_COLUMNS)
+
+
+def coerce_source_expression_values(
+    df: pd.DataFrame, value_cols=None
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Coerce source expression values to numeric and report parse/missing diagnostics.
+
+    Literal zeros, input missing values, and non-parsing cells are counted separately so
+    builders do not have to collapse missingness into measured zero before QC.
+    """
+    cols = list(value_cols) if value_cols is not None else sample_columns(df)
+    out = df.copy()
+    rows: list[dict] = []
+    for col in cols:
+        if col not in out.columns:
+            continue
+        raw = out[col]
+        input_missing = raw.isna()
+        coerced = pd.to_numeric(raw, errors="coerce")
+        parse_missing = coerced.isna() & ~input_missing
+        literal_zero = coerced == 0
+        n = len(raw)
+        rows.append(
+            {
+                "value_col": col,
+                "n_values": n,
+                "n_input_missing": int(input_missing.sum()),
+                "n_parse_missing": int(parse_missing.sum()),
+                "n_literal_zero": int(literal_zero.sum()),
+                "parse_missing_fraction": float(parse_missing.sum() / n) if n else 0.0,
+                "literal_zero_fraction": float(literal_zero.sum() / n) if n else 0.0,
+            }
+        )
+        out[col] = coerced
+    return out, pd.DataFrame(rows, columns=SOURCE_VALUE_PARSE_DIAGNOSTIC_COLUMNS)
+
+
+def canonicalize_source_gene_matrix(
+    df: pd.DataFrame,
+    *,
+    row_id_col: str | None = None,
+    symbol_col: str | None = None,
+    value_cols=None,
+    high_expression_threshold: float = 1.0,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Map source rows to canonical ENSG IDs and sum duplicate rows in linear space.
+
+    Returns ``(matrix, audit)``. ``matrix`` has stable ``Ensembl_Gene_ID`` /
+    ``Symbol`` columns plus the requested value columns. ``audit`` is the full
+    row-level mapping table from :func:`map_source_gene_rows`, including unresolved
+    high-expression rows for builder QC reports.
+    """
+    row_id_col = row_id_col or find_column(
+        df, _DEFAULT_GENE_ROW_ID_COLUMN_CANDIDATES, "source gene row ID"
+    )
+    if symbol_col is None:
+        symbol_col = _find_optional_column(df, _DEFAULT_GENE_SYMBOL_COLUMN_CANDIDATES)
+        if symbol_col == row_id_col:
+            symbol_col = None
+    cols = _source_value_columns(df, row_id_col, symbol_col, value_cols)
+    coerced, parse_diagnostics = coerce_source_expression_values(df, cols)
+    audit = map_source_gene_rows(
+        coerced,
+        row_id_col=row_id_col,
+        symbol_col=symbol_col,
+        value_cols=cols,
+        high_expression_threshold=high_expression_threshold,
+    )
+    resolved = audit["mapping_status"] == "resolved"
+    if not resolved.any():
+        empty = pd.DataFrame(columns=["Ensembl_Gene_ID", "Symbol", *cols])
+        empty.attrs["source_gene_mapping_stats"] = source_gene_mapping_stats(audit)
+        empty.attrs["source_value_parse_diagnostics"] = parse_diagnostics
+        return empty, audit
+
+    work = coerced.loc[resolved.to_numpy(), cols].copy()
+    work.insert(0, "Symbol", audit.loc[resolved, "canonical_symbol"].to_numpy())
+    work.insert(0, "Ensembl_Gene_ID", audit.loc[resolved, "canonical_ensembl_gene_id"].to_numpy())
+    grouped = work.groupby("Ensembl_Gene_ID", sort=False)
+    ids = grouped[["Symbol"]].first()
+    values = grouped[cols].sum(min_count=1)
+    out = ids.join(values).reset_index()
+    out.attrs["source_gene_mapping_stats"] = source_gene_mapping_stats(audit)
+    out.attrs["source_value_parse_diagnostics"] = parse_diagnostics
+    return out[["Ensembl_Gene_ID", "Symbol", *cols]], audit
+
+
+def source_gene_mapping_stats(audit: pd.DataFrame) -> dict:
+    """Compact counts from a :func:`map_source_gene_rows` audit table."""
+    if audit.empty:
+        return {
+            "n_source_rows": 0,
+            "n_resolved_rows": 0,
+            "n_unresolved_rows": 0,
+            "n_ambiguous_rows": 0,
+            "n_high_expression_unresolved_rows": 0,
+        }
+    status = audit["mapping_status"].value_counts().to_dict()
+    return {
+        "n_source_rows": len(audit),
+        "n_resolved_rows": int(status.get("resolved", 0)),
+        "n_unresolved_rows": int(status.get("unresolved", 0)),
+        "n_ambiguous_rows": int(status.get("ambiguous", 0)),
+        "n_high_expression_unresolved_rows": int(audit["high_expression_unresolved"].sum()),
+    }
 
 
 def expanded_tx_map(tx_to_gene_name: dict) -> dict:
@@ -163,6 +538,11 @@ def aggregate_transcripts_to_genes(
 
 __all__ = [
     "aggregate_transcripts_to_genes",
+    "canonicalize_source_gene_matrix",
+    "coerce_source_expression_values",
+    "detect_source_row_id_type",
     "expanded_tx_map",
     "find_column",
+    "map_source_gene_rows",
+    "source_gene_mapping_stats",
 ]

--- a/tests/test_expression_engine.py
+++ b/tests/test_expression_engine.py
@@ -101,6 +101,33 @@ def test_map_source_gene_rows_resolves_ids_symbols_and_transcripts():
     assert stats["n_high_expression_unresolved_rows"] == 1
 
 
+def test_map_source_gene_rows_falls_back_from_noncanonical_transcript_gene_id():
+    df = pd.DataFrame({"gene_id": ["ENST00000644628"], "s1": [11.0]})
+    audit = ee.map_source_gene_rows(df, row_id_col="gene_id", value_cols=["s1"])
+    row = audit.iloc[0]
+
+    assert row["mapping_status"] == "resolved"
+    assert row["mapping_method"] == "extra_transcript_mapping"
+    assert row["canonical_ensembl_gene_id"] == "ENSG00000171862"
+    assert row["canonical_symbol"] == "PTEN"
+
+
+def test_map_source_gene_rows_preserves_identifier_unresolved_reasons():
+    df = pd.DataFrame(
+        {
+            "gene_id": ["ENSG99999999999", "123456789"],
+            "s1": [10.0, 20.0],
+        }
+    )
+    audit = ee.map_source_gene_rows(df, row_id_col="gene_id", value_cols=["s1"])
+    by_id = audit.set_index("source_row_id")
+
+    assert by_id.loc["ENSG99999999999", "unresolved_reason"] == "unknown_ensembl_gene_id"
+    assert by_id.loc["ENSG99999999999", "mapping_method"] == "unresolved"
+    assert by_id.loc["123456789", "unresolved_reason"] == "unsupported_entrez_id"
+    assert by_id.loc["123456789", "mapping_method"] == "unresolved"
+
+
 def test_canonicalize_source_gene_matrix_sums_duplicate_canonical_ids():
     df = pd.DataFrame(
         {
@@ -142,3 +169,19 @@ def test_coerce_source_expression_values_distinguishes_missing_nonparse_and_zero
     assert by_col.loc["s1", "n_input_missing"] == 1
     assert by_col.loc["s2", "n_literal_zero"] == 1
     assert by_col.loc["s2", "n_parse_missing"] == 1
+
+
+def test_coerce_source_expression_values_default_preserves_source_identifiers():
+    df = pd.DataFrame(
+        {
+            "gene_id": ["ENSG00000141510", "ENSG00000278311"],
+            "symbol": ["TP53", "GGNBP2"],
+            "sample_a": ["1.5", "0"],
+        }
+    )
+    out, diag = ee.coerce_source_expression_values(df)
+
+    assert out["gene_id"].tolist() == ["ENSG00000141510", "ENSG00000278311"]
+    assert out["symbol"].tolist() == ["TP53", "GGNBP2"]
+    assert out["sample_a"].tolist() == [1.5, 0.0]
+    assert diag["value_col"].tolist() == ["sample_a"]

--- a/tests/test_expression_engine.py
+++ b/tests/test_expression_engine.py
@@ -112,6 +112,25 @@ def test_map_source_gene_rows_falls_back_from_noncanonical_transcript_gene_id():
     assert row["canonical_symbol"] == "PTEN"
 
 
+def test_map_source_gene_rows_normalizes_case_varied_ensembl_identifiers():
+    df = pd.DataFrame(
+        {
+            "gene_id": ["ensg00000141510.17", "enst00000644628"],
+            "s1": [3.0, 4.0],
+        }
+    )
+    audit = ee.map_source_gene_rows(df, row_id_col="gene_id", value_cols=["s1"])
+    by_id = audit.set_index("source_row_id")
+
+    assert by_id.loc["ensg00000141510.17", "mapping_status"] == "resolved"
+    assert by_id.loc["ensg00000141510.17", "canonical_ensembl_gene_id"] == "ENSG00000141510"
+    assert by_id.loc["enst00000644628", "mapping_status"] == "resolved"
+    assert by_id.loc["enst00000644628", "canonical_ensembl_gene_id"] == "ENSG00000171862"
+
+    matrix, _ = ee.canonicalize_source_gene_matrix(df, row_id_col="gene_id", value_cols=["s1"])
+    assert set(matrix["Ensembl_Gene_ID"]) == {"ENSG00000141510", "ENSG00000171862"}
+
+
 def test_map_source_gene_rows_preserves_identifier_unresolved_reasons():
     df = pd.DataFrame(
         {
@@ -222,3 +241,14 @@ def test_coerce_source_expression_values_default_preserves_source_identifiers():
     assert out["symbol"].tolist() == ["TP53", "GGNBP2"]
     assert out["sample_a"].tolist() == [1.5, 0.0]
     assert diag["value_col"].tolist() == ["sample_a"]
+
+
+def test_source_expression_helpers_reject_missing_requested_value_columns():
+    df = pd.DataFrame({"gene_id": ["TP53"], "sample_a": [1.0]})
+
+    with pytest.raises(ValueError, match="missing"):
+        ee.map_source_gene_rows(df, row_id_col="gene_id", value_cols=["sample_b"])
+    with pytest.raises(ValueError, match="missing"):
+        ee.canonicalize_source_gene_matrix(df, row_id_col="gene_id", value_cols=["sample_b"])
+    with pytest.raises(ValueError, match="missing"):
+        ee.coerce_source_expression_values(df, value_cols=["sample_b"])

--- a/tests/test_expression_engine.py
+++ b/tests/test_expression_engine.py
@@ -128,6 +128,43 @@ def test_map_source_gene_rows_preserves_identifier_unresolved_reasons():
     assert by_id.loc["123456789", "mapping_method"] == "unresolved"
 
 
+def test_map_source_gene_rows_accepts_symbol_only_matrix_by_default():
+    df = pd.DataFrame({"Symbol": ["TP53", "PTEN"], "sample_a": [5.0, 7.0]})
+    audit = ee.map_source_gene_rows(df)
+    by_id = audit.set_index("source_row_id")
+
+    assert by_id.loc["TP53", "canonical_ensembl_gene_id"] == "ENSG00000141510"
+    assert by_id.loc["PTEN", "canonical_ensembl_gene_id"] == "ENSG00000171862"
+
+    matrix, _ = ee.canonicalize_source_gene_matrix(df)
+    assert set(matrix["Symbol"]) == {"TP53", "PTEN"}
+    assert matrix["sample_a"].sum() == 12.0
+
+
+def test_map_source_gene_rows_treats_duplicate_synonym_alias_as_ambiguous():
+    df = pd.DataFrame({"gene_id": ["A3"], "sample_a": [9.0]})
+    audit = ee.map_source_gene_rows(df, row_id_col="gene_id")
+    row = audit.iloc[0]
+
+    assert row["mapping_status"] == "ambiguous"
+    assert row["mapping_method"] == "ambiguous"
+    assert row["unresolved_reason"] == "ambiguous_symbol"
+    assert pd.isna(row["canonical_ensembl_gene_id"])
+
+
+def test_map_source_gene_rows_handles_duplicate_dataframe_index_labels():
+    df = pd.DataFrame(
+        {"gene_id": ["TP53", "PTEN"], "sample_a": [5.0, 7.0]},
+        index=["dup", "dup"],
+    )
+    audit = ee.map_source_gene_rows(df, row_id_col="gene_id")
+
+    assert audit["source_row_index"].tolist() == ["dup", "dup"]
+    assert audit["source_value_sum"].tolist() == [5.0, 7.0]
+    matrix, _ = ee.canonicalize_source_gene_matrix(df, row_id_col="gene_id")
+    assert matrix["sample_a"].sum() == 12.0
+
+
 def test_canonicalize_source_gene_matrix_sums_duplicate_canonical_ids():
     df = pd.DataFrame(
         {

--- a/tests/test_expression_engine.py
+++ b/tests/test_expression_engine.py
@@ -58,3 +58,87 @@ def test_default_map_is_oncoref_extra_tx():
     df = pd.DataFrame({"transcript_id": ["ENST00000264036"], "tpm": [99.0]})
     out = ee.aggregate_transcripts_to_genes(df)
     assert "MCAM" in set(out["gene"])  # ENST00000264036 -> MCAM in extra-tx-mappings
+
+
+def test_detect_source_row_id_type():
+    assert ee.detect_source_row_id_type(["ENSG00000141510.17", "ENSG00000278311"]) == (
+        "ensembl_gene_id"
+    )
+    assert ee.detect_source_row_id_type(["ENST00000264036", "ENST00000367770.8"]) == (
+        "ensembl_transcript_id"
+    )
+    assert ee.detect_source_row_id_type(["TP53", "GGNBP2"]) == "symbol"
+    assert ee.detect_source_row_id_type(["7157", "1234"]) == "entrez_id"
+    assert ee.detect_source_row_id_type(["ENSG00000141510", "TP53"]) == "mixed"
+
+
+def test_map_source_gene_rows_resolves_ids_symbols_and_transcripts():
+    df = pd.DataFrame(
+        {
+            "gene_id": [
+                "ENSG00000005955.7",  # old GGNBP2 id -> canonical alias
+                "TP53",
+                "ENST00000264036",
+                "NOT_A_REAL_GENE",
+            ],
+            "s1": [2.0, 3.0, 4.0, 10.0],
+        }
+    )
+    audit = ee.map_source_gene_rows(df, row_id_col="gene_id", value_cols=["s1"])
+    by_id = audit.set_index("source_row_id")
+
+    assert by_id.loc["ENSG00000005955.7", "canonical_ensembl_gene_id"] == "ENSG00000278311"
+    assert by_id.loc["ENSG00000005955.7", "mapping_method"] == "ensembl_gene_id_alias"
+    assert by_id.loc["TP53", "canonical_ensembl_gene_id"] == "ENSG00000141510"
+    assert by_id.loc["TP53", "mapping_method"] == "symbol"
+    assert by_id.loc["ENST00000264036", "mapping_method"] == "extra_transcript_mapping"
+    assert by_id.loc["NOT_A_REAL_GENE", "mapping_status"] == "unresolved"
+    assert bool(by_id.loc["NOT_A_REAL_GENE", "high_expression_unresolved"]) is True
+
+    stats = ee.source_gene_mapping_stats(audit)
+    assert stats["n_source_rows"] == 4
+    assert stats["n_resolved_rows"] == 3
+    assert stats["n_high_expression_unresolved_rows"] == 1
+
+
+def test_canonicalize_source_gene_matrix_sums_duplicate_canonical_ids():
+    df = pd.DataFrame(
+        {
+            "gene_id": ["ENSG00000005955.7", "ENSG00000278311", "TP53", "NOT_A_REAL_GENE"],
+            "sample_a": [1.0, 2.0, 5.0, 100.0],
+            "sample_b": [10.0, 20.0, 50.0, 200.0],
+        }
+    )
+    matrix, audit = ee.canonicalize_source_gene_matrix(
+        df, row_id_col="gene_id", value_cols=["sample_a", "sample_b"]
+    )
+    by_gene = matrix.set_index("Ensembl_Gene_ID")
+
+    assert by_gene.loc["ENSG00000278311", "Symbol"] == "GGNBP2"
+    assert by_gene.loc["ENSG00000278311", "sample_a"] == 3.0
+    assert by_gene.loc["ENSG00000278311", "sample_b"] == 30.0
+    assert by_gene.loc["ENSG00000141510", "sample_a"] == 5.0
+    assert "NOT_A_REAL_GENE" in set(
+        audit.loc[audit["mapping_status"] == "unresolved", "source_row_id"]
+    )
+    assert matrix.attrs["source_gene_mapping_stats"]["n_unresolved_rows"] == 1
+
+
+def test_coerce_source_expression_values_distinguishes_missing_nonparse_and_zero():
+    df = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG00000141510", "ENSG00000278311", "ENSG00000000003"],
+            "s1": ["0", "", None],
+            "s2": ["1.5", "bad", "0"],
+        }
+    )
+    out, diag = ee.coerce_source_expression_values(df, value_cols=["s1", "s2"])
+    by_col = diag.set_index("value_col")
+
+    assert out["s1"].isna().sum() == 2
+    assert out["s2"].isna().sum() == 1
+    assert by_col.loc["s1", "n_literal_zero"] == 1
+    assert by_col.loc["s1", "n_parse_missing"] == 1
+    assert by_col.loc["s1", "n_input_missing"] == 1
+    assert by_col.loc["s2", "n_literal_zero"] == 1
+    assert by_col.loc["s2", "n_parse_missing"] == 1


### PR DESCRIPTION
## Summary

Adds reusable builder-side primitives in `oncoref.expression_engine` for source expression matrix ingestion:

- source row ID-type detection (`ENSG`, `ENST`, symbol, Entrez, mixed/unknown);
- row-level source gene mapping audits over canonical ENSG IDs, symbols/synonyms, Ensembl aliases, and supplemental transcript mappings;
- linear-space duplicate canonical gene aggregation with the full audit returned alongside the matrix;
- source value coercion diagnostics that distinguish input missing values, non-parsing values, and literal zeros;
- API guide documentation for `expression_engine` as the builder primitive layer.

## Why

This starts the #210 API surface without claiming a rebuilt expression bundle exists yet. It gives pirlygenes/oncoref builders a shared import point for the row-mapping and parse-QC pieces that feed the broader source-matrix QC work in #203 and the sparse/artifactual-zero audit in #205.

## Scope Notes

This PR does not regenerate source matrices, rebuild expression artifacts, or publish a new data bundle. It only exposes the reusable primitives and tests their behavior.

Refs #210
Refs #203
Refs #205

## Validation

- `./lint.sh`
- `python -m pytest tests/test_expression_engine.py tests/test_expression.py tests/test_build_generators.py`