### PR TITLE
Expose cancer reference expression availability

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -178,6 +178,18 @@ and `SOURCE_MATRIX_VERSION`. This accessor is the compatibility surface for
 reference-expression reads; expression artifact row-set/value parity is still
 tracked separately in the upstream parity issues.
 
+Use `expression.cancer_reference_expression_availability()` before delegating a
+downstream reference-expression accessor that must distinguish unavailable
+oncoref artifacts from empty gene filters. It returns one row per requested
+code/mode with `requested_code`, expanded `cancer_code`, `request_kind`,
+`available`, `missing_reason`, provenance fields, and the reference-expression
+schema/data versions. `expression.cancer_reference_expression(...,
+on_missing="empty")` returns a schema-stable empty frame and stores the same
+missing rows in `df.attrs["missing_requests"]`; `on_missing="raise"` fails fast
+for required cohorts. `include_request_metadata=True` adds request/availability
+columns to long expression output, which is useful when a requested aggregate
+expands to child expression cohorts.
+
 Representative and percentile artifact readers have explicit downstream-facing
 contracts:
 

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -117,12 +117,14 @@ from .cta import (
     cta_unfiltered_gene_names,
 )
 from .expression import (
+    REFERENCE_EXPRESSION_SCHEMA_VERSION,
     SHARD_DATASETS,
     ShardDataset,
     available_percentile_cohorts,
     available_representative_cohorts,
     available_within_sample_cohorts,
     cancer_reference_expression,
+    cancer_reference_expression_availability,
     cohort_gene_percentiles,
     cohort_mean_expression,
     cohort_stats,
@@ -286,6 +288,7 @@ __all__ = [
     "CANCER_TYPE_NAMES",
     "OTHER_TECHNICAL_FRACTION",
     "PROPORTION_METRICS",
+    "REFERENCE_EXPRESSION_SCHEMA_VERSION",
     "REGIMEN_FALLBACK",
     "REGIMEN_LABELS",
     "RIBOSOMAL_PROTEIN_FRACTION",
@@ -345,6 +348,7 @@ __all__ = [
     "cancer_normal_tissue_map",
     "cancer_ontology",
     "cancer_reference_expression",
+    "cancer_reference_expression_availability",
     "cancer_subtype_group",
     "cancer_subtype_groupings",
     # TMB

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -161,6 +161,7 @@ _WITHIN_SAMPLE = SHARD_DATASETS["within_sample"]
 
 REPRESENTATIVE_ARTIFACT_SCHEMA_VERSION = "representative_expression_v1"
 PERCENTILE_ARTIFACT_SCHEMA_VERSION = "cohort_percentile_expression_v1"
+REFERENCE_EXPRESSION_SCHEMA_VERSION = "cancer_reference_expression_v1"
 REPRESENTATIVE_SELECTION_METHOD = "central_medoid_then_farthest_first"
 REPRESENTATIVE_SELECTION_BASIS = "biological_clean_tpm_log1p_distance"
 
@@ -984,6 +985,8 @@ def cancer_reference_expression(
     *,
     format: str = "long",
     include_provenance: bool = True,
+    include_request_metadata: bool = False,
+    on_missing: str = "omit",
     auto_fetch: bool = False,
 ) -> pd.DataFrame:
     """Observed tumor expression references as cohort-level clean TPM summaries.
@@ -1001,22 +1004,46 @@ def cancer_reference_expression(
         the source matrix.
 
     Raw-TPM mode needs the per-sample source matrix available; pass
-    ``auto_fetch=True`` to download it.
+    ``auto_fetch=True`` to download it. Missing requested cohorts are omitted by
+    default to preserve the historical behavior; pass ``on_missing="empty"`` to
+    preserve a schema-stable empty result with missing-request metadata in
+    ``df.attrs["missing_requests"]`` or ``on_missing="raise"`` to fail when any
+    requested cohort/mode is unavailable.
     """
     modes = _reference_normalize_modes(normalize)
     if format not in ("long", "wide"):
         raise ValueError("format must be 'long' or 'wide'")
-    available = set(available_percentile_cohorts())
-    if cancer_types is None:
-        codes = sorted(available)
-    else:
-        requested = _resolve_cancer_types(cancer_types, expand_aggregates=True) or []
-        codes = [code for code in dict.fromkeys(requested) if code in available]
+    if on_missing not in ("omit", "empty", "raise"):
+        raise ValueError("on_missing must be 'omit', 'empty', or 'raise'")
+    if include_request_metadata and format != "long":
+        raise ValueError("include_request_metadata=True requires format='long'")
+
+    requests = _reference_expression_requests(cancer_types, modes)
+    availability = _reference_expression_availability_for_requests(requests, modes)
+    missing = availability.loc[~availability["available"]].reset_index(drop=True)
+    if on_missing == "raise" and not missing.empty:
+        detail = ", ".join(
+            f"{r.cancer_code}/{r.normalization}: {r.missing_reason}"
+            for r in missing.itertuples(index=False)
+        )
+        raise ValueError(f"missing cancer reference expression artifact(s): {detail}")
+    available_keys = {
+        (str(r.requested_code), str(r.cancer_code), str(r.normalization))
+        for r in availability.loc[availability["available"]].itertuples(index=False)
+    }
+    request_lookup = {
+        (str(r.requested_code), str(r.cancer_code), str(r.normalization)): r
+        for r in availability.loc[availability["available"]].itertuples(index=False)
+    }
 
     long_parts: list[pd.DataFrame] = []
     wide_parts: list[pd.DataFrame] = []
-    for code in codes:
+    for request in requests:
+        code = request["cancer_code"]
         for mode in modes:
+            request_key = (request["requested_code"], code, mode)
+            if request_key not in available_keys:
+                continue
             ref, method = _reference_expression_frame(code, mode, auto_fetch=auto_fetch)
             ref = ref[_gene_filter_mask(ref, genes)].reset_index(drop=True)
             label = _REFERENCE_NORMALIZE_LABELS[mode]
@@ -1024,12 +1051,20 @@ def cancer_reference_expression(
                 part = ref[["Ensembl_Gene_ID", "Symbol", "p25", "p50", "p75"]].copy()
                 part.insert(2, "cancer_code", code)
                 part["normalization"] = label
+                if include_request_metadata:
+                    request_row = request_lookup[request_key]
+                    part["requested_code"] = request_row.requested_code
+                    part["request_kind"] = request_row.request_kind
+                    part["available"] = bool(request_row.available)
+                    part["missing_reason"] = str(request_row.missing_reason)
                 part = part.rename(columns={"p50": "expression", "p25": "q1", "p75": "q3"})
                 if include_provenance:
                     provenance = _reference_expression_provenance(code, mode, method)
                     for col, value in provenance.items():
                         part[col] = value
-                long_parts.append(part[_reference_long_columns(include_provenance)])
+                long_parts.append(
+                    part[_reference_long_columns(include_provenance, include_request_metadata)]
+                )
             else:
                 suffix = _REFERENCE_WIDE_SUFFIXES[mode]
                 part = ref[["Ensembl_Gene_ID", "Symbol", "p50"]].rename(
@@ -1038,14 +1073,36 @@ def cancer_reference_expression(
                 wide_parts.append(part)
 
     if format == "long":
-        cols = _reference_long_columns(include_provenance)
+        cols = _reference_long_columns(include_provenance, include_request_metadata)
         if not long_parts:
-            return pd.DataFrame(columns=cols)
-        return pd.concat(long_parts, ignore_index=True)
+            out = pd.DataFrame(columns=cols)
+        else:
+            out = pd.concat(long_parts, ignore_index=True)
+        _attach_reference_expression_attrs(out, availability if on_missing != "omit" else None)
+        return out
 
     if not wide_parts:
-        return pd.DataFrame(columns=["Ensembl_Gene_ID", "Symbol"])
-    return _merge_cancer_reference_wide_parts(wide_parts)
+        out = pd.DataFrame(columns=["Ensembl_Gene_ID", "Symbol"])
+    else:
+        out = _merge_cancer_reference_wide_parts(wide_parts)
+    _attach_reference_expression_attrs(out, availability if on_missing != "omit" else None)
+    return out
+
+
+def cancer_reference_expression_availability(
+    cancer_types: str | Iterable[str] | None = None,
+    normalize: str | Iterable[str] = "tpm_clean",
+) -> pd.DataFrame:
+    """Availability/provenance table for :func:`cancer_reference_expression`.
+
+    The result is one row per requested cancer code (expanding computed aggregate
+    requests to member cohorts) and normalization mode. It is intentionally
+    gene-independent: use it to decide whether an empty expression frame means an
+    empty gene filter or an unavailable upstream artifact.
+    """
+    modes = _reference_normalize_modes(normalize)
+    requests = _reference_expression_requests(cancer_types, modes)
+    return _reference_expression_availability_for_requests(requests, modes)
 
 
 _REFERENCE_NORMALIZE_ALIASES = {
@@ -1086,6 +1143,137 @@ _REFERENCE_PROVENANCE_COLUMNS = [
     "source_matrix_version",
 ]
 
+_REFERENCE_REQUEST_COLUMNS = [
+    "requested_code",
+    "request_kind",
+    "available",
+    "missing_reason",
+]
+
+
+def _reference_expression_requests(
+    cancer_types: str | Iterable[str] | None, modes: list[str]
+) -> list[dict[str, str]]:
+    """Resolved request rows while preserving aggregate-vs-direct intent."""
+    if cancer_types is None:
+        return [
+            {"requested_code": code, "cancer_code": code, "request_kind": "default_available"}
+            for code in _reference_available_codes_for_modes(modes)
+        ]
+    raw_values = [cancer_types] if isinstance(cancer_types, str) else list(cancer_types)
+    aggregates = cohort_aggregates()
+    rows: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for raw in raw_values:
+        resolved = resolve_cancer_type(raw)
+        members = aggregates.get(str(raw)) or aggregates.get(resolved)
+        if members:
+            expanded = [(member, "aggregate_member") for member in members]
+        else:
+            expanded = [(resolved, "direct")]
+        for code, kind in expanded:
+            key = (resolved, code)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append({"requested_code": resolved, "cancer_code": code, "request_kind": kind})
+    return rows
+
+
+def _reference_available_codes_for_modes(modes: list[str]) -> list[str]:
+    out: set[str] = set()
+    if any(mode in {"tpm_clean", "tpm_clean_biological", "tpm_clean_log1p"} for mode in modes):
+        out.update(available_percentile_cohorts())
+    if "tpm_raw" in modes:
+        out.update(source_matrices.available_cohorts())
+    return sorted(out)
+
+
+def _reference_expression_availability_for_requests(
+    requests: list[dict[str, str]], modes: list[str]
+) -> pd.DataFrame:
+    percentile_available = set(available_percentile_cohorts())
+    source_matrix_available = set(source_matrices.available_cohorts())
+    rows: list[dict] = []
+    for request in requests:
+        code = request["cancer_code"]
+        for mode in modes:
+            available, missing_reason = _reference_mode_availability(
+                code, mode, percentile_available, source_matrix_available
+            )
+            method = _reference_expected_method(mode)
+            row = {
+                "requested_code": request["requested_code"],
+                "cancer_code": code,
+                "request_kind": request["request_kind"],
+                "normalization": _REFERENCE_NORMALIZE_LABELS[mode],
+                "available": bool(available),
+                "missing_reason": "" if available else missing_reason,
+                "reference_method": method,
+                "artifact_schema_version": REFERENCE_EXPRESSION_SCHEMA_VERSION,
+                "data_version": DATA_VERSION,
+                "source_matrix_version": SOURCE_MATRIX_VERSION,
+            }
+            row.update(_reference_expression_provenance(code, mode, method))
+            rows.append(row)
+    columns = [
+        "requested_code",
+        "cancer_code",
+        "request_kind",
+        "normalization",
+        "available",
+        "missing_reason",
+        "source_cohort",
+        "source_type",
+        "source_unit",
+        "source_scale_class",
+        "linear_tpm_comparable",
+        "reference_method",
+        "artifact_schema_version",
+        "data_version",
+        "source_matrix_version",
+    ]
+    out = pd.DataFrame(rows, columns=columns)
+    out.attrs["artifact_schema_version"] = REFERENCE_EXPRESSION_SCHEMA_VERSION
+    out.attrs["data_version"] = DATA_VERSION
+    out.attrs["source_matrix_version"] = SOURCE_MATRIX_VERSION
+    out.attrs["issues"] = ["#207"]
+    return out
+
+
+def _reference_mode_availability(
+    code: str,
+    mode: str,
+    percentile_available: set[str],
+    source_matrix_available: set[str],
+) -> tuple[bool, str]:
+    if mode in {"tpm_clean", "tpm_clean_biological", "tpm_clean_log1p"}:
+        return (True, "") if code in percentile_available else (False, "no_percentile_artifact")
+    if mode == "tpm_raw":
+        return (True, "") if code in source_matrix_available else (False, "no_source_matrix")
+    raise AssertionError(f"unhandled reference normalize mode: {mode}")
+
+
+def _reference_expected_method(mode: str) -> str:
+    if mode in {"tpm_clean", "tpm_clean_biological"}:
+        return "percentile_shard"
+    if mode == "tpm_clean_log1p":
+        return "percentile_shard_log1p"
+    if mode == "tpm_raw":
+        return "source_matrix_stats"
+    raise AssertionError(f"unhandled reference normalize mode: {mode}")
+
+
+def _attach_reference_expression_attrs(df: pd.DataFrame, availability: pd.DataFrame | None) -> None:
+    df.attrs["artifact_schema_version"] = REFERENCE_EXPRESSION_SCHEMA_VERSION
+    df.attrs["data_version"] = DATA_VERSION
+    df.attrs["source_matrix_version"] = SOURCE_MATRIX_VERSION
+    if availability is None:
+        return
+    missing = availability.loc[~availability["available"]]
+    df.attrs["availability"] = availability.to_dict("records")
+    df.attrs["missing_requests"] = missing.to_dict("records")
+
 
 def _reference_normalize_modes(normalize: str | Iterable[str]) -> list[str]:
     if isinstance(normalize, str):
@@ -1107,8 +1295,10 @@ def _reference_normalize_modes(normalize: str | Iterable[str]) -> list[str]:
     return modes
 
 
-def _reference_long_columns(include_provenance: bool) -> list[str]:
+def _reference_long_columns(include_provenance: bool, include_request_metadata: bool) -> list[str]:
     cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code", "normalization"]
+    if include_request_metadata:
+        cols += _REFERENCE_REQUEST_COLUMNS
     if include_provenance:
         cols += _REFERENCE_PROVENANCE_COLUMNS
     return [*cols, "expression", "q1", "q3"]

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -903,6 +903,93 @@ def test_cancer_reference_expression_multiple_normalizations(monkeypatch):
     assert wide.loc[0, "X_TPM_clean_log1p"] == pytest.approx(np.log1p(3.0))
 
 
+def test_cancer_reference_expression_availability_reports_missing(monkeypatch):
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    monkeypatch.setattr(expression.source_matrices, "available_cohorts", lambda: ["Y"])
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+
+    out = expression.cancer_reference_expression_availability(
+        ["x", "z"], normalize=["tpm_clean", "tpm_raw"]
+    )
+
+    assert list(out.columns) == [
+        "requested_code",
+        "cancer_code",
+        "request_kind",
+        "normalization",
+        "available",
+        "missing_reason",
+        "source_cohort",
+        "source_type",
+        "source_unit",
+        "source_scale_class",
+        "linear_tpm_comparable",
+        "reference_method",
+        "artifact_schema_version",
+        "data_version",
+        "source_matrix_version",
+    ]
+    assert out.attrs["artifact_schema_version"] == expression.REFERENCE_EXPRESSION_SCHEMA_VERSION
+    keyed = out.set_index(["cancer_code", "normalization"])
+    assert bool(keyed.loc[("X", "tpm_clean"), "available"]) is True
+    assert keyed.loc[("X", "tpm_raw"), "missing_reason"] == "no_source_matrix"
+    assert keyed.loc[("Z", "tpm_clean"), "missing_reason"] == "no_percentile_artifact"
+
+
+def test_cancer_reference_expression_missing_empty_and_raise(monkeypatch):
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    monkeypatch.setattr(expression.source_matrices, "available_cohorts", lambda: [])
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+
+    empty = expression.cancer_reference_expression("z", on_missing="empty")
+    assert empty.empty
+    assert list(empty.columns) == [
+        "Ensembl_Gene_ID",
+        "Symbol",
+        "cancer_code",
+        "normalization",
+        "source_cohort",
+        "source_type",
+        "source_unit",
+        "source_scale_class",
+        "linear_tpm_comparable",
+        "reference_method",
+        "data_version",
+        "source_matrix_version",
+        "expression",
+        "q1",
+        "q3",
+    ]
+    assert empty.attrs["missing_requests"][0]["cancer_code"] == "Z"
+    assert empty.attrs["missing_requests"][0]["missing_reason"] == "no_percentile_artifact"
+    with pytest.raises(ValueError, match="Z/tpm_clean: no_percentile_artifact"):
+        expression.cancer_reference_expression("z", on_missing="raise")
+
+
+def test_cancer_reference_expression_request_metadata_for_aggregate(monkeypatch):
+    pct = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1"],
+            "Symbol": ["A"],
+            "p25": [1.0],
+            "p50": [3.0],
+            "p75": [5.0],
+        }
+    )
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X", "Y"])
+    monkeypatch.setattr(expression, "cohort_aggregates", lambda: {"AGG": ["X", "Y"]})
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+    monkeypatch.setattr(expression, "cohort_gene_percentiles", lambda *a, **k: pct.copy())
+
+    out = expression.cancer_reference_expression("agg", include_request_metadata=True)
+
+    assert out["requested_code"].tolist() == ["AGG", "AGG"]
+    assert out["cancer_code"].tolist() == ["X", "Y"]
+    assert out["request_kind"].tolist() == ["aggregate_member", "aggregate_member"]
+    assert out["available"].tolist() == [True, True]
+    assert out["missing_reason"].tolist() == ["", ""]
+
+
 def test_cancer_reference_expression_raw_tpm_uses_source_stats(monkeypatch):
     stats = pd.DataFrame(
         {
@@ -915,6 +1002,7 @@ def test_cancer_reference_expression_raw_tpm_uses_source_stats(monkeypatch):
     )
     seen = {}
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    monkeypatch.setattr(expression.source_matrices, "available_cohorts", lambda: ["X"])
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
     monkeypatch.setattr(
         expression,


### PR DESCRIPTION
## Summary

Addresses the next scoped slice of #207.

- adds `cancer_reference_expression_availability(...)` for requested-code/mode availability, missing reasons, source provenance, and schema/data versions
- adds opt-in `on_missing="empty" | "raise"` behavior to `cancer_reference_expression(...)` while keeping the default omit behavior
- adds `include_request_metadata=True` for long reference-expression output so aggregate requests preserve `requested_code` and request kind
- documents the reference-expression availability contract for downstream adapters

## Validation

- `./lint.sh`
- `python -m pytest tests/test_expression.py -q`
- `./test.sh` (569 passed, existing matplotlib open-figure warning)

## Notes

This exposes absence/provenance for compatibility adapters. It does not synthesize missing expression rows or claim artifact row/value parity; those remain tracked by #191/#193/#203/#205/#208/#209.