### PR TITLE
Expose data bundle contract metadata

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -229,7 +229,10 @@ but it is not the clean-TPM biological denominator.
 ## Data Management
 
 - `oncoref.catalog` — unified dataset inventory and fetch/status/path operations.
-- `oncoref.data_bundle` — heavy expression bundle cache.
+- `oncoref.data_bundle` — heavy expression bundle cache. Use
+  `data_bundle.bundle_contract()` to inspect the downstream-stable package/data
+  version linkage, release asset URLs, cache environment variables, completion
+  marker policy, and expected artifact inventory for the active bundle.
 - `oncoref.reference_data` / `oncoref.hpa` — HPA reference-data cache and HPA
   tissue/cell-type accessors.
 

--- a/oncoref/data_bundle.py
+++ b/oncoref/data_bundle.py
@@ -55,7 +55,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-from .version import DATA_VERSION
+from .version import DATA_VERSION, SOURCE_MATRIX_VERSION, __version__
 
 
 def _release_url(repo: str, filename: str) -> str:
@@ -108,6 +108,7 @@ RELEASE_URLS: tuple[str, ...] = tuple(source["url"] for source in RELEASE_SOURCE
 CACHE_COMPLETE_FILENAME = ".oncoref-bundle-complete.json"
 CACHE_MANIFEST_VERSION = 1
 BUNDLE_MANIFEST_VERSION = 1
+BUNDLE_CONTRACT_VERSION = 1
 
 
 class BundleIntegrityError(RuntimeError):
@@ -387,6 +388,42 @@ def find(relative_path: str) -> Path | None:
     return candidate if candidate.exists() else None
 
 
+def bundle_contract() -> dict:
+    """Stable downstream contract for the active expression data bundle.
+
+    This is the single lightweight object a downstream package can inspect to
+    know which package/data/source-matrix versions belong together, which release
+    assets should exist, which cache override variables are honored, and which
+    artifact paths make up a complete bundle.
+    """
+    sources = [
+        {
+            "name": source["name"],
+            "repo": source["repo"],
+            "tarball_filename": source["tarball_filename"],
+            "release_url": source["url"],
+            "manifest_url": source["manifest_url"],
+            "checksum_url": source["checksum_url"],
+            "require_integrity": bool(source["require_integrity"]),
+        }
+        for source in RELEASE_SOURCES
+    ]
+    return {
+        "contract_version": BUNDLE_CONTRACT_VERSION,
+        "package_version": __version__,
+        "data_version": DATA_VERSION,
+        "source_matrix_version": SOURCE_MATRIX_VERSION,
+        "cache_dir_env_var": CACHE_DIR_ENV_VAR,
+        "legacy_cache_dir_env_var": LEGACY_CACHE_DIR_ENV_VAR,
+        "cache_complete_filename": CACHE_COMPLETE_FILENAME,
+        "cache_manifest_version": CACHE_MANIFEST_VERSION,
+        "bundle_manifest_version": BUNDLE_MANIFEST_VERSION,
+        "downloadable_paths": list(DOWNLOADABLE_PATHS),
+        "release_sources": sources,
+        "primary_release_source": sources[0],
+    }
+
+
 def _download_and_extract(
     url: str,
     root: Path,
@@ -539,8 +576,12 @@ def status() -> dict:
     for p, item in items.items():
         item["path"] = str(root / p)
     marker = _read_completion_marker(root)
+    contract = bundle_contract()
     return {
+        "contract_version": contract["contract_version"],
+        "package_version": __version__,
         "data_version": DATA_VERSION,
+        "source_matrix_version": SOURCE_MATRIX_VERSION,
         "cache_dir": str(root),
         "release_url": RELEASE_URL,
         "release_urls": list(RELEASE_URLS),
@@ -555,6 +596,7 @@ def status() -> dict:
         },
         "items": items,
         "all_local": is_local(),
+        "contract": contract,
     }
 
 
@@ -658,6 +700,7 @@ def prune_cache(*, keep_current: bool = True, dry_run: bool = False) -> list[dic
 
 
 __all__ = [
+    "BUNDLE_CONTRACT_VERSION",
     "BUNDLE_MANIFEST_VERSION",
     "CACHE_COMPLETE_FILENAME",
     "CHECKSUM_FILENAME",
@@ -678,6 +721,7 @@ __all__ = [
     "RELEASE_URLS",
     "TARBALL_FILENAME",
     "BundleIntegrityError",
+    "bundle_contract",
     "cache_dir",
     "cache_root",
     "ensure_local",

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -12,7 +12,7 @@ import urllib.error
 import pytest
 
 from oncoref import data_bundle
-from oncoref.version import DATA_VERSION
+from oncoref.version import DATA_VERSION, SOURCE_MATRIX_VERSION, __version__
 
 
 def test_is_downloadable_distinguishes_bundle_from_wheel():
@@ -45,13 +45,35 @@ def test_new_env_wins_over_legacy(monkeypatch, tmp_path):
 def test_status_reports_missing_without_download(monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
     snap = data_bundle.status()
+    assert snap["contract_version"] == data_bundle.BUNDLE_CONTRACT_VERSION
+    assert snap["package_version"] == __version__
     assert snap["all_local"] is False
+    assert snap["data_version"] == DATA_VERSION
+    assert snap["source_matrix_version"] == SOURCE_MATRIX_VERSION
     assert snap["completion_marker"]["present"] is False
     assert snap["completion_marker"]["valid"] is False
     assert snap["release_manifest_url"] == data_bundle.RELEASE_MANIFEST_URL
     assert snap["release_checksum_url"] == data_bundle.RELEASE_CHECKSUM_URL
     assert set(snap["items"]) == set(data_bundle.DOWNLOADABLE_PATHS)
     assert all(not v["present"] for v in snap["items"].values())
+    assert snap["contract"] == data_bundle.bundle_contract()
+
+
+def test_bundle_contract_links_package_data_release_and_cache_policy():
+    contract = data_bundle.bundle_contract()
+
+    assert contract["contract_version"] == data_bundle.BUNDLE_CONTRACT_VERSION
+    assert contract["package_version"] == __version__
+    assert contract["data_version"] == DATA_VERSION
+    assert contract["source_matrix_version"] == SOURCE_MATRIX_VERSION
+    assert contract["cache_dir_env_var"] == data_bundle.CACHE_DIR_ENV_VAR
+    assert contract["legacy_cache_dir_env_var"] == data_bundle.LEGACY_CACHE_DIR_ENV_VAR
+    assert contract["downloadable_paths"] == list(data_bundle.DOWNLOADABLE_PATHS)
+    assert contract["primary_release_source"]["name"] == "oncoref"
+    assert contract["primary_release_source"]["require_integrity"] is True
+    assert contract["primary_release_source"]["manifest_url"] == data_bundle.RELEASE_MANIFEST_URL
+    assert contract["primary_release_source"]["checksum_url"] == data_bundle.RELEASE_CHECKSUM_URL
+    assert [s["name"] for s in contract["release_sources"]] == ["oncoref", "pirlygenes"]
 
 
 def _write_bundle_fixture(root):


### PR DESCRIPTION
## Summary

- add `data_bundle.bundle_contract()` as a single downstream-stable data-bundle contract object
- include package version, `DATA_VERSION`, `SOURCE_MATRIX_VERSION`, release assets, cache env vars, completion-marker policy, and expected bundle inventory
- embed the same contract/version fields in `data_bundle.status()` and document the API

## Why

This addresses another concrete part of #209: downstream consumers need a stable way to know which package version expects which data bundle/source-matrix versions and which release/cache artifacts define a complete bundle. The download integrity mechanics already exist; this PR makes that contract easy to inspect.

## References

- Part of #209
- Related to #14/#21 bundle-release and cache-integrity requirements

## Validation

- `python -m pytest tests/test_data_bundle.py tests/test_catalog.py -q`
- `./lint.sh`
- `./test.sh`
