### PR TITLE
Expose expression builder primitives as public API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -149,10 +149,13 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   expression tables: identity/value column detection, transcript-to-gene
   aggregation, source row ID-type detection, source gene-row mapping audits,
   missing-vs-non-parsing numeric diagnostics, and canonical ENSG aggregation in
-  linear expression space. Use these in builders before committing a source
-  matrix so unresolved high-expression rows and duplicate canonical IDs are
-  explicit artifacts rather than hidden cleanup. Source audit CSV contracts are
-  versioned by `SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION` and
+  linear expression space. It is an explicit public module, so downstream
+  builders can import `oncoref.expression_engine.map_source_gene_rows`,
+  `canonicalize_source_gene_matrix`, and `coerce_source_expression_values`
+  without reaching into scripts. Use these in builders before committing a
+  source matrix so unresolved high-expression rows and duplicate canonical IDs
+  are explicit artifacts rather than hidden cleanup. Source audit CSV contracts
+  are versioned by `SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION` and
   `SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION`, and the emitted audit frames
   include those versions as persisted columns.
 - `oncoref.source_matrices` — raw per-cohort source-matrix cache/fetch helpers.

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -17,7 +17,17 @@ Bottom-of-stack: depends only on pandas/numpy/pyarrow, never on the analysis
 or target-selection libraries that consume it.
 """
 
-from . import antigen_coverage, cancer_ontology, cohorts, cta_coverage, cta_peptides, ici_response
+from . import (
+    antigen_coverage,
+    cancer_ontology,
+    cohorts,
+    cta_coverage,
+    cta_peptides,
+    expression_builders,
+    expression_engine,
+    ici_response,
+    source_matrices,
+)
 from .apd1 import cancer_apd1_response, cancer_apd1_response_df
 from .cancer_types import (
     CANCER_TYPE_ALIASES,
@@ -441,6 +451,8 @@ __all__ = [
     "expression_artifact_build_summary",
     "expression_artifact_gene_universe_delta_summary",
     "expression_artifact_gene_universe_deltas",
+    "expression_builders",
+    "expression_engine",
     "expression_level",
     "expression_source",
     "expression_sources",
@@ -536,6 +548,7 @@ __all__ = [
     "samples_for_cohort",
     "sarcoma_lineage_codes",
     "signature_score",
+    "source_matrices",
     "source_matrix_sample_qc_manifest",
     "sources_for_cancer_code",
     "tissue_of_origin",

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.39"
+__version__ = "1.8.40"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_api_structure.py
+++ b/tests/test_api_structure.py
@@ -11,10 +11,31 @@ def test_semantic_modules_are_top_level_facades():
         "cohorts",
         "cta_coverage",
         "cta_peptides",
+        "expression_builders",
+        "expression_engine",
         "ici_response",
+        "source_matrices",
     ):
         assert hasattr(oncoref, name)
         assert name in oncoref.__all__
+
+
+def test_expression_engine_builder_audit_surface_is_public():
+    assert callable(oncoref.expression_engine.detect_source_row_id_type)
+    assert callable(oncoref.expression_engine.map_source_gene_rows)
+    assert callable(oncoref.expression_engine.canonicalize_source_gene_matrix)
+    assert callable(oncoref.expression_engine.coerce_source_expression_values)
+    assert callable(oncoref.expression_engine.source_gene_mapping_stats)
+    assert (
+        "source_gene_mapping_schema_version"
+        in oncoref.expression_engine.SOURCE_GENE_MAPPING_AUDIT_COLUMNS
+    )
+    assert (
+        "source_value_parse_schema_version"
+        in oncoref.expression_engine.SOURCE_VALUE_PARSE_DIAGNOSTIC_COLUMNS
+    )
+    assert oncoref.expression_engine.SOURCE_GENE_MAPPING_AUDIT_SCHEMA_VERSION
+    assert oncoref.expression_engine.SOURCE_VALUE_PARSE_DIAGNOSTIC_SCHEMA_VERSION
 
 
 def test_clearer_names_stay_in_semantic_modules_not_flat_namespace():


### PR DESCRIPTION
## Summary
- make expression_builders, expression_engine, and source_matrices explicit top-level module facades
- document expression_engine as the public import surface for source matrix row mapping and parse diagnostics
- add API-structure coverage for the builder audit helpers and schema constants

## Scope
This addresses the public import/schema documentation slice of #210. It does not claim to close the remaining regenerated-bundle parity work under #203/#205/#208/#209.

## Tests
- python -m pytest tests/test_api_structure.py tests/test_expression_engine.py
- ./lint.sh
- ./test.sh

Refs #210
Refs #203
Refs #205