### PR TITLE
[codex] Expose expression artifact QC metadata readers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -127,6 +127,11 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   | "all")` filters sample columns at read time; the raw per-sample accessor
   defaults to `"all"` for forensic access, while live summaries such as
   `cohort_stats` and `pooled_cohort_stats` default to QC-passing samples.
+  `source_matrix_sample_qc_manifest`, `expression_artifact_build_metadata`, and
+  `expression_artifact_build_summary` read the optional QC/build metadata emitted
+  by regenerated expression bundles. Until a regenerated heavy bundle ships those
+  files, they return schema-stable empty metadata by default; use
+  `on_missing="raise"` when a downstream migration requires the manifests.
 - `oncoref.expression_builders` — pure build-time cores used by data-bundle
   generation scripts. `scripts/rebuild_expression_artifacts.py` applies the same
   sample-QC policy to derived shards by default (`--sample-qc pass`) and emits

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -117,8 +117,10 @@ from .cta import (
     cta_unfiltered_gene_names,
 )
 from .expression import (
+    EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION,
     REFERENCE_EXPRESSION_SCHEMA_VERSION,
     SHARD_DATASETS,
+    SOURCE_MATRIX_SAMPLE_QC_MANIFEST_SCHEMA_VERSION,
     ShardDataset,
     available_percentile_cohorts,
     available_representative_cohorts,
@@ -128,6 +130,8 @@ from .expression import (
     cohort_gene_percentiles,
     cohort_mean_expression,
     cohort_stats,
+    expression_artifact_build_metadata,
+    expression_artifact_build_summary,
     expression_artifact_gene_universe_delta_summary,
     expression_artifact_gene_universe_deltas,
     gene_cohort_mean_expression,
@@ -149,6 +153,7 @@ from .expression import (
     proteoform_within_sample_top_fraction,
     representative_cohort_samples,
     sample_expression_qc,
+    source_matrix_sample_qc_manifest,
     within_sample_top_fraction,
 )
 from .expression_engine import aggregate_transcripts_to_genes, id_columns, sample_columns
@@ -286,6 +291,7 @@ __all__ = [
     # ontology / registry
     "CANCER_TYPE_ALIASES",
     "CANCER_TYPE_NAMES",
+    "EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION",
     "OTHER_TECHNICAL_FRACTION",
     "PROPORTION_METRICS",
     "REFERENCE_EXPRESSION_SCHEMA_VERSION",
@@ -293,6 +299,7 @@ __all__ = [
     "REGIMEN_LABELS",
     "RIBOSOMAL_PROTEIN_FRACTION",
     "SHARD_DATASETS",
+    "SOURCE_MATRIX_SAMPLE_QC_MANIFEST_SCHEMA_VERSION",
     "TECHNICAL_FRACTION",
     "TECHNICAL_RNA_FAMILIES",
     "TECHNICAL_RNA_GROUPS",
@@ -429,6 +436,8 @@ __all__ = [
     "cta_unfiltered_gene_names",
     "drop_technical_rna",
     "ensembl_id_aliases",
+    "expression_artifact_build_metadata",
+    "expression_artifact_build_summary",
     "expression_artifact_gene_universe_delta_summary",
     "expression_artifact_gene_universe_deltas",
     "expression_level",
@@ -525,6 +534,7 @@ __all__ = [
     "samples_for_cohort",
     "sarcoma_lineage_codes",
     "signature_score",
+    "source_matrix_sample_qc_manifest",
     "sources_for_cancer_code",
     "tissue_of_origin",
     "tpm_to_housekeeping_normalized",

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -56,6 +56,7 @@ views over these same shipped artifacts rather than separate data products.
 
 from __future__ import annotations
 
+import json
 import os
 import warnings
 from collections import Counter, defaultdict
@@ -506,6 +507,68 @@ def expression_artifact_gene_universe_delta_summary() -> pd.DataFrame:
 _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p", "tpm_clean_hk")
 _SAMPLE_QC_MODES = ("all", "pass", "pass_or_warn")
 SAMPLE_EXPRESSION_QC_POLICY_VERSION = "sample_expression_qc_v1"
+SOURCE_MATRIX_SAMPLE_QC_MANIFEST_SCHEMA_VERSION = "source_matrix_sample_qc_manifest_v1"
+EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION = "expression_artifact_build_metadata_v1"
+SOURCE_MATRIX_SAMPLE_QC_MANIFEST_PATH = "source-matrix-sample-qc.csv"
+EXPRESSION_ARTIFACT_BUILD_METADATA_PATH = "expression-artifact-build-metadata.csv"
+EXPRESSION_ARTIFACT_BUILD_METADATA_JSON_PATH = "expression-artifact-build-metadata.json"
+
+_SOURCE_MATRIX_SAMPLE_QC_MANIFEST_COLUMNS = [
+    "cancer_code",
+    "sample_qc_policy_version",
+    "source_cohort",
+    "source_type",
+    "unit",
+    "source_scale_class",
+    "linear_tpm_comparable",
+    "sample_id",
+    "n_measured_genes",
+    "n_detected_genes",
+    "n_detected_raw",
+    "n_detected_clean",
+    "n_detected_clean_biological",
+    "detected_gene_fraction",
+    "zero_fraction_raw",
+    "parse_missing_fraction",
+    "total_tpm",
+    "top_gene_id",
+    "top_gene_symbol",
+    "top_gene_tpm",
+    "top_gene_fraction",
+    "top1_fraction_raw",
+    "top10_tpm",
+    "top10_fraction",
+    "top10_fraction_raw",
+    "top1_fraction_clean",
+    "top10_fraction_clean",
+    "housekeeping_genes_present",
+    "housekeeping_genes_detected",
+    "housekeeping_genes_above_30",
+    "housekeeping_zero_fraction",
+    "tpm_proxy",
+    "qc_flags",
+    "qc_status",
+    "qc_reasons",
+    "sample_qc_status",
+    "sample_qc_reasons",
+    "passes_expression_qc",
+    "recommended_for_absolute_tpm_floor",
+    "source_matrix_path",
+]
+
+_EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS = [
+    "cancer_code",
+    "source_cohort",
+    "source_version",
+    "source_matrix_path",
+    "sample_qc",
+    "sample_qc_policy_version",
+    "n_source_samples",
+    "n_cohort_samples",
+    "n_qc_pass",
+    "n_qc_warn",
+    "n_qc_fail",
+]
 DEFAULT_MIN_DETECTED_GENES_FOR_QC = 5000
 DEFAULT_MIN_HOUSEKEEPING_GENES_FOR_QC = 10
 DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC = 0.20
@@ -800,6 +863,187 @@ def sample_expression_qc(
         max_top_gene_fraction=max_top_gene_fraction,
         max_top10_gene_fraction=max_top10_gene_fraction,
     )
+
+
+def _validate_metadata_on_missing(on_missing: str) -> str:
+    mode = str(on_missing).lower()
+    if mode not in {"empty", "raise"}:
+        raise ValueError("on_missing must be 'empty' or 'raise'")
+    return mode
+
+
+def _empty_metadata_frame(columns: list[str], *, schema_version: str, missing_reason: str):
+    out = pd.DataFrame(columns=columns)
+    out.attrs["schema_version"] = schema_version
+    out.attrs["data_version"] = DATA_VERSION
+    out.attrs["source_matrix_version"] = SOURCE_MATRIX_VERSION
+    out.attrs["missing_reason"] = missing_reason
+    return out
+
+
+def _optional_bundle_metadata_path(relative_path: str, *, auto_fetch: bool) -> Path | None:
+    path = data_bundle.find(relative_path)
+    if path is not None:
+        return path
+    if auto_fetch:
+        data_bundle.ensure_local(auto_fetch=True, verbose=False)
+        path = data_bundle.find(relative_path)
+    return path
+
+
+def _requested_cancer_codes(cancer_type) -> set[str] | None:
+    if cancer_type is None:
+        return None
+    if isinstance(cancer_type, str):
+        values = [cancer_type]
+    else:
+        values = list(cancer_type)
+    return {resolve_cancer_type(value, strict=False) or str(value) for value in values}
+
+
+def source_matrix_sample_qc_manifest(
+    cancer_type=None,
+    *,
+    sample_qc: str = "all",
+    auto_fetch: bool = True,
+    on_missing: str = "empty",
+) -> pd.DataFrame:
+    """Read the generated source-matrix sample-QC manifest from the data bundle.
+
+    This is the bundle-level companion to :func:`sample_expression_qc`, which computes
+    QC live from a single source matrix. The rebuild script emits
+    ``source-matrix-sample-qc.csv`` for the exact samples that fed generated
+    expression artifacts. Current released bundles may not yet contain it; by default
+    this returns an empty schema-stable frame rather than synthesizing rows.
+    """
+    mode = _validate_metadata_on_missing(on_missing)
+    path = _optional_bundle_metadata_path(
+        SOURCE_MATRIX_SAMPLE_QC_MANIFEST_PATH, auto_fetch=auto_fetch
+    )
+    if path is None:
+        if mode == "raise":
+            raise FileNotFoundError(
+                f"{SOURCE_MATRIX_SAMPLE_QC_MANIFEST_PATH} is not present in the "
+                f"oncoref data bundle at {data_bundle.cache_dir()}"
+            )
+        return _empty_metadata_frame(
+            _SOURCE_MATRIX_SAMPLE_QC_MANIFEST_COLUMNS,
+            schema_version=SOURCE_MATRIX_SAMPLE_QC_MANIFEST_SCHEMA_VERSION,
+            missing_reason="source-matrix sample QC manifest not present in bundle",
+        )
+
+    out = pd.read_csv(path)
+    for col in _SOURCE_MATRIX_SAMPLE_QC_MANIFEST_COLUMNS:
+        if col not in out.columns:
+            out[col] = pd.NA
+    extra_cols = [
+        col for col in out.columns if col not in _SOURCE_MATRIX_SAMPLE_QC_MANIFEST_COLUMNS
+    ]
+    out = out[[*_SOURCE_MATRIX_SAMPLE_QC_MANIFEST_COLUMNS, *extra_cols]]
+
+    codes = _requested_cancer_codes(cancer_type)
+    if codes is not None:
+        if not codes:
+            out = out.iloc[0:0].copy()
+        else:
+            out = out[out["cancer_code"].astype(str).isin(codes)].copy()
+    qc_mode = _validate_sample_qc(sample_qc)
+    if qc_mode == "pass":
+        out = out[out["sample_qc_status"].astype(str) == "pass"].copy()
+    elif qc_mode == "pass_or_warn":
+        out = out[out["sample_qc_status"].astype(str).isin(["pass", "warn"])].copy()
+
+    out.attrs["schema_version"] = SOURCE_MATRIX_SAMPLE_QC_MANIFEST_SCHEMA_VERSION
+    out.attrs["data_version"] = DATA_VERSION
+    out.attrs["source_matrix_version"] = SOURCE_MATRIX_VERSION
+    out.attrs["path"] = str(path)
+    return out.reset_index(drop=True)
+
+
+def expression_artifact_build_metadata(
+    cancer_type=None,
+    *,
+    auto_fetch: bool = True,
+    on_missing: str = "empty",
+) -> pd.DataFrame:
+    """Read per-cohort build metadata for generated expression artifacts.
+
+    The rows are emitted by ``scripts/rebuild_expression_artifacts.py`` and record the
+    selected source matrix, QC policy, selected sample count, and QC pass/warn/fail
+    counts for each cohort. Missing current-bundle metadata returns a schema-stable
+    empty frame by default.
+    """
+    mode = _validate_metadata_on_missing(on_missing)
+    path = _optional_bundle_metadata_path(
+        EXPRESSION_ARTIFACT_BUILD_METADATA_PATH, auto_fetch=auto_fetch
+    )
+    if path is None:
+        if mode == "raise":
+            raise FileNotFoundError(
+                f"{EXPRESSION_ARTIFACT_BUILD_METADATA_PATH} is not present in the "
+                f"oncoref data bundle at {data_bundle.cache_dir()}"
+            )
+        return _empty_metadata_frame(
+            _EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS,
+            schema_version=EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION,
+            missing_reason="expression artifact build metadata not present in bundle",
+        )
+
+    out = pd.read_csv(path)
+    for col in _EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS:
+        if col not in out.columns:
+            out[col] = pd.NA
+    extra_cols = [
+        col for col in out.columns if col not in _EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS
+    ]
+    out = out[[*_EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS, *extra_cols]]
+    codes = _requested_cancer_codes(cancer_type)
+    if codes is not None:
+        if not codes:
+            out = out.iloc[0:0].copy()
+        else:
+            out = out[out["cancer_code"].astype(str).isin(codes)].copy()
+    out.attrs["schema_version"] = EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION
+    out.attrs["data_version"] = DATA_VERSION
+    out.attrs["source_matrix_version"] = SOURCE_MATRIX_VERSION
+    out.attrs["path"] = str(path)
+    return out.reset_index(drop=True)
+
+
+def expression_artifact_build_summary(
+    *,
+    auto_fetch: bool = True,
+    on_missing: str = "empty",
+) -> dict:
+    """Read bundle-level expression artifact build metadata.
+
+    Returns the JSON summary emitted beside the per-cohort metadata CSV. The summary
+    remains optional until a regenerated data bundle ships it; callers that require it
+    should pass ``on_missing="raise"``.
+    """
+    mode = _validate_metadata_on_missing(on_missing)
+    path = _optional_bundle_metadata_path(
+        EXPRESSION_ARTIFACT_BUILD_METADATA_JSON_PATH, auto_fetch=auto_fetch
+    )
+    if path is None:
+        if mode == "raise":
+            raise FileNotFoundError(
+                f"{EXPRESSION_ARTIFACT_BUILD_METADATA_JSON_PATH} is not present in the "
+                f"oncoref data bundle at {data_bundle.cache_dir()}"
+            )
+        return {
+            "schema_version": EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION,
+            "data_version": DATA_VERSION,
+            "source_matrix_version": SOURCE_MATRIX_VERSION,
+            "missing_reason": "expression artifact build summary not present in bundle",
+        }
+    with path.open() as handle:
+        out = json.load(handle)
+    out.setdefault("schema_version", EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION)
+    out.setdefault("data_version", DATA_VERSION)
+    out.setdefault("source_matrix_version", SOURCE_MATRIX_VERSION)
+    out["path"] = str(path)
+    return out
 
 
 def per_sample_expression(

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -4,6 +4,8 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import json
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -708,6 +710,102 @@ def test_per_sample_expression_filters_by_sample_qc(tmp_path, monkeypatch):
 
     all_samples = expression.per_sample_expression("X", normalize="tpm_raw", sample_qc="all")
     assert expression.sample_columns(all_samples) == ["pass_sample", "warn_sample", "fail_sample"]
+
+
+def test_source_matrix_sample_qc_manifest_missing_is_schema_stable(tmp_path, monkeypatch):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+
+    out = expression.source_matrix_sample_qc_manifest(auto_fetch=False)
+
+    assert out.empty
+    assert "sample_qc_status" in out.columns
+    assert out.attrs["schema_version"] == expression.SOURCE_MATRIX_SAMPLE_QC_MANIFEST_SCHEMA_VERSION
+    assert out.attrs["data_version"] == expression.DATA_VERSION
+    assert "missing_reason" in out.attrs
+    with pytest.raises(FileNotFoundError, match="source-matrix-sample-qc"):
+        expression.source_matrix_sample_qc_manifest(auto_fetch=False, on_missing="raise")
+
+
+def test_source_matrix_sample_qc_manifest_reads_filters_and_exports(tmp_path, monkeypatch):
+    import oncoref
+
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    pd.DataFrame(
+        {
+            "cancer_code": ["PRAD", "PRAD", "BRCA"],
+            "sample_id": ["pass_sample", "warn_sample", "fail_sample"],
+            "sample_qc_status": ["pass", "warn", "fail"],
+            "source_cohort": ["SRC", "SRC", "SRC2"],
+            "custom_future_column": [1, 2, 3],
+        }
+    ).to_csv(tmp_path / expression.SOURCE_MATRIX_SAMPLE_QC_MANIFEST_PATH, index=False)
+
+    out = expression.source_matrix_sample_qc_manifest(
+        "prostate", sample_qc="pass_or_warn", auto_fetch=False
+    )
+
+    assert out["sample_id"].tolist() == ["pass_sample", "warn_sample"]
+    assert out["custom_future_column"].tolist() == [1, 2]
+    assert out.attrs["path"].endswith(expression.SOURCE_MATRIX_SAMPLE_QC_MANIFEST_PATH)
+    assert oncoref.source_matrix_sample_qc_manifest is expression.source_matrix_sample_qc_manifest
+    assert (
+        oncoref.SOURCE_MATRIX_SAMPLE_QC_MANIFEST_SCHEMA_VERSION
+        == expression.SOURCE_MATRIX_SAMPLE_QC_MANIFEST_SCHEMA_VERSION
+    )
+
+
+def test_expression_artifact_build_metadata_and_summary(tmp_path, monkeypatch):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    pd.DataFrame(
+        {
+            "cancer_code": ["PRAD", "BRCA"],
+            "source_cohort": ["SRC_PRAD", "SRC_BRCA"],
+            "sample_qc": ["pass", "all"],
+            "n_source_samples": [5, 7],
+            "n_cohort_samples": [4, 7],
+            "extra_future_column": ["x", "y"],
+        }
+    ).to_csv(tmp_path / expression.EXPRESSION_ARTIFACT_BUILD_METADATA_PATH, index=False)
+    (tmp_path / expression.EXPRESSION_ARTIFACT_BUILD_METADATA_JSON_PATH).write_text(
+        json.dumps(
+            {
+                "artifact": "expression-derived-shards",
+                "sample_qc": "pass",
+                "n_cohorts": 2,
+            }
+        )
+        + "\n"
+    )
+
+    meta = expression.expression_artifact_build_metadata("PRAD", auto_fetch=False)
+    summary = expression.expression_artifact_build_summary(auto_fetch=False)
+
+    assert meta["source_cohort"].tolist() == ["SRC_PRAD"]
+    assert meta["extra_future_column"].tolist() == ["x"]
+    assert "n_qc_pass" in meta.columns
+    assert (
+        meta.attrs["schema_version"] == expression.EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION
+    )
+    assert summary["artifact"] == "expression-derived-shards"
+    assert summary["schema_version"] == expression.EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION
+    assert summary["path"].endswith(expression.EXPRESSION_ARTIFACT_BUILD_METADATA_JSON_PATH)
+
+
+def test_expression_artifact_build_metadata_missing_can_raise(tmp_path, monkeypatch):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+
+    out = expression.expression_artifact_build_metadata(auto_fetch=False)
+    summary = expression.expression_artifact_build_summary(auto_fetch=False)
+
+    assert out.empty
+    assert (
+        out.attrs["schema_version"] == expression.EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION
+    )
+    assert summary["missing_reason"]
+    with pytest.raises(FileNotFoundError, match=r"expression-artifact-build-metadata\.csv"):
+        expression.expression_artifact_build_metadata(auto_fetch=False, on_missing="raise")
+    with pytest.raises(FileNotFoundError, match=r"expression-artifact-build-metadata\.json"):
+        expression.expression_artifact_build_summary(auto_fetch=False, on_missing="raise")
 
 
 def test_per_sample_expression_gene_and_proteoform_levels(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Adds public readers for optional expression artifact QC/build metadata emitted by the bundle rebuild workflow:

- `source_matrix_sample_qc_manifest(...)` for the source-matrix sample QC manifest
- `expression_artifact_build_metadata(...)` for per-cohort artifact build metadata
- `expression_artifact_build_summary(...)` for the JSON build summary

The readers return schema-stable empty metadata when current released bundles do not yet contain these files, with `on_missing="raise"` for downstream migrations that require regenerated bundle manifests. This makes the QC/build metadata discoverable without pretending that the heavy expression bundle has already been regenerated.

## Issue context

References #203, #205, and #210. This also supports the broader expression-artifact migration work in #208 and the bundle contract work in #209 by exposing artifact metadata once regenerated bundles ship it.

## Validation

- `python -m pytest tests/test_expression.py -q`
- `./lint.sh`
- `./test.sh` (580 passed, existing matplotlib open-figure warning)

## Remaining work

This PR does not regenerate or publish a new heavy expression bundle. The remaining blocker is a regenerated bundle containing these manifests and parity validation for derived expression artifacts.