### PR TITLE
[codex] Select representatives on biological clean TPM

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -132,7 +132,10 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   sample-QC policy to derived shards by default (`--sample-qc pass`) and emits
   `source-matrix-sample-qc.csv` plus `expression-artifact-build-metadata.*` in
   the staging directory so bundle releases can record which source samples fed
-  percentiles, representatives, and within-sample summaries.
+  percentiles, representatives, and within-sample summaries. Representative
+  sample selection uses `representative_sample_columns` / `cohort_medoids` on the
+  biological clean-TPM view, then stores the selected samples' full
+  clean_tpm_16_9_75 vectors.
 - `oncoref.expression_engine` — reusable low-level builder primitives for
   expression tables: identity/value column detection, transcript-to-gene
   aggregation, source row ID-type detection, source gene-row mapping audits,
@@ -197,6 +200,9 @@ contracts:
   include_provenance=True)` includes the representative id, source cohort/project,
   source sample id, cohort sample count, deterministic selection rank/method/basis,
   artifact schema version, `DATA_VERSION`, and `SOURCE_MATRIX_VERSION`.
+  Representatives are selected by central-medoid plus farthest-first traversal in
+  log1p biological clean-TPM space, with stable sample-id tie-breaking; the
+  persisted vectors remain full clean_tpm_16_9_75.
 - `expression.cohort_gene_percentiles(..., include_provenance=True)` appends the
   cohort code, normalization, expression unit, percentile basis, artifact schema
   version, `DATA_VERSION`, and `SOURCE_MATRIX_VERSION`.

--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -280,12 +280,63 @@ def cohort_percentile_vectors(
     return out
 
 
+def representative_sample_columns(
+    selection_df: pd.DataFrame,
+    sample_cols: Iterable[str] | None = None,
+    *,
+    k: int = 5,
+    distance_log1p: bool = True,
+) -> list[str]:
+    """Choose representative sample columns from a selection matrix.
+
+    ``selection_df`` defines only the geometry used for picking samples. For the
+    shipped oncoref representative artifacts this is the biological clean-TPM
+    matrix with ribosomal/technical rows removed, so technical composition cannot
+    choose the medoids. Values can then be copied from a separate full clean-TPM
+    matrix with the same sample columns.
+
+    Ties are resolved by lexicographic sample id order, making the result stable
+    even when an input parquet happens to carry columns in a different order.
+    """
+    cols = list(sample_cols) if sample_cols is not None else sample_columns(selection_df)
+    missing = [c for c in cols if c not in selection_df.columns]
+    if missing:
+        raise ValueError(f"selection matrix is missing sample columns: {missing}")
+    if not cols:
+        raise ValueError("no per-sample columns to choose from")
+
+    ordered = sorted(cols, key=str)
+    if len(ordered) <= k:
+        return ordered
+
+    mat = selection_df[ordered].to_numpy(dtype=float).T  # samples x genes
+    if distance_log1p:
+        mat = np.log1p(mat)
+    mat = np.nan_to_num(mat, nan=0.0)
+
+    # Pairwise squared Euclidean via the ||a-b||^2 = ||a||^2 + ||b||^2 - 2a.b
+    # identity (avoids materializing an n x n x g intermediate).
+    gram = mat @ mat.T
+    sq_norms = np.diag(gram)
+    sq = sq_norms[:, None] + sq_norms[None, :] - 2.0 * gram
+    dist = np.sqrt(np.maximum(sq, 0.0))
+
+    selected = [int(np.argmin(dist.sum(axis=1)))]  # central medoid
+    while len(selected) < k:
+        min_to_selected = dist[:, selected].min(axis=1)
+        min_to_selected[selected] = -np.inf  # never re-pick
+        selected.append(int(np.argmax(min_to_selected)))
+
+    return [ordered[i] for i in selected]
+
+
 def cohort_medoids(
     df: pd.DataFrame,
     sample_cols: Iterable[str] | None = None,
     *,
     k: int = 5,
     distance_log1p: bool = True,
+    selection_df: pd.DataFrame | None = None,
 ) -> pd.DataFrame:
     """Pick ``k`` representative real per-sample vectors spanning a cohort.
 
@@ -298,37 +349,25 @@ def cohort_medoids(
     within-cohort variation rather than clustering them near the center.
 
     Distance is computed on ``log1p`` TPM (``distance_log1p=True``) so a few
-    very-high-TPM genes don't dominate the geometry, but the returned values are
-    the **original** TPM (the artifact ships clean TPM; the reader optionally
-    ``log1p``-transforms). Cohorts with ``≤ k`` samples keep all of them, in
-    input order. Returns ``Ensembl_Gene_ID``, ``Symbol`` and the ``k`` selected
-    sample columns (original names), medoid first.
+    very-high-TPM genes don't dominate the geometry. If ``selection_df`` is
+    provided, it supplies the geometry while returned values still come from
+    ``df``; this is how the build pipeline selects on biological clean TPM but
+    stores full clean_tpm_16_9_75 vectors. Cohorts with ``≤ k`` samples keep all
+    of them in stable sample id order. Returns ``Ensembl_Gene_ID``, ``Symbol`` and
+    the selected sample columns (original names), medoid first.
     """
     cols = list(sample_cols) if sample_cols is not None else sample_columns(df)
+    missing = [c for c in cols if c not in df.columns]
+    if missing:
+        raise ValueError(f"value matrix is missing sample columns: {missing}")
     if not cols:
         raise ValueError("no per-sample columns to choose from")
     base = ["Ensembl_Gene_ID", "Symbol"]
 
-    if len(cols) <= k:
-        return df[base + cols].reset_index(drop=True)
-
-    mat = df[cols].to_numpy(dtype=float).T  # samples × genes
-    if distance_log1p:
-        mat = np.log1p(mat)
-    mat = np.nan_to_num(mat, nan=0.0)
-
-    # Pairwise squared Euclidean via the ||a-b||^2 = ||a||^2 + ||b||^2 - 2a·b
-    # identity (avoids materializing an n×n×g intermediate).
-    gram = mat @ mat.T
-    sq_norms = np.diag(gram)
-    sq = sq_norms[:, None] + sq_norms[None, :] - 2.0 * gram
-    dist = np.sqrt(np.maximum(sq, 0.0))
-
-    selected = [int(np.argmin(dist.sum(axis=1)))]  # central medoid
-    while len(selected) < k:
-        min_to_selected = dist[:, selected].min(axis=1)
-        min_to_selected[selected] = -np.inf  # never re-pick
-        selected.append(int(np.argmax(min_to_selected)))
-
-    keep = [cols[i] for i in selected]
+    keep = representative_sample_columns(
+        selection_df if selection_df is not None else df,
+        sample_cols=cols,
+        k=k,
+        distance_log1p=distance_log1p,
+    )
     return df[base + keep].reset_index(drop=True)

--- a/scripts/generate_representatives.py
+++ b/scripts/generate_representatives.py
@@ -19,9 +19,10 @@ medoid samples: the cohort medoid (most central tumor) first, then farthest-firs
 picks that span the within-cohort variation (see ``expression_builders.cohort_medoids``).
 
 Computed from the full per-sample matrices, which are never shipped (see
-``source_matrices`` for the per-cohort fetch). The kept columns store the
-**original** clean TPM (the reader optionally ``log1p``-transforms); only the
-medoid *distance* geometry uses log1p so a few high-TPM genes don't dominate.
+``source_matrices`` for the per-cohort fetch). The medoid distance geometry uses
+the biological clean-TPM view with technical/ribosomal rows removed, but the kept
+columns store the **original** full clean TPM vectors (the reader optionally
+``log1p``-transforms).
 
 Input
 -----
@@ -56,12 +57,19 @@ import pandas as pd
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from oncoref.expression_builders import cohort_medoids, sample_columns
+from oncoref.gene_families import clean_tpm_censored_gene_ids
 
 _DATA_DIR = Path(__file__).resolve().parents[1] / "oncoref" / "data"
 OUT_DIR = _DATA_DIR / "cancer-reference-expression-representatives"
 _BASE = ["Ensembl_Gene_ID", "Symbol"]
 #: Columns representative_cohort_samples(include_provenance=True) merges back in.
 _PROVENANCE_COLUMNS = ["representative_id", "source_cohort", "source_project", "n_cohort_samples"]
+
+
+def _drop_technical(df: pd.DataFrame) -> pd.DataFrame:
+    censored = clean_tpm_censored_gene_ids()
+    unversioned = df["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+    return df[~unversioned.isin(censored)].reset_index(drop=True)
 
 
 def _cohort_provenance(code: str) -> tuple[str, str]:
@@ -105,7 +113,9 @@ def build(input_dir: Path, *, k: int = 5, out_dir: Path = OUT_DIR) -> None:
         if n_cohort == 0:
             print(f"  {code}: no sample columns, skipped", flush=True)
             continue
-        reps = cohort_medoids(df, k=k)
+        sample_cols = sample_columns(df)
+        selection_df = _drop_technical(df)
+        reps = cohort_medoids(df, sample_cols=sample_cols, k=k, selection_df=selection_df)
         source_cols = [c for c in reps.columns if c not in _BASE]
         rep_ids = [f"{code}__rep{i}" for i in range(1, len(source_cols) + 1)]
         reps = reps.rename(columns=dict(zip(source_cols, rep_ids)))

--- a/scripts/rebuild_expression_artifacts.py
+++ b/scripts/rebuild_expression_artifacts.py
@@ -248,14 +248,16 @@ def rebuild(
         clean_df = clean_df[[*_BASE, *samples]].copy()
         clean_df.to_parquet(clean_dir / f"{code}.parquet", index=False, compression="zstd")
 
-        # Biological view (technical genes dropped) for the percentile + within-sample
-        # artifacts, matching pirlygenes' shipped biology-only artifacts.
+        # Biological view (technical genes dropped) for the percentile, within-sample,
+        # and representative-selection geometry, matching the shared contract:
+        # choose representatives on biological signal but store full clean TPM vectors.
         bio_df = _drop_technical(clean_df)
         pct = cohort_percentile_vectors(bio_df, samples)
         pct.to_parquet(pct_dir / f"{code}.parquet", index=False, compression="zstd")
 
-        # Representatives keep the full gene set (real per-sample vectors).
-        reps = cohort_medoids(clean_df, k=5)
+        # Representatives keep the full gene set (real per-sample vectors), while
+        # the medoid/farthest-first distances are computed on biological genes only.
+        reps = cohort_medoids(clean_df, sample_cols=samples, k=5, selection_df=bio_df)
         rep_cols = [c for c in reps.columns if c not in _BASE]
         rep_ids = [f"{code}__rep{i}" for i in range(1, len(rep_cols) + 1)]
         reps = reps.rename(columns=dict(zip(rep_cols, rep_ids)))

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -109,6 +109,12 @@ def test_medoids_small_cohort_keeps_all():
     assert [c for c in out.columns if c not in ("Ensembl_Gene_ID", "Symbol")] == ["s1", "s2"]
 
 
+def test_medoids_small_cohort_uses_stable_sample_id_order():
+    vals = np.array([[2.0, 1.0]])
+    out = expression_builders.cohort_medoids(_matrix(["A"], ["s2", "s1"], vals), k=5)
+    assert [c for c in out.columns if c not in ("Ensembl_Gene_ID", "Symbol")] == ["s1", "s2"]
+
+
 def test_medoids_central_first_then_outlier():
     # 4 near-identical "typical" samples + 1 far outlier. The medoid (pick 1)
     # must come from the dense cluster; the farthest pick (2) must be the outlier.
@@ -130,6 +136,32 @@ def test_medoids_preserve_original_tpm():
     out = expression_builders.cohort_medoids(_matrix(["A"], ["s1", "s2", "s3"], vals), k=3)
     kept = out[[c for c in out.columns if c not in ("Ensembl_Gene_ID", "Symbol")]].to_numpy()
     assert set(kept.ravel()) == {7.0, 8.0, 9.0}
+
+
+def test_medoids_can_select_on_biological_view_but_return_full_values():
+    full = _matrix(
+        ["BIO", "TECH"],
+        ["s3", "s1", "s2"],
+        np.array(
+            [
+                [10.0, 0.0, 5.0],
+                [1000.0, 1000.0, 0.0],
+            ]
+        ),
+    )
+    biological = full[full["Ensembl_Gene_ID"] == "BIO"].reset_index(drop=True)
+
+    out = expression_builders.cohort_medoids(
+        full,
+        sample_cols=["s3", "s1", "s2"],
+        k=1,
+        selection_df=biological,
+    )
+
+    rep_cols = [c for c in out.columns if c not in ("Ensembl_Gene_ID", "Symbol")]
+    assert rep_cols == ["s2"]
+    assert list(out["Ensembl_Gene_ID"]) == ["BIO", "TECH"]
+    assert out.set_index("Ensembl_Gene_ID").loc["TECH", "s2"] == 0.0
 
 
 def test_medoids_deterministic():
@@ -215,6 +247,37 @@ def test_representatives_generator_writes_shards_and_provenance(tmp_path):
     assert (prov["source_cohort"] == "COHORT_A").all()
 
 
+def test_representatives_generator_selects_on_biological_view(tmp_path, monkeypatch):
+    gen = _load_script("generate_representatives")
+    inp = tmp_path / "in"
+    inp.mkdir()
+    _write_cohort(
+        inp,
+        "COHORT_A",
+        ["BIO", "TECH"],
+        ["sample_a", "sample_b"],
+        np.array([[5.0, 10.0], [1000.0, 0.0]]),
+    )
+    monkeypatch.setattr(gen, "clean_tpm_censored_gene_ids", lambda: {"TECH"})
+    seen = {}
+
+    def fake_medoids(df, sample_cols, *, k, selection_df):
+        seen["value_ids"] = df["Ensembl_Gene_ID"].tolist()
+        seen["selection_ids"] = selection_df["Ensembl_Gene_ID"].tolist()
+        seen["sample_cols"] = list(sample_cols)
+        return df[["Ensembl_Gene_ID", "Symbol", sample_cols[0]]].copy()
+
+    monkeypatch.setattr(gen, "cohort_medoids", fake_medoids)
+
+    gen.build(inp, k=1, out_dir=tmp_path / "out")
+
+    assert seen == {
+        "value_ids": ["BIO", "TECH"],
+        "selection_ids": ["BIO"],
+        "sample_cols": ["sample_a", "sample_b"],
+    }
+
+
 def _write_rebuild_inputs(tmp_path):
     cache = tmp_path / "cache"
     ref = tmp_path / "ref"
@@ -293,6 +356,62 @@ def test_rebuild_expression_artifacts_defaults_to_qc_passing_samples(tmp_path, m
     assert metadata["sample_qc_manifest"] == "source-matrix-sample-qc.csv"
     assert metadata["n_source_samples"] == 3
     assert metadata["n_cohort_samples"] == 1
+
+
+def test_rebuild_expression_artifacts_selects_representatives_on_biological_view(
+    tmp_path, monkeypatch
+):
+    gen = _load_script("rebuild_expression_artifacts")
+    cache = tmp_path / "cache"
+    ref = tmp_path / "ref"
+    source_dir = cache / "TEST_SOURCE" / "derived"
+    source_dir.mkdir(parents=True)
+    ref.mkdir()
+    _matrix(
+        ["BIO", "TECH"],
+        ["sample_a", "sample_b"],
+        np.array([[5.0, 10.0], [1000.0, 0.0]]),
+    ).to_parquet(source_dir / "X_per_sample_tpm.parquet", index=False)
+    _write_cohort(ref, "X", ["BIO"], ["reference"], np.array([[1.0]]))
+
+    monkeypatch.setattr(
+        gen,
+        "source_registry",
+        lambda: pd.DataFrame({"cancer_code": ["X"], "source_cohort": ["TEST_SOURCE"]}),
+    )
+    monkeypatch.setattr(gen, "cohort_source_version", lambda code: "test-source-version")
+    monkeypatch.setattr(
+        gen,
+        "sample_expression_qc_from_matrix",
+        lambda raw, cancer_type: pd.DataFrame(
+            {
+                "cancer_code": [cancer_type, cancer_type],
+                "sample_id": ["sample_a", "sample_b"],
+                "sample_qc_status": ["pass", "pass"],
+                "sample_qc_reasons": ["", ""],
+            }
+        ),
+    )
+    monkeypatch.setattr(gen, "clean_tpm", lambda values, gene_table: values.copy())
+    monkeypatch.setattr(gen, "clean_tpm_censored_gene_ids", lambda: {"TECH"})
+
+    seen = {}
+
+    def fake_medoids(df, sample_cols, *, k, selection_df):
+        seen["value_ids"] = df["Ensembl_Gene_ID"].tolist()
+        seen["selection_ids"] = selection_df["Ensembl_Gene_ID"].tolist()
+        seen["sample_cols"] = list(sample_cols)
+        return df[["Ensembl_Gene_ID", "Symbol", sample_cols[0]]].copy()
+
+    monkeypatch.setattr(gen, "cohort_medoids", fake_medoids)
+
+    gen.rebuild(cache, ref, tmp_path / "out", limit=None, validate=False, sample_qc="pass")
+
+    assert seen == {
+        "value_ids": ["BIO", "TECH"],
+        "selection_ids": ["BIO"],
+        "sample_cols": ["sample_a", "sample_b"],
+    }
 
 
 def test_rebuild_expression_artifacts_keeps_all_samples_when_requested(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- add an explicit representative_sample_columns selector that resolves medoid/farthest-first ties by stable sample id
- let cohort_medoids select on a separate matrix while returning full value vectors
- update both representative generation paths to select on biological clean TPM but store full clean_tpm_16_9_75 vectors

## Issues

Addresses the representative-selection contract in #195 and supports the expression-artifact parity work tracked by #208, #191, and #193.

## Validation

- python -m pytest tests/test_build_generators.py -q
- ./lint.sh
- ./test.sh