### PR TITLE
[codex] Expose source-matrix QC helpers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -151,6 +151,10 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   versioned by `SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION` and
   `SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION`, and the emitted audit frames
   include those versions as persisted columns.
+- `oncoref.source_matrices` — raw per-cohort source-matrix cache/fetch helpers.
+  Use `source_matrices.sample_qc(code)` for the live source-matrix QC audit and
+  `source_matrices.sample_qc_manifest(...)` for the optional generated-bundle QC
+  manifest that records which samples fed derived artifacts.
 - `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,
   log transforms, percentile ranks, and housekeeping normalization.
 

--- a/oncoref/source_matrices.py
+++ b/oncoref/source_matrices.py
@@ -145,3 +145,62 @@ def ensure(code: str) -> Path:
     """Local path to a cohort's per-sample matrix, downloading if absent."""
     dest = local_path(code)
     return dest if dest.exists() else fetch(code)
+
+
+def sample_qc(
+    code: str,
+    *,
+    auto_fetch: bool = True,
+    min_detected_genes: int | None = None,
+    min_housekeeping_detected: int | None = None,
+    max_top_gene_fraction: float | None = None,
+    max_top10_gene_fraction: float | None = None,
+) -> pd.DataFrame:
+    """Compute source-matrix sample QC for one cohort.
+
+    This is the ``source_matrices``-side entry point for the shared QC policy used
+    by expression reads and expression-artifact rebuilds. It delegates to
+    :func:`oncoref.expression.sample_expression_qc`, preserving the same columns:
+    detected-gene counts, source-scale class, top-gene concentration,
+    housekeeping-panel detection, ``sample_qc_status``, and reasons.
+
+    Optional threshold arguments default to the expression module's policy values.
+    """
+    from . import expression
+
+    kwargs = {
+        "auto_fetch": auto_fetch,
+    }
+    if min_detected_genes is not None:
+        kwargs["min_detected_genes"] = min_detected_genes
+    if min_housekeeping_detected is not None:
+        kwargs["min_housekeeping_detected"] = min_housekeeping_detected
+    if max_top_gene_fraction is not None:
+        kwargs["max_top_gene_fraction"] = max_top_gene_fraction
+    if max_top10_gene_fraction is not None:
+        kwargs["max_top10_gene_fraction"] = max_top10_gene_fraction
+    return expression.sample_expression_qc(code, **kwargs)
+
+
+def sample_qc_manifest(
+    cancer_type=None,
+    *,
+    sample_qc: str = "all",
+    auto_fetch: bool = True,
+    on_missing: str = "empty",
+) -> pd.DataFrame:
+    """Read the generated source-matrix sample-QC manifest from the data bundle.
+
+    This is a semantic alias for
+    :func:`oncoref.expression.source_matrix_sample_qc_manifest`. It represents the
+    QC rows recorded during expression-artifact generation, not a live recompute
+    from a raw per-sample matrix. Use :func:`sample_qc` for live per-cohort QC.
+    """
+    from . import expression
+
+    return expression.source_matrix_sample_qc_manifest(
+        cancer_type,
+        sample_qc=sample_qc,
+        auto_fetch=auto_fetch,
+        on_missing=on_missing,
+    )

--- a/tests/test_source_matrices.py
+++ b/tests/test_source_matrices.py
@@ -8,6 +8,7 @@
 
 import urllib.error
 
+import pandas as pd
 import pytest
 
 from oncoref import catalog
@@ -73,6 +74,50 @@ def test_fetch_download_failure_raises(monkeypatch, tmp_path):
     with pytest.raises(sm.SourceMatrixError, match="failed to download"):
         sm.fetch("BRCA")
     assert not sm.is_cached("BRCA")  # no partial file left
+
+
+def test_sample_qc_facade_uses_shared_expression_policy(monkeypatch):
+    from oncoref import expression
+
+    calls = {}
+
+    def fake_sample_expression_qc(code, **kwargs):
+        calls["code"] = code
+        calls["kwargs"] = kwargs
+        return pd.DataFrame(
+            {
+                "sample_id": ["S1"],
+                "sample_qc_status": ["pass"],
+                "source_scale_class": ["linear_rnaseq_tpm"],
+            }
+        )
+
+    monkeypatch.setattr(expression, "sample_expression_qc", fake_sample_expression_qc)
+
+    out = sm.sample_qc("lung_adeno", auto_fetch=False, min_detected_genes=123)
+
+    assert calls == {
+        "code": "lung_adeno",
+        "kwargs": {"auto_fetch": False, "min_detected_genes": 123},
+    }
+    assert out["sample_qc_status"].tolist() == ["pass"]
+
+
+def test_sample_qc_manifest_semantic_alias(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    pd.DataFrame(
+        {
+            "cancer_code": ["LUAD", "LUAD", "BRCA"],
+            "sample_id": ["pass_sample", "warn_sample", "fail_sample"],
+            "sample_qc_status": ["pass", "warn", "fail"],
+            "source_cohort": ["SRC", "SRC", "SRC2"],
+        }
+    ).to_csv(tmp_path / "source-matrix-sample-qc.csv", index=False)
+
+    out = sm.sample_qc_manifest("lung_adeno", sample_qc="pass_or_warn", auto_fetch=False)
+
+    assert out["sample_id"].tolist() == ["pass_sample", "warn_sample"]
+    assert out.attrs["path"].endswith("source-matrix-sample-qc.csv")
 
 
 # ---- catalog routing + group fetch ----


### PR DESCRIPTION
## Summary

- add `source_matrices.sample_qc(...)` as the raw source-matrix entry point for live per-cohort sample QC
- add `source_matrices.sample_qc_manifest(...)` as the semantic alias for generated bundle QC metadata
- document where downstream code should look for raw source-matrix QC vs expression read APIs

Addresses the source-matrices API surface requested in #203 and #210. This does not regenerate or publish a new heavy expression bundle.

## Validation

- `python -m pytest tests/test_source_matrices.py tests/test_expression.py::test_source_matrix_sample_qc_manifest_reads_filters_and_exports tests/test_expression.py::test_sample_expression_qc_flags_sparse_samples -q`
- `./lint.sh`
- `./test.sh`
