### PR TITLE
[codex] Expose data bundle contract CLI

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -298,6 +298,10 @@ but it is not the clean-TPM biological denominator.
   release manifest/checksum for the active `DATA_VERSION`, including tarball
   sha256 plus any artifact inventory, builder commit, source-matrix version, and
   sample-QC policy metadata published with the release.
+  CLI equivalents are available for CI/notebooks: `oncoref data contract` prints
+  the active bundle contract as JSON, and `oncoref data release-manifest
+  [oncoref|pirlygenes]` prints the validated release manifest/checksum metadata
+  as JSON.
 - `oncoref.reference_data` / `oncoref.hpa` — HPA reference-data cache and HPA
   tissue/cell-type accessors.
 

--- a/oncoref/cli.py
+++ b/oncoref/cli.py
@@ -115,6 +115,20 @@ def _cmd_data(args: argparse.Namespace) -> int:
             )
         return 0
 
+    if args.action == "contract":
+        print(json.dumps(data_bundle.bundle_contract(), indent=2, sort_keys=True, default=str))
+        return 0
+
+    if args.action == "release-manifest":
+        source = args.name or "oncoref"
+        try:
+            manifest = data_bundle.bundle_release_manifest(source)
+        except (ValueError, data_bundle.BundleIntegrityError, OSError) as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        print(json.dumps(manifest, indent=2, sort_keys=True, default=str))
+        return 0
+
     if args.action == "dir":
         target = args.name or "all"
         dirs = {
@@ -580,10 +594,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_data.add_argument(
         "action",
-        choices=["list", "status", "dir", "fetch", "path", "prune"],
+        choices=[
+            "list",
+            "status",
+            "contract",
+            "release-manifest",
+            "dir",
+            "fetch",
+            "path",
+            "prune",
+        ],
         help=(
-            "list (catalog), status (cache state), dir (cache roots), "
-            "fetch (download), path (ensure + print), prune (bundle cache cleanup)"
+            "list (catalog), status (cache state), contract (bundle contract JSON), "
+            "release-manifest (release metadata JSON), dir (cache roots), fetch (download), "
+            "path (ensure + print), prune (bundle cache cleanup)"
         ),
     )
     p_data.add_argument(

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,6 +6,8 @@
 
 """Unified data catalog over the bundle + HPA backends (#35, D-cat)."""
 
+import json
+
 import pytest
 
 from oncoref import catalog, cli, data_bundle, reference_data
@@ -158,6 +160,38 @@ def test_cli_data_status_absent(monkeypatch, tmp_path, capsys):
 def test_cli_data_status_unknown_errors(capsys):
     assert cli.main(["data", "status", "nope"]) == 1
     assert "unknown dataset" in capsys.readouterr().err
+
+
+def test_cli_data_contract_json(capsys):
+    assert cli.main(["data", "contract"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["contract_version"] == data_bundle.BUNDLE_CONTRACT_VERSION
+    assert payload["data_version"] == data_bundle.DATA_VERSION
+    assert payload["primary_release_source"]["name"] == "oncoref"
+
+
+def test_cli_data_release_manifest_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        data_bundle,
+        "bundle_release_manifest",
+        lambda source="oncoref": {"source": source, "data_version": data_bundle.DATA_VERSION},
+    )
+
+    assert cli.main(["data", "release-manifest", "pirlygenes"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload == {"source": "pirlygenes", "data_version": data_bundle.DATA_VERSION}
+
+
+def test_cli_data_release_manifest_errors(monkeypatch, capsys):
+    def boom(source="oncoref"):
+        raise data_bundle.BundleIntegrityError("missing manifest")
+
+    monkeypatch.setattr(data_bundle, "bundle_release_manifest", boom)
+
+    assert cli.main(["data", "release-manifest"]) == 1
+    assert "missing manifest" in capsys.readouterr().err
 
 
 def test_cli_data_path_requires_name(capsys):


### PR DESCRIPTION
## Summary
- add `oncoref data contract` JSON output for the active bundle contract
- add `oncoref data release-manifest [source]` JSON output for validated release metadata
- document CLI equivalents for CI/notebook downstream checks

Addresses the CLI/downstream inspection part of #209. This does not regenerate or publish a new heavy expression bundle.

## Validation
- `python -m pytest tests/test_catalog.py::test_cli_data_contract_json tests/test_catalog.py::test_cli_data_release_manifest_json tests/test_catalog.py::test_cli_data_release_manifest_errors tests/test_catalog.py::test_cli_help_never_crashes -q`
- `./lint.sh`
- `./test.sh`