### PR TITLE
Expose bundle release manifest metadata

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -274,7 +274,11 @@ but it is not the clean-TPM biological denominator.
 - `oncoref.data_bundle` — heavy expression bundle cache. Use
   `data_bundle.bundle_contract()` to inspect the downstream-stable package/data
   version linkage, release asset URLs, cache environment variables, completion
-  marker policy, and expected artifact inventory for the active bundle.
+  marker policy, and expected artifact inventory for the active bundle. Use
+  `data_bundle.bundle_release_manifest()` to fetch and validate only the small
+  release manifest/checksum for the active `DATA_VERSION`, including tarball
+  sha256 plus any artifact inventory, builder commit, source-matrix version, and
+  sample-QC policy metadata published with the release.
 - `oncoref.reference_data` / `oncoref.hpa` — HPA reference-data cache and HPA
   tissue/cell-type accessors.
 

--- a/oncoref/data_bundle.py
+++ b/oncoref/data_bundle.py
@@ -263,6 +263,27 @@ def _validate_release_manifest(manifest: dict, source: dict, *, manifest_url: st
         raise BundleIntegrityError(
             f"{manifest_url} downloadable_paths do not match this oncoref build"
         )
+    manifest_source_matrix_version = manifest.get("source_matrix_version")
+    if (
+        manifest_source_matrix_version is not None
+        and str(manifest_source_matrix_version) != SOURCE_MATRIX_VERSION
+    ):
+        raise BundleIntegrityError(
+            f"{manifest_url} is for source_matrix_version {manifest_source_matrix_version!r}, "
+            f"expected {SOURCE_MATRIX_VERSION!r}"
+        )
+    inventory = manifest.get("inventory")
+    if inventory is not None:
+        if not isinstance(inventory, dict):
+            raise BundleIntegrityError(f"{manifest_url} inventory must be an object")
+        missing_inventory = [
+            path for path in DOWNLOADABLE_PATHS if not isinstance(inventory.get(path), dict)
+        ]
+        if missing_inventory:
+            raise BundleIntegrityError(
+                f"{manifest_url} inventory lacks required bundle paths: "
+                + ", ".join(missing_inventory)
+            )
     normalized = {
         "manifest_version": manifest.get("manifest_version", BUNDLE_MANIFEST_VERSION),
         "data_version": DATA_VERSION,
@@ -277,6 +298,23 @@ def _validate_release_manifest(manifest: dict, source: dict, *, manifest_url: st
             "downloadable_paths": list(DOWNLOADABLE_PATHS),
         },
     }
+    if isinstance(inventory, dict):
+        normalized["inventory"] = {
+            path: inventory.get(path)
+            for path in DOWNLOADABLE_PATHS
+            if isinstance(inventory.get(path), dict)
+        }
+    for key in (
+        "builder",
+        "builder_commit",
+        "created_at",
+        "source_matrix_version",
+        "sample_qc_policy",
+        "source_matrix_sample_qc",
+        "artifact_build_metadata",
+    ):
+        if key in manifest:
+            normalized[key] = manifest[key]
     return normalized
 
 
@@ -422,6 +460,23 @@ def bundle_contract() -> dict:
         "release_sources": sources,
         "primary_release_source": sources[0],
     }
+
+
+def bundle_release_manifest(source: str = "oncoref") -> dict | None:
+    """Fetch and validate the small release manifest/checksum for ``DATA_VERSION``.
+
+    This is a metadata-only inspection helper for downstream packages that need to
+    decide whether the active data version has a published, checksum-anchored bundle
+    before downloading hundreds of MB. The returned manifest includes the tarball
+    sha256 and any release-side artifact inventory / builder metadata present in
+    the release asset. The transitional ``pirlygenes`` source can return ``None`` if
+    no manifest/checksum exists because it is explicitly not the integrity authority.
+    """
+    source_record = next((s for s in RELEASE_SOURCES if s["name"] == source), None)
+    if source_record is None:
+        supported = ", ".join(s["name"] for s in RELEASE_SOURCES)
+        raise ValueError(f"unknown bundle release source {source!r}; supported: {supported}")
+    return _fetch_release_manifest(source_record)
 
 
 def _download_and_extract(
@@ -722,6 +777,7 @@ __all__ = [
     "TARBALL_FILENAME",
     "BundleIntegrityError",
     "bundle_contract",
+    "bundle_release_manifest",
     "cache_dir",
     "cache_root",
     "ensure_local",

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -112,6 +112,13 @@ def _release_manifest(tar_path):
             "sha256": hashlib.sha256(tar_path.read_bytes()).hexdigest(),
             "downloadable_paths": list(data_bundle.DOWNLOADABLE_PATHS),
         },
+        "builder_commit": "abc123",
+        "source_matrix_version": SOURCE_MATRIX_VERSION,
+        "sample_qc_policy": "pass",
+        "inventory": {
+            path: {"path": path, "file_count": 1, "size_bytes": 10}
+            for path in data_bundle.DOWNLOADABLE_PATHS
+        },
     }
 
 
