### PR TITLE
Version source expression audit schemas

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -139,7 +139,10 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   missing-vs-non-parsing numeric diagnostics, and canonical ENSG aggregation in
   linear expression space. Use these in builders before committing a source
   matrix so unresolved high-expression rows and duplicate canonical IDs are
-  explicit artifacts rather than hidden cleanup.
+  explicit artifacts rather than hidden cleanup. Source audit CSV contracts are
+  versioned by `SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION` and
+  `SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION`, and the emitted audit frames
+  include those versions as persisted columns.
 - `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,
   log transforms, percentile ranks, and housekeeping normalization.
 

--- a/oncoref/expression_engine.py
+++ b/oncoref/expression_engine.py
@@ -90,6 +90,7 @@ _DEFAULT_GENE_SYMBOL_COLUMN_CANDIDATES = (
 )
 
 SOURCE_GENE_MAPPING_AUDIT_COLUMNS = (
+    "source_gene_mapping_schema_version",
     "source_row_index",
     "source_row_id",
     "source_row_id_type",
@@ -104,6 +105,7 @@ SOURCE_GENE_MAPPING_AUDIT_COLUMNS = (
 )
 
 SOURCE_VALUE_PARSE_DIAGNOSTIC_COLUMNS = (
+    "source_value_parse_schema_version",
     "value_col",
     "n_values",
     "n_input_missing",
@@ -112,6 +114,9 @@ SOURCE_VALUE_PARSE_DIAGNOSTIC_COLUMNS = (
     "parse_missing_fraction",
     "literal_zero_fraction",
 )
+
+SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION = "source_gene_mapping_audit_v1"
+SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION = "source_value_parse_diagnostics_v1"
 
 
 def find_column(df: pd.DataFrame, candidates, column_name: str) -> str:
@@ -395,6 +400,7 @@ def map_source_gene_rows(
         source_value_sum = float(row_sum_values[pos]) if pos < len(row_sum_values) else 0.0
         rows.append(
             {
+                "source_gene_mapping_schema_version": SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION,
                 "source_row_index": idx,
                 "source_row_id": raw_id,
                 "source_row_id_type": row_type if row_type != "unknown" else id_type,
@@ -410,7 +416,9 @@ def map_source_gene_rows(
                 ),
             }
         )
-    return pd.DataFrame(rows, columns=SOURCE_GENE_MAPPING_AUDIT_COLUMNS)
+    out = pd.DataFrame(rows, columns=SOURCE_GENE_MAPPING_AUDIT_COLUMNS)
+    out.attrs["schema_version"] = SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION
+    return out
 
 
 def coerce_source_expression_values(
@@ -445,6 +453,7 @@ def coerce_source_expression_values(
         n = len(raw)
         rows.append(
             {
+                "source_value_parse_schema_version": SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION,
                 "value_col": col,
                 "n_values": n,
                 "n_input_missing": int(input_missing.sum()),
@@ -455,7 +464,9 @@ def coerce_source_expression_values(
             }
         )
         out[col] = coerced
-    return out, pd.DataFrame(rows, columns=SOURCE_VALUE_PARSE_DIAGNOSTIC_COLUMNS)
+    diagnostics = pd.DataFrame(rows, columns=SOURCE_VALUE_PARSE_DIAGNOSTIC_COLUMNS)
+    diagnostics.attrs["schema_version"] = SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION
+    return out, diagnostics
 
 
 def canonicalize_source_gene_matrix(
@@ -596,6 +607,10 @@ def aggregate_transcripts_to_genes(
 
 
 __all__ = [
+    "SOURCE_GENE_MAPPING_AUDIT_COLUMNS",
+    "SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION",
+    "SOURCE_VALUE_PARSE_DIAGNOSTIC_COLUMNS",
+    "SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION",
     "aggregate_transcripts_to_genes",
     "canonicalize_source_gene_matrix",
     "coerce_source_expression_values",

--- a/tests/test_expression_engine.py
+++ b/tests/test_expression_engine.py
@@ -101,6 +101,33 @@ def test_map_source_gene_rows_resolves_ids_symbols_and_transcripts():
     assert stats["n_high_expression_unresolved_rows"] == 1
 
 
+def test_source_audit_outputs_include_persisted_schema_versions():
+    df = pd.DataFrame({"gene_id": ["TP53"], "sample_a": ["1.5"]})
+
+    audit = ee.map_source_gene_rows(df, row_id_col="gene_id", value_cols=["sample_a"])
+    coerced, diagnostics = ee.coerce_source_expression_values(df, value_cols=["sample_a"])
+    matrix, matrix_audit = ee.canonicalize_source_gene_matrix(
+        df, row_id_col="gene_id", value_cols=["sample_a"]
+    )
+
+    assert audit.attrs["schema_version"] == ee.SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION
+    assert audit["source_gene_mapping_schema_version"].unique().tolist() == [
+        ee.SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION
+    ]
+    assert diagnostics.attrs["schema_version"] == ee.SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION
+    assert diagnostics["source_value_parse_schema_version"].unique().tolist() == [
+        ee.SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION
+    ]
+    assert matrix_audit["source_gene_mapping_schema_version"].unique().tolist() == [
+        ee.SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION
+    ]
+    parse = matrix.attrs["source_value_parse_diagnostics"]
+    assert parse["source_value_parse_schema_version"].unique().tolist() == [
+        ee.SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION
+    ]
+    assert coerced["sample_a"].tolist() == [1.5]
+
+
 def test_map_source_gene_rows_falls_back_from_noncanonical_transcript_gene_id():
     df = pd.DataFrame({"gene_id": ["ENST00000644628"], "s1": [11.0]})
     audit = ee.map_source_gene_rows(df, row_id_col="gene_id", value_cols=["s1"])


### PR DESCRIPTION
## Summary

- add persisted schema-version columns to source gene-mapping audit frames and source value-parse diagnostic frames
- export schema-version constants alongside the existing stable column tuples
- document the source-audit CSV contract in the API guide

## Why

This tightens the reusable builder primitive contract requested in #210. The mapping and parse-audit helpers already exist; this PR makes their emitted CSV shape explicitly versioned so downstream builders such as pirlygenes can pin the contract instead of relying only on implicit column names.

## References

- Part of #210
- Related source-QC/artifact ownership comments in #203 and #205

## Validation

- `python -m pytest tests/test_expression_engine.py tests/test_build_generators.py -q`
- `./lint.sh`
- `./test.sh`
