### PR TITLE
Expose pirlygenes-compatible representative IDs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -219,6 +219,9 @@ contracts:
   include_provenance=True)` includes the representative id, source cohort/project,
   source sample id, cohort sample count, deterministic selection rank/method/basis,
   artifact schema version, `DATA_VERSION`, and `SOURCE_MATRIX_VERSION`.
+  Public representative ids default to pirlygenes-compatible `CODE_rep01`
+  columns/values. Pass `representative_id_style="internal"` to expose the
+  underlying bundle/provenance ids (`CODE__rep1`).
   Representatives are selected by central-medoid plus farthest-first traversal in
   log1p biological clean-TPM space, with stable sample-id tie-breaking; the
   persisted vectors remain full clean_tpm_16_9_75.

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import warnings
 from collections import Counter, defaultdict
 from collections.abc import Iterable
@@ -292,19 +293,42 @@ _REPRESENTATIVE_PROVENANCE_COLUMNS = [
 ]
 
 
+_INTERNAL_REPRESENTATIVE_ID_RE = re.compile(r"^(?P<code>.+)__rep(?P<rank>\d+)$")
+_PIRLYGENES_REPRESENTATIVE_ID_RE = re.compile(r"^(?P<code>.+)_rep(?P<rank>\d+)$")
+
+
 def _representative_rank(representative_id: object) -> int | None:
     text = str(representative_id)
-    prefix, sep, suffix = text.rpartition("__rep")
-    if not prefix or not sep:
-        return None
-    try:
-        return int(suffix)
-    except ValueError:
-        return None
+    for pattern in (_INTERNAL_REPRESENTATIVE_ID_RE, _PIRLYGENES_REPRESENTATIVE_ID_RE):
+        match = pattern.match(text)
+        if match:
+            return int(match.group("rank"))
+    return None
+
+
+def _representative_id_for_style(representative_id: object, *, style: str) -> str:
+    _validate_representative_id_style(style)
+    text = str(representative_id)
+    if style == "internal":
+        return text
+    match = _INTERNAL_REPRESENTATIVE_ID_RE.match(text)
+    if not match:
+        return text
+    return f"{match.group('code')}_rep{int(match.group('rank')):02d}"
+
+
+def _validate_representative_id_style(style: str) -> None:
+    if style not in {"pirlygenes", "internal"}:
+        raise ValueError("representative_id_style must be 'pirlygenes' or 'internal'")
 
 
 def _representative_attrs(
-    *, codes: Iterable[str], normalize: str, format: str, k: int | None
+    *,
+    codes: Iterable[str],
+    normalize: str,
+    format: str,
+    k: int | None,
+    representative_id_style: str,
 ) -> dict[str, object]:
     return {
         "artifact": "representative_samples",
@@ -315,6 +339,7 @@ def _representative_attrs(
         "normalize": normalize,
         "format": format,
         "k": k,
+        "representative_id_style": representative_id_style,
         "selection_method": REPRESENTATIVE_SELECTION_METHOD,
         "selection_basis": REPRESENTATIVE_SELECTION_BASIS,
     }
@@ -1775,6 +1800,7 @@ def representative_cohort_samples(
     normalize: str = "tpm_clean",
     format: str = "wide",
     include_provenance: bool = False,
+    representative_id_style: str = "pirlygenes",
 ) -> pd.DataFrame:
     """Representative real per-sample expression vectors per cohort.
 
@@ -1785,10 +1811,14 @@ def representative_cohort_samples(
     ``cancer_types`` accepts a code, alias, or iterable; a computed-aggregate
     code expands to its member subtypes; ``None`` returns every cohort that ships
     representatives. ``k`` keeps at most the first ``k`` reps per cohort.
-    ``format`` is ``"wide"`` (genes × reps) or ``"long"``. Long output can attach
-    representative-level provenance: source cohort/project/sample, selection rank,
-    selection method/basis, and package/data schema versions.
+    ``format`` is ``"wide"`` (genes × reps) or ``"long"``. Public representative
+    IDs default to pirlygenes-compatible ``CODE_rep01`` columns/values; pass
+    ``representative_id_style="internal"`` for the shard/provenance IDs
+    (``CODE__rep1``). Long output can attach representative-level provenance:
+    source cohort/project/sample, selection rank, selection method/basis, and
+    package/data schema versions.
     """
+    _validate_representative_id_style(representative_id_style)
     if normalize not in ("tpm_clean", "tpm_clean_log1p"):
         raise ValueError(
             "representative_cohort_samples normalize must be 'tpm_clean' or "
@@ -1838,11 +1868,15 @@ def representative_cohort_samples(
         gid = shard["Ensembl_Gene_ID"].astype(str)
         for g, s in zip(gid, shard["Symbol"].astype(str)):
             symbols[g][s] += 1
-        mat = shard[rep_cols].set_axis(gid.to_numpy(), axis=0)
+        display_cols = [
+            _representative_id_for_style(c, style=representative_id_style) for c in rep_cols
+        ]
+        mat = shard[rep_cols].set_axis(gid.to_numpy(), axis=0).set_axis(display_cols, axis=1)
         if format == "wide":
             wide_parts.append(mat)
         else:
-            melted = mat.reset_index(names="Ensembl_Gene_ID").melt(
+            internal_mat = shard[rep_cols].set_axis(gid.to_numpy(), axis=0)
+            melted = internal_mat.reset_index(names="Ensembl_Gene_ID").melt(
                 id_vars="Ensembl_Gene_ID", var_name="representative_id", value_name="expression"
             )
             melted.insert(1, "cancer_code", code)
@@ -1864,7 +1898,13 @@ def representative_cohort_samples(
         if not wide_parts:
             out = pd.DataFrame(columns=base)
             out.attrs.update(
-                _representative_attrs(codes=codes, normalize=normalize, format=format, k=k)
+                _representative_attrs(
+                    codes=codes,
+                    normalize=normalize,
+                    format=format,
+                    k=k,
+                    representative_id_style=representative_id_style,
+                )
             )
             return out
         combined = pd.concat(wide_parts, axis=1, join="outer").sort_index()
@@ -1873,21 +1913,44 @@ def representative_cohort_samples(
         out = combined.reset_index(names="Ensembl_Gene_ID")
         out.insert(1, "Symbol", out["Ensembl_Gene_ID"].map(_canonical_symbol))
         out.attrs.update(
-            _representative_attrs(codes=codes, normalize=normalize, format=format, k=k)
+            _representative_attrs(
+                codes=codes,
+                normalize=normalize,
+                format=format,
+                k=k,
+                representative_id_style=representative_id_style,
+            )
         )
         return out
 
     if not long_parts:
         out = _representative_empty_frame(include_provenance=include_provenance)
         out.attrs.update(
-            _representative_attrs(codes=codes, normalize=normalize, format=format, k=k)
+            _representative_attrs(
+                codes=codes,
+                normalize=normalize,
+                format=format,
+                k=k,
+                representative_id_style=representative_id_style,
+            )
         )
         return out
     long = pd.concat(long_parts, ignore_index=True)
     long.insert(1, "Symbol", long["Ensembl_Gene_ID"].map(_canonical_symbol))
     if include_provenance:
         long = _attach_representative_provenance(long, root)
-    long.attrs.update(_representative_attrs(codes=codes, normalize=normalize, format=format, k=k))
+    long["representative_id"] = long["representative_id"].map(
+        lambda x: _representative_id_for_style(x, style=representative_id_style)
+    )
+    long.attrs.update(
+        _representative_attrs(
+            codes=codes,
+            normalize=normalize,
+            format=format,
+            k=k,
+            representative_id_style=representative_id_style,
+        )
+    )
     return long
 
 

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.37"
+__version__ = "1.8.38"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -329,6 +329,7 @@ def test_representative_provenance_includes_source_sample_and_selection_metadata
 
     df = expression.representative_cohort_samples("PRAD", format="long", include_provenance=True)
 
+    assert df.loc[0, "representative_id"] == "PRAD_rep01"
     assert df.loc[0, "source_sample"] == "TCGA-XX-0001"
     assert df.loc[0, "selection_rank"] == 1
     assert df.loc[0, "selection_method"] == expression.REPRESENTATIVE_SELECTION_METHOD
@@ -336,6 +337,15 @@ def test_representative_provenance_includes_source_sample_and_selection_metadata
     assert df.loc[0, "artifact_schema_version"] == expression.REPRESENTATIVE_ARTIFACT_SCHEMA_VERSION
     assert df.attrs["schema_version"] == expression.REPRESENTATIVE_ARTIFACT_SCHEMA_VERSION
     assert df.attrs["cancer_codes"] == ["PRAD"]
+    assert df.attrs["representative_id_style"] == "pirlygenes"
+
+    internal = expression.representative_cohort_samples(
+        "PRAD",
+        format="long",
+        include_provenance=True,
+        representative_id_style="internal",
+    )
+    assert internal.loc[0, "representative_id"] == "PRAD__rep1"
 
 
 def test_representative_empty_long_schema_includes_requested_provenance(monkeypatch, tmp_path):
@@ -364,6 +374,15 @@ def test_representative_empty_long_schema_includes_requested_provenance(monkeypa
         "source_matrix_version",
     ]
     assert df.attrs["schema_version"] == expression.REPRESENTATIVE_ARTIFACT_SCHEMA_VERSION
+    assert df.attrs["representative_id_style"] == "pirlygenes"
+
+
+def test_representative_id_style_validation(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    (tmp_path / "cancer-reference-expression-representatives").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="representative_id_style"):
+        expression.representative_cohort_samples("PRAD", representative_id_style="legacy")
 
 
 def test_representative_wide_does_not_fragment_genes(monkeypatch, tmp_path):
@@ -398,7 +417,12 @@ def test_representative_wide_does_not_fragment_genes(monkeypatch, tmp_path):
     assert len(shared) == 1
     assert shared["Symbol"].iloc[0] != "ENSG234"  # canonical symbol prefers a real alias
     # all three cohorts' values land on that single row
-    assert bool(shared[["A__rep1", "B__rep1", "C__rep1"]].notna().all(axis=1).iloc[0])
+    assert bool(shared[["A_rep01", "B_rep01", "C_rep01"]].notna().all(axis=1).iloc[0])
+
+    internal = expression.representative_cohort_samples(
+        format="wide", representative_id_style="internal"
+    )
+    assert {"A__rep1", "B__rep1", "C__rep1"} <= set(internal.columns)
 
     # the long form carries the same canonical symbol (so a downstream pivot won't fragment)
     lg = expression.representative_cohort_samples(format="long")
@@ -424,7 +448,7 @@ def test_representative_wide_merges_alt_haplotype_aliases(monkeypatch, tmp_path)
     w = expression.representative_cohort_samples(format="wide")
     assert list(w["Ensembl_Gene_ID"]) == [primary]  # one row, the canonical primary
     assert alt not in set(w["Ensembl_Gene_ID"])
-    assert bool(w[["A__rep1", "B__rep1"]].notna().all(axis=1).iloc[0])  # both cohorts on it
+    assert bool(w[["A_rep01", "B_rep01"]].notna().all(axis=1).iloc[0])  # both cohorts on it
 
 
 def test_representative_wide_sums_alt_haplotype_within_cohort(monkeypatch, tmp_path):
@@ -448,7 +472,7 @@ def test_representative_wide_sums_alt_haplotype_within_cohort(monkeypatch, tmp_p
 
     w = expression.representative_cohort_samples(format="wide")
     assert list(w["Ensembl_Gene_ID"]) == [primary]  # collapsed onto the canonical id
-    assert w["A__rep1"].iloc[0] == pytest.approx(13.0)  # 10 + 3 summed, not 10 or 3
+    assert w["A_rep01"].iloc[0] == pytest.approx(13.0)  # 10 + 3 summed, not 10 or 3
 
 
 def test_representative_log1p_sums_in_linear_space(monkeypatch, tmp_path):
@@ -466,8 +490,8 @@ def test_representative_log1p_sums_in_linear_space(monkeypatch, tmp_path):
 
     w = expression.representative_cohort_samples(format="wide", normalize="tpm_clean_log1p")
     assert list(w["Ensembl_Gene_ID"]) == [primary]
-    assert w["A__rep1"].iloc[0] == pytest.approx(np.log1p(13.0))  # log1p(10+3)
-    assert w["A__rep1"].iloc[0] != pytest.approx(np.log1p(10.0) + np.log1p(3.0))  # NOT Σlog1p
+    assert w["A_rep01"].iloc[0] == pytest.approx(np.log1p(13.0))  # log1p(10+3)
+    assert w["A_rep01"].iloc[0] != pytest.approx(np.log1p(10.0) + np.log1p(3.0))  # NOT Σlog1p
 
 
 def _raw_matrix(tmp_path):


### PR DESCRIPTION
## Summary

- default `representative_cohort_samples(...)` public representative ids to pirlygenes-style `CODE_rep01` columns/values
- add `representative_id_style="internal"` for callers that need the underlying bundle/provenance ids (`CODE__rep1`)
- preserve provenance joins on internal ids before converting the displayed representative id
- bump package version to 1.8.38 without changing `DATA_VERSION`

## Scope

Refs #208 and the pirlygenes expression parity work in #191/#193. This is a narrow API-shape compatibility fix for representative sample ids. It does not claim to fix the remaining gene-universe, percentile value, or representative value parity differences.

## Validation

- `./lint.sh`
- focused representative expression tests: 7 passed
- `./test.sh`: 594 passed, 1 existing matplotlib warning