@@ -137,6 +144,71 @@ def test_fetch_release_manifest_accepts_sha256_sidecar(monkeypatch):
     manifest = data_bundle._fetch_release_manifest(data_bundle.RELEASE_SOURCES[0])
     assert manifest["tarball"]["sha256"] == sha
     assert manifest["tarball"]["filename"] == data_bundle.TARBALL_FILENAME
+
+
+def test_bundle_release_manifest_preserves_inventory_and_build_metadata(monkeypatch, tmp_path):
+    src = tmp_path / "src"
+    _write_bundle_fixture(src)
+    tar_path = _bundle_tarball(tmp_path, src)
+    release_manifest = _release_manifest(tar_path)
+
+    def fake_read_url_text(url):
+        if url == data_bundle.RELEASE_MANIFEST_URL:
+            return data_bundle.json.dumps(release_manifest)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(data_bundle, "_read_url_text", fake_read_url_text)
+
+    manifest = data_bundle.bundle_release_manifest()
+
+    assert manifest["source"] == "oncoref"
+    assert manifest["tarball"]["sha256"] == release_manifest["tarball"]["sha256"]
+    assert manifest["builder_commit"] == "abc123"
+    assert manifest["source_matrix_version"] == SOURCE_MATRIX_VERSION
+    assert manifest["sample_qc_policy"] == "pass"
+    assert set(manifest["inventory"]) == set(data_bundle.DOWNLOADABLE_PATHS)
+    assert manifest["inventory"]["pan-cancer-expression.csv"]["file_count"] == 1
+
+
+def test_bundle_release_manifest_source_validation_and_legacy_absence(monkeypatch):
+    with pytest.raises(ValueError, match="unknown bundle release source"):
+        data_bundle.bundle_release_manifest("other")
+
+    def fake_read_url_text(url):
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(data_bundle, "_read_url_text", fake_read_url_text)
+
+    assert data_bundle.bundle_release_manifest("pirlygenes") is None
+    with pytest.raises(data_bundle.BundleIntegrityError, match="missing release manifest"):
+        data_bundle.bundle_release_manifest("oncoref")
+
+
+def test_release_manifest_rejects_partial_inventory_and_source_version_mismatch(tmp_path):
+    src = tmp_path / "src"
+    _write_bundle_fixture(src)
+    tar_path = _bundle_tarball(tmp_path, src)
+    manifest = _release_manifest(tar_path)
+
+    partial = dict(manifest)
+    partial["inventory"] = {
+        "pan-cancer-expression.csv": manifest["inventory"]["pan-cancer-expression.csv"]
+    }
+    with pytest.raises(data_bundle.BundleIntegrityError, match="inventory lacks required"):
+        data_bundle._validate_release_manifest(
+            partial,
+            data_bundle.RELEASE_SOURCES[0],
+            manifest_url=data_bundle.RELEASE_MANIFEST_URL,
+        )
+
+    mismatch = dict(manifest)
+    mismatch["source_matrix_version"] = "old"
+    with pytest.raises(data_bundle.BundleIntegrityError, match="source_matrix_version"):
+        data_bundle._validate_release_manifest(
+            mismatch,
+            data_bundle.RELEASE_SOURCES[0],
+            manifest_url=data_bundle.RELEASE_MANIFEST_URL,
+        )
 
 
 def test_is_local_requires_nonempty_dirs(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Addresses a focused #209 / #14 / #21 slice for downstream bundle inspection.

- adds `data_bundle.bundle_release_manifest(source="oncoref")` as a metadata-only helper that validates the active `DATA_VERSION` release manifest/checksum without downloading the data tarball
- preserves release-side artifact inventory and build/provenance metadata in the normalized manifest
- validates optional release manifest inventory completeness and `source_matrix_version` consistency
- documents the new inspection helper in the API guide

## Validation

- `./lint.sh`
- `python -m pytest tests/test_data_bundle.py -q`
- `./test.sh` (572 passed, existing matplotlib open-figure warning)

## Notes

This strengthens the bundle metadata contract. It does not rebuild or publish a new expression data bundle; generated artifact parity remains tracked separately by #191/#193/#203/#205/#208.