### PR TITLE
Flag high-zero source samples in QC policy

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -120,11 +120,11 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
 - `oncoref.expression` — read-time accessors for per-sample expression,
   percentile vectors, representative samples, within-sample top fractions, and
   pan-cancer reference tables. `sample_expression_qc` reports per-sample
-  detected-gene counts, top-gene/top-10 concentration, biological-housekeeping
-  detection, source-scale class, and source-type caveats so sparse source-matrix
-  artifacts can be audited before using absolute TPM floors or housekeeping
-  normalization. `per_sample_expression(..., sample_qc="pass" | "pass_or_warn"
-  | "all")` filters sample columns at read time; the raw per-sample accessor
+  detected-gene counts, literal-zero fraction, top-gene/top-10 concentration,
+  biological-housekeeping detection, source-scale class, and source-type caveats
+  so sparse source-matrix artifacts can be audited before using absolute TPM
+  floors or housekeeping normalization. `per_sample_expression(...,
+  sample_qc="pass" | "pass_or_warn" | "all")` filters sample columns at read time; the raw per-sample accessor
   defaults to `"all"` for forensic access, while live summaries such as
   `cohort_stats` and `pooled_cohort_stats` default to QC-passing samples.
   `source_matrix_sample_qc_manifest`, `expression_artifact_build_metadata`, and

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -535,7 +535,7 @@ def expression_artifact_gene_universe_delta_summary() -> pd.DataFrame:
 
 _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p", "tpm_clean_hk")
 _SAMPLE_QC_MODES = ("all", "pass", "pass_or_warn")
-SAMPLE_EXPRESSION_QC_POLICY_VERSION = "sample_expression_qc_v1"
+SAMPLE_EXPRESSION_QC_POLICY_VERSION = "sample_expression_qc_v2"
 SOURCE_MATRIX_SAMPLE_QC_MANIFEST_SCHEMA_VERSION = "source_matrix_sample_qc_manifest_v1"
 EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION = "expression_artifact_build_metadata_v1"
 SOURCE_MATRIX_SAMPLE_QC_MANIFEST_PATH = "source-matrix-sample-qc.csv"
@@ -600,12 +600,14 @@ _EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS = [
 ]
 DEFAULT_MIN_DETECTED_GENES_FOR_QC = 5000
 DEFAULT_MIN_HOUSEKEEPING_GENES_FOR_QC = 10
