### PR TITLE
Create GitHub release objects during deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build-and-publish:
+    if: ${{ !contains(github.event.release.body, '<!-- oncoref-deploy-pypi-published -->') }}
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,11 @@
-#!/bin/bash
-set -o errexit
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-pirl-unc/oncoref}"
+VERSION="$(python3 -c 'from oncoref.version import __version__; print(__version__)')"
+TAG="v${VERSION}"
+PYPI_URL="https://pypi.org/project/oncoref/${VERSION}/"
+PYPI_PUBLISHED_MARKER="<!-- oncoref-deploy-pypi-published -->"
 
 ./lint.sh
 ./test.sh
@@ -7,5 +13,29 @@ python3 -m pip install --upgrade build twine
 rm -rf dist
 python3 -m build
 python3 -m twine upload dist/*
-git tag "$(python3 oncoref/version.py)"
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "tag $TAG already exists locally"
+else
+    git tag "$TAG"
+fi
 git push --tags
+
+RELEASE_NOTES="${PYPI_PUBLISHED_MARKER}
+
+PyPI package: ${PYPI_URL}
+
+This release was published by \`./deploy.sh\` after local lint and test checks passed."
+
+if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+    gh release edit "$TAG" \
+        --repo "$REPO" \
+        --title "$TAG" \
+        --notes "$RELEASE_NOTES"
+else
+    gh release create "$TAG" \
+        --repo "$REPO" \
+        --verify-tag \
+        --title "$TAG" \
+        --notes "$RELEASE_NOTES" \
+        --generate-notes
+fi

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_release_workflow_skips_deploy_sh_created_releases():
+    workflow = Path(".github/workflows/release.yml").read_text()
+
+    assert "oncoref-deploy-pypi-published" in workflow
+    assert "gh-action-pypi-publish" in workflow


### PR DESCRIPTION
## Summary

- make `./deploy.sh` create or update a public GitHub release for the package tag after PyPI upload and tag push
- add a release-body marker so deploy-created releases do not trigger the release workflow to duplicate the PyPI upload
- keep the release workflow available for manually published releases without that marker

Fixes #228.
Refs #209.

## Tests

- `bash -n deploy.sh`
- `python -m pytest tests/test_release_workflow.py`
- `./lint.sh`