### PR TITLE
Broaden cancer reference expression compatibility API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -156,6 +156,25 @@ columns are `<CODE>_FPKM_raw`, deterministic TCGA TPM companions are
 `column_style="pirlygenes"`; the legacy `to_tpm=True` keyword is accepted as a
 compatibility alias for that view and maps the default call to `normalize="tpm"`.
 
+`expression.cancer_reference_expression()` returns cohort-level tumor reference
+expression with stable long or wide output. It accepts canonical cancer codes,
+aliases, and aggregate cohorts, resolves gene filters by ENSG or symbol, and can
+return one or more normalization modes in one call:
+
+- `normalize="tpm_clean"` / `"clean_tpm"` — shipped biological clean-TPM
+  percentiles.
+- `normalize="tpm_clean_biological"` — explicit name for that biological-only
+  reference artifact.
+- `normalize="tpm_clean_log1p"` — stored log1p biological clean-TPM percentiles.
+- `normalize="tpm_raw"` / `"tpm"` — source-matrix raw TPM summaries recomputed
+  through `cohort_stats`.
+
+Long output includes source/provenance columns by default, including source
+cohort, source type/unit, source scale class, reference method, `DATA_VERSION`,
+and `SOURCE_MATRIX_VERSION`. This accessor is the compatibility surface for
+reference-expression reads; expression artifact row-set/value parity is still
+tracked separately in the upstream parity issues.
+
 Clean TPM has one public compartment contract:
 
 - `clean-tpm-censored-genes.csv:category == "ribosomal_protein"` — 16%

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -762,16 +762,21 @@ def cancer_reference_expression(
     The default long form mirrors the downstream reference contract:
     ``Ensembl_Gene_ID``, ``Symbol``, ``cancer_code``, ``source_cohort``,
     ``normalization``, ``expression`` (median clean TPM), ``q1`` and ``q3``.
-    Wide form returns one row per gene with ``<CODE>_TPM_clean`` columns.
+    Wide form returns one row per gene with ``<CODE>_<normalization>`` columns.
+
+    ``normalize`` accepts one mode or an iterable of modes:
+      - ``"tpm_clean"`` / ``"clean_tpm"``: shipped biological clean-TPM percentiles;
+      - ``"tpm_clean_biological"``: explicit alias for that biological-only artifact;
+      - ``"tpm_clean_log1p"``: stored log1p biological clean-TPM percentiles;
+      - ``"tpm_raw"`` / ``"tpm"`` / ``"raw_tpm"``: raw-TPM cohort stats recomputed from
+        the source matrix.
+
+    Raw-TPM mode needs the per-sample source matrix available; pass
+    ``auto_fetch=True`` to download it.
     """
     modes = _reference_normalize_modes(normalize)
     if format not in ("long", "wide"):
         raise ValueError("format must be 'long' or 'wide'")
-    if modes != {"tpm_clean"}:
-        raise ValueError(
-            "cancer_reference_expression currently supports normalize='tpm_clean' "
-            "(alias 'clean_tpm')"
-        )
     available = set(available_percentile_cohorts())
     if cancer_types is None:
         codes = sorted(available)
@@ -782,31 +787,29 @@ def cancer_reference_expression(
     long_parts: list[pd.DataFrame] = []
     wide_parts: list[pd.DataFrame] = []
     for code in codes:
-        pct = cohort_gene_percentiles(code, as_tpm=True, auto_fetch=auto_fetch)
-        pct = pct[_gene_filter_mask(pct, genes)].reset_index(drop=True)
-        if format == "long":
-            part = pct[["Ensembl_Gene_ID", "Symbol", "p25", "p50", "p75"]].copy()
-            part.insert(2, "cancer_code", code)
-            if include_provenance:
-                part.insert(3, "source_cohort", code)
-            part["normalization"] = "tpm_clean"
-            part = part.rename(columns={"p50": "expression", "p25": "q1", "p75": "q3"})
-            cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code"]
-            if include_provenance:
-                cols.append("source_cohort")
-            cols += ["normalization", "expression", "q1", "q3"]
-            long_parts.append(part[cols])
-        else:
-            part = pct[["Ensembl_Gene_ID", "Symbol", "p50"]].rename(
-                columns={"p50": f"{code}_TPM_clean"}
-            )
-            wide_parts.append(part)
+        for mode in modes:
+            ref, method = _reference_expression_frame(code, mode, auto_fetch=auto_fetch)
+            ref = ref[_gene_filter_mask(ref, genes)].reset_index(drop=True)
+            label = _REFERENCE_NORMALIZE_LABELS[mode]
+            if format == "long":
+                part = ref[["Ensembl_Gene_ID", "Symbol", "p25", "p50", "p75"]].copy()
+                part.insert(2, "cancer_code", code)
+                part["normalization"] = label
+                part = part.rename(columns={"p50": "expression", "p25": "q1", "p75": "q3"})
+                if include_provenance:
+                    provenance = _reference_expression_provenance(code, mode, method)
+                    for col, value in provenance.items():
+                        part[col] = value
+                long_parts.append(part[_reference_long_columns(include_provenance)])
+            else:
+                suffix = _REFERENCE_WIDE_SUFFIXES[mode]
+                part = ref[["Ensembl_Gene_ID", "Symbol", "p50"]].rename(
+                    columns={"p50": f"{code}_{suffix}"}
+                )
+                wide_parts.append(part)
 
     if format == "long":
-        cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code"]
-        if include_provenance:
-            cols.append("source_cohort")
-        cols += ["normalization", "expression", "q1", "q3"]
+        cols = _reference_long_columns(include_provenance)
         if not long_parts:
             return pd.DataFrame(columns=cols)
         return pd.concat(long_parts, ignore_index=True)
@@ -816,12 +819,102 @@ def cancer_reference_expression(
     return _merge_cancer_reference_wide_parts(wide_parts)
 
 
-def _reference_normalize_modes(normalize: str | Iterable[str]) -> set[str]:
+_REFERENCE_NORMALIZE_ALIASES = {
+    "clean_tpm": "tpm_clean",
+    "tpm_clean": "tpm_clean",
+    "clean_tpm_biological": "tpm_clean_biological",
+    "tpm_clean_biological": "tpm_clean_biological",
+    "biological_clean_tpm": "tpm_clean_biological",
+    "tpm_clean_log1p": "tpm_clean_log1p",
+    "clean_tpm_log1p": "tpm_clean_log1p",
+    "tpm": "tpm_raw",
+    "raw_tpm": "tpm_raw",
+    "tpm_raw": "tpm_raw",
+}
+
+_REFERENCE_NORMALIZE_LABELS = {
+    "tpm_clean": "tpm_clean",
+    "tpm_clean_biological": "tpm_clean_biological",
+    "tpm_clean_log1p": "tpm_clean_log1p",
+    "tpm_raw": "tpm_raw",
+}
+
+_REFERENCE_WIDE_SUFFIXES = {
+    "tpm_clean": "TPM_clean",
+    "tpm_clean_biological": "TPM_clean_biological",
+    "tpm_clean_log1p": "TPM_clean_log1p",
+    "tpm_raw": "TPM_raw",
+}
+
+_REFERENCE_PROVENANCE_COLUMNS = [
+    "source_cohort",
+    "source_type",
+    "source_unit",
+    "source_scale_class",
+    "linear_tpm_comparable",
+    "reference_method",
+    "data_version",
+    "source_matrix_version",
+]
+
+
+def _reference_normalize_modes(normalize: str | Iterable[str]) -> list[str]:
     if isinstance(normalize, str):
-        modes = {normalize.lower()}
+        requested = [normalize]
     else:
-        modes = {str(mode).lower() for mode in normalize}
-    return {"tpm_clean" if mode == "clean_tpm" else mode for mode in modes}
+        requested = list(normalize)
+    modes: list[str] = []
+    bad: list[str] = []
+    for mode in requested:
+        key = str(mode).lower()
+        resolved = _REFERENCE_NORMALIZE_ALIASES.get(key)
+        if resolved is None:
+            bad.append(str(mode))
+        elif resolved not in modes:
+            modes.append(resolved)
+    if bad:
+        supported = ", ".join(sorted(_REFERENCE_NORMALIZE_ALIASES))
+        raise ValueError(f"unsupported reference normalize mode(s): {bad}; supported: {supported}")
+    return modes
+
+
+def _reference_long_columns(include_provenance: bool) -> list[str]:
+    cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code", "normalization"]
+    if include_provenance:
+        cols += _REFERENCE_PROVENANCE_COLUMNS
+    return [*cols, "expression", "q1", "q3"]
+
+
+def _reference_expression_frame(
+    code: str, mode: str, *, auto_fetch: bool
+) -> tuple[pd.DataFrame, str]:
+    if mode in {"tpm_clean", "tpm_clean_biological"}:
+        return cohort_gene_percentiles(code, as_tpm=True, auto_fetch=auto_fetch), "percentile_shard"
+    if mode == "tpm_clean_log1p":
+        return (
+            cohort_gene_percentiles(code, as_tpm=False, auto_fetch=auto_fetch),
+            "percentile_shard_log1p",
+        )
+    if mode == "tpm_raw":
+        return (
+            cohort_stats(code, normalize="tpm_raw", auto_fetch=auto_fetch, sample_qc="all"),
+            "source_matrix_stats",
+        )
+    raise AssertionError(f"unhandled reference normalize mode: {mode}")
+
+
+def _reference_expression_provenance(code: str, mode: str, method: str) -> dict:
+    meta = _selected_expression_source_metadata(code)
+    return {
+        "source_cohort": meta["source_cohort"] or code,
+        "source_type": meta["source_type"],
+        "source_unit": meta["unit"],
+        "source_scale_class": meta["source_scale_class"],
+        "linear_tpm_comparable": bool(meta["linear_tpm_comparable"]),
+        "reference_method": method,
+        "data_version": DATA_VERSION,
+        "source_matrix_version": SOURCE_MATRIX_VERSION,
+    }
 
 
 def _merge_cancer_reference_wide_parts(parts: list[pd.DataFrame]) -> pd.DataFrame:

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -709,14 +709,22 @@ def test_cancer_reference_expression_long_and_wide(monkeypatch):
         "Ensembl_Gene_ID",
         "Symbol",
         "cancer_code",
-        "source_cohort",
         "normalization",
+        "source_cohort",
+        "source_type",
+        "source_unit",
+        "source_scale_class",
+        "linear_tpm_comparable",
+        "reference_method",
+        "data_version",
+        "source_matrix_version",
         "expression",
         "q1",
         "q3",
     ]
     assert long["cancer_code"].tolist() == ["X"]
     assert long["normalization"].tolist() == ["tpm_clean"]
+    assert long["reference_method"].tolist() == ["percentile_shard"]
     assert long["expression"].tolist() == [3.0]
     assert long["q1"].tolist() == [1.0] and long["q3"].tolist() == [5.0]
     assert expression.cancer_reference_expression("x", genes=["E1"], normalize="clean_tpm").equals(
@@ -726,6 +734,84 @@ def test_cancer_reference_expression_long_and_wide(monkeypatch):
     wide = expression.cancer_reference_expression(["x", "y"], format="wide")
     assert {"X_TPM_clean", "Y_TPM_clean"} <= set(wide.columns)
     assert wide.loc[wide["Symbol"] == "A", "X_TPM_clean"].iloc[0] == 3.0
+
+
+def test_cancer_reference_expression_multiple_normalizations(monkeypatch):
+    pct_tpm = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1"],
+            "Symbol": ["A"],
+            "p25": [1.0],
+            "p50": [3.0],
+            "p75": [5.0],
+        }
+    )
+    pct_log = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1"],
+            "Symbol": ["A"],
+            "p25": [np.log1p(1.0)],
+            "p50": [np.log1p(3.0)],
+            "p75": [np.log1p(5.0)],
+        }
+    )
+
+    def fake_pct(code, *, as_tpm=True, **kwargs):
+        return pct_tpm.copy() if as_tpm else pct_log.copy()
+
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+    monkeypatch.setattr(expression, "cohort_gene_percentiles", fake_pct)
+
+    long = expression.cancer_reference_expression("x", normalize=["clean_tpm", "tpm_clean_log1p"])
+    assert long["normalization"].tolist() == ["tpm_clean", "tpm_clean_log1p"]
+    assert long["expression"].tolist() == [3.0, pytest.approx(np.log1p(3.0))]
+
+    wide = expression.cancer_reference_expression(
+        "x", normalize=["tpm_clean", "tpm_clean_log1p"], format="wide"
+    )
+    assert wide.loc[0, "X_TPM_clean"] == 3.0
+    assert wide.loc[0, "X_TPM_clean_log1p"] == pytest.approx(np.log1p(3.0))
+
+
+def test_cancer_reference_expression_raw_tpm_uses_source_stats(monkeypatch):
+    stats = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1"],
+            "Symbol": ["A"],
+            "p25": [10.0],
+            "p50": [20.0],
+            "p75": [30.0],
+        }
+    )
+    seen = {}
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+    monkeypatch.setattr(
+        expression,
+        "cohort_stats",
+        lambda code, **k: seen.update(k) or stats.copy(),
+    )
+    monkeypatch.setattr(
+        expression,
+        "_selected_expression_source_metadata",
+        lambda code: {
+            "source_cohort": "SRC_X",
+            "source_type": "gdc",
+            "unit": "TPM",
+            "source_scale_class": "linear_rnaseq_tpm",
+            "linear_tpm_comparable": True,
+            "tpm_proxy": False,
+        },
+    )
+
+    long = expression.cancer_reference_expression("x", normalize="tpm", auto_fetch=True)
+    assert seen == {"normalize": "tpm_raw", "auto_fetch": True, "sample_qc": "all"}
+    assert long["normalization"].tolist() == ["tpm_raw"]
+    assert long["source_cohort"].tolist() == ["SRC_X"]
+    assert long["source_type"].tolist() == ["gdc"]
+    assert long["reference_method"].tolist() == ["source_matrix_stats"]
+    assert long["expression"].tolist() == [20.0]
 
 
 def test_cancer_reference_expression_wide_merges_by_gene_id_not_symbol(monkeypatch):


### PR DESCRIPTION
## Summary

- broaden `cancer_reference_expression()` to accept one or more reference-expression normalization modes
- add long-output provenance fields for source cohort/type/unit, scale class, reference method, data version, and source matrix version
- document the accessor as the #207 compatibility surface while keeping #191/#193/#208 artifact row/value parity tracked separately

## Supported modes

- `tpm_clean` / `clean_tpm`: shipped biological clean-TPM percentile shards
- `tpm_clean_biological`: explicit name for the biological-only clean-TPM reference artifact
- `tpm_clean_log1p`: stored log1p biological clean-TPM percentile shards
- `tpm_raw` / `tpm`: source-matrix raw TPM summaries via `cohort_stats(..., sample_qc="all")`

## References

- Addresses the API-surface part of #207
- Leaves full artifact parity under #191, #193, and #208

## Validation

- `python -m pytest tests/test_expression.py -k "cancer_reference_expression or representative"`
- `python -m pytest tests/test_api_structure.py tests/test_catalog.py`
- `./lint.sh`
- `./test.sh`