+DEFAULT_MAX_ZERO_FRACTION_FOR_QC = 0.70
 DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC = 0.20
 DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC = 0.50
 _BLOCKING_SAMPLE_QC_REASONS = frozenset(
     {
         "low_detected_genes",
         "low_housekeeping_detection",
+        "high_zero_fraction",
         "high_top_gene_fraction",
         "high_top10_gene_fraction",
     }
@@ -709,6 +711,7 @@ def sample_expression_qc_from_matrix(
     source_metadata: dict[str, str | bool | None] | None = None,
     min_detected_genes: int = DEFAULT_MIN_DETECTED_GENES_FOR_QC,
     min_housekeeping_detected: int | None = None,
+    max_zero_fraction: float = DEFAULT_MAX_ZERO_FRACTION_FOR_QC,
     max_top_gene_fraction: float = DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC,
     max_top10_gene_fraction: float = DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC,
 ) -> pd.DataFrame:
@@ -806,6 +809,8 @@ def sample_expression_qc_from_matrix(
             flags.append("low_detected_genes")
         if min_hk is not None and hk_detected < min_hk:
             flags.append("low_housekeeping_detection")
+        if pd.notna(zero_fraction) and zero_fraction > max_zero_fraction:
+            flags.append("high_zero_fraction")
         if pd.notna(top_fraction) and top_fraction > max_top_gene_fraction:
             flags.append("high_top_gene_fraction")
         if (
@@ -871,6 +876,7 @@ def sample_expression_qc(
     auto_fetch: bool = True,
     min_detected_genes: int = DEFAULT_MIN_DETECTED_GENES_FOR_QC,
     min_housekeeping_detected: int | None = None,
+    max_zero_fraction: float = DEFAULT_MAX_ZERO_FRACTION_FOR_QC,
     max_top_gene_fraction: float = DEFAULT_MAX_TOP_GENE_FRACTION_FOR_QC,
     max_top10_gene_fraction: float = DEFAULT_MAX_TOP10_GENE_FRACTION_FOR_QC,
 ) -> pd.DataFrame:
@@ -889,6 +895,7 @@ def sample_expression_qc(
         cancer_type=code,
         min_detected_genes=min_detected_genes,
         min_housekeeping_detected=min_housekeeping_detected,
+        max_zero_fraction=max_zero_fraction,
         max_top_gene_fraction=max_top_gene_fraction,
         max_top10_gene_fraction=max_top10_gene_fraction,
     )

--- a/oncoref/source_matrices.py
+++ b/oncoref/source_matrices.py
@@ -153,6 +153,7 @@ def sample_qc(
     auto_fetch: bool = True,
     min_detected_genes: int | None = None,
     min_housekeeping_detected: int | None = None,
+    max_zero_fraction: float | None = None,
     max_top_gene_fraction: float | None = None,
     max_top10_gene_fraction: float | None = None,
 ) -> pd.DataFrame:
@@ -175,6 +176,8 @@ def sample_qc(
         kwargs["min_detected_genes"] = min_detected_genes
     if min_housekeeping_detected is not None:
         kwargs["min_housekeeping_detected"] = min_housekeeping_detected
+    if max_zero_fraction is not None:
+        kwargs["max_zero_fraction"] = max_zero_fraction
     if max_top_gene_fraction is not None:
         kwargs["max_top_gene_fraction"] = max_top_gene_fraction
     if max_top10_gene_fraction is not None:

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.40"
+__version__ = "1.8.41"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -338,7 +338,7 @@ def test_rebuild_expression_artifacts_defaults_to_qc_passing_samples(tmp_path, m
     assert prov.loc[0, "n_source_samples"] == 3
     assert prov.loc[0, "n_cohort_samples"] == 1
     assert prov.loc[0, "sample_qc"] == "pass"
-    assert prov.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v1"
+    assert prov.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v2"
     assert prov.loc[0, "n_qc_pass"] == 1
     assert prov.loc[0, "n_qc_warn"] == 1
     assert prov.loc[0, "n_qc_fail"] == 1
@@ -349,7 +349,7 @@ def test_rebuild_expression_artifacts_defaults_to_qc_passing_samples(tmp_path, m
     build_meta = pd.read_csv(out / "expression-artifact-build-metadata.csv")
     assert build_meta.loc[0, "n_source_samples"] == 3
     assert build_meta.loc[0, "n_cohort_samples"] == 1
-    assert build_meta.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v1"
+    assert build_meta.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v2"
 
     metadata = json.loads((out / "expression-artifact-build-metadata.json").read_text())
     assert metadata["sample_qc"] == "pass"

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -110,7 +110,7 @@ def _release_manifest(tar_path):
         "package_version": __version__,
         "source_matrix_version": SOURCE_MATRIX_VERSION,
         "sample_qc_policy": "pass",
-        "sample_qc_policy_version": "sample_expression_qc_v1",
+        "sample_qc_policy_version": "sample_expression_qc_v2",
         "source_matrix_sample_qc": "source-matrix-sample-qc.csv",
         "artifact_build_metadata": {
             "cohort_metadata": "expression-artifact-build-metadata.csv",
@@ -177,7 +177,7 @@ def test_bundle_release_manifest_preserves_inventory_and_build_metadata(monkeypa
     assert manifest["package_version"] == __version__
     assert manifest["source_matrix_version"] == SOURCE_MATRIX_VERSION
     assert manifest["sample_qc_policy"] == "pass"
-    assert manifest["sample_qc_policy_version"] == "sample_expression_qc_v1"
+    assert manifest["sample_qc_policy_version"] == "sample_expression_qc_v2"
     assert manifest["source_matrix_sample_qc"] == "source-matrix-sample-qc.csv"
     assert manifest["artifact_build_metadata"]["n_cohorts"] == 118
     assert set(manifest["inventory"]) == set(data_bundle.DOWNLOADABLE_PATHS)

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -734,6 +734,39 @@ def test_sample_expression_qc_flags_sparse_samples(tmp_path, monkeypatch):
     assert "high_top_gene_fraction" in qc.loc["sparse", "qc_flags"]
 
 
+def test_sample_expression_qc_flags_high_literal_zero_fraction():
+    raw = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": [f"ENSG{i:011d}" for i in range(10)],
+            "Symbol": [f"G{i}" for i in range(10)],
+            "sparse_zero": [1.0, 1.0, *([0.0] * 8)],
+            "less_sparse": [1.0, 1.0, 1.0, 1.0, *([0.0] * 6)],
+        }
+    )
+
+    qc = expression.sample_expression_qc_from_matrix(
+        raw,
+        cancer_type="X",
+        source_metadata={
+            "source_type": "geo",
+            "unit": "TPM",
+            "source_scale_class": "linear_rnaseq_tpm",
+            "linear_tpm_comparable": True,
+        },
+        min_detected_genes=1,
+        min_housekeeping_detected=0,
+        max_zero_fraction=0.7,
+        max_top_gene_fraction=1.0,
+        max_top10_gene_fraction=1.0,
+    ).set_index("sample_id")
+
+    assert qc.loc["sparse_zero", "zero_fraction_raw"] == pytest.approx(0.8)
+    assert qc.loc["sparse_zero", "sample_qc_status"] == "fail"
+    assert "high_zero_fraction" in qc.loc["sparse_zero", "sample_qc_reasons"]
+    assert qc.loc["less_sparse", "zero_fraction_raw"] == pytest.approx(0.6)
+    assert qc.loc["less_sparse", "sample_qc_status"] == "pass"
+
+
 def test_per_sample_expression_filters_by_sample_qc(tmp_path, monkeypatch):
     raw = pd.DataFrame(
         {

--- a/tests/test_source_matrices.py
+++ b/tests/test_source_matrices.py
@@ -94,11 +94,20 @@ def test_sample_qc_facade_uses_shared_expression_policy(monkeypatch):
 
     monkeypatch.setattr(expression, "sample_expression_qc", fake_sample_expression_qc)
 
-    out = sm.sample_qc("lung_adeno", auto_fetch=False, min_detected_genes=123)
+    out = sm.sample_qc(
+        "lung_adeno",
+        auto_fetch=False,
+        min_detected_genes=123,
+        max_zero_fraction=0.7,
+    )
 
     assert calls == {
         "code": "lung_adeno",
-        "kwargs": {"auto_fetch": False, "min_detected_genes": 123},
+        "kwargs": {
+            "auto_fetch": False,
+            "min_detected_genes": 123,
+            "max_zero_fraction": 0.7,
+        },
     }
     assert out["sample_qc_status"].tolist() == ["pass"]
 


### PR DESCRIPTION
## Summary
- bump sample expression QC policy to v2 with a blocking high_zero_fraction reason
- add a configurable max_zero_fraction threshold and thread it through source_matrices.sample_qc
- document literal-zero fraction in the sample-QC API and update bundle/build metadata expectations

## Sparse-sample check
With the default v2 policy, the named suspicious samples from #205 now fail live source QC:

- SARC_PEC/JNGR150: low_detected_genes; low_housekeeping_detection; high_zero_fraction
- SARC_PEC/JNGR175: high_zero_fraction
- SARC_PEC/JNGR178: high_top_gene_fraction
- SARC_PEC/JNGR179: low_detected_genes; high_zero_fraction
- BL/BLGSP-71-23-00437-01A: high_zero_fraction

## Scope
This updates the reusable/read-time QC policy and future artifact-build policy version. It does not regenerate the heavy expression bundle; that still belongs to the bundle rebuild/release work under #203/#205/#209.

## Tests
- python -m pytest tests/test_expression.py::test_sample_expression_qc_flags_sparse_samples tests/test_expression.py::test_sample_expression_qc_flags_high_literal_zero_fraction tests/test_source_matrices.py::test_sample_qc_facade_uses_shared_expression_policy tests/test_build_generators.py::test_rebuild_expression_artifacts_defaults_to_qc_passing_samples tests/test_data_bundle.py::test_bundle_release_manifest_preserves_inventory_and_build_metadata
- ./lint.sh
- ./test.sh

Refs #205
Refs #203
Refs #209