### PR TITLE
Replace nonexistent key-gene PMIDs

### DIFF
--- a/oncoref/data/cancer-key-genes.csv
+++ b/oncoref/data/cancer-key-genes.csv
@@ -98,7 +98,7 @@ SKCM,,S100B,biomarker,,,,,,,,Serum biomarker for melanoma progression,PMID:19380
 SKCM,,MLANA,biomarker,,,,,,,,Melan-A / MART-1 — melanocyte lineage antigen and TCR target,PMID:7539751
 SKCM,,TYR,biomarker,,,,,,,,Tyrosinase — melanocyte lineage antigen,PMID:8201753
 SKCM,,PMEL,biomarker,,,,,,,,gp100 — melanocyte antigen; vaccine and TCR target,PMID:8201753
-SKCM,,PRAME,biomarker,,,,,,,,Cancer-testis antigen broadly expressed in melanoma; IMCgp100 / PRAME TCR trials,PMID:34428009
+SKCM,,PRAME,biomarker,,,,,,,,Cancer-testis antigen with diagnostic/prognostic and therapeutic relevance in melanoma; PRAME-directed TCR trials require HLA-A*02 and expression confirmation,PMID:38338862
 SKCM,,CD274,biomarker,,,,,,,,PD-L1 stratifies IO response,PMID:26027431
 SKCM,,BRAF,target,dabrafenib + trametinib,small_molecule,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,BRAF V600 melanoma,Standard BRAF/MEK combination in V600-mutant disease,PMID:25399551
 SKCM,,BRAF,target,encorafenib + binimetinib,small_molecule,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,BRAF V600 melanoma,COLUMBUS trial combination,PMID:29573941
@@ -107,7 +107,7 @@ SKCM,,CD274,target,pembrolizumab,antibody,approved,approved_standard,standard_or
 SKCM,,CD274,target,nivolumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced melanoma,First-line anti-PD-1; combined with ipi for high-risk disease,PMID:26027431
 SKCM,,CTLA4,target,ipilimumab,antibody,approved,approved_standard,standard_or_frontline,confirm indication and line of therapy,advanced melanoma,Anti-CTLA4; combination with nivolumab standard of care,PMID:20525992
 SKCM,,LAG3,target,relatlimab,antibody,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,advanced melanoma,LAG-3 + PD-1 combination (nivolumab-relatlimab),PMID:35063055
-SKCM,,PRAME,target,IMA203,TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,advanced melanoma,PRAME-directed TCR-T trials,PMID:34428009
+SKCM,,PRAME,target,IMA203,TCR-T,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HLA-A*02+ PRAME+ advanced solid tumors including melanoma,PRAME-directed autologous TCR-T phase 1 trial,PMID:40205198
 SKCM,,PMEL,target,IMCgp100 / tebentafusp,TCE,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,uveal melanoma,gp100 ImmTAC — approved for HLA-A*02:01 uveal melanoma,PMID:33053284
 SKCM,,TYR,target,,TCR-T,preclinical,preclinical,preclinical,preclinical follow-up; not a clinical recommendation,melanoma,Historical tyrosinase TCRs; active cell-therapy research,PMID:31054264
 HNSC,,CDKN2A,biomarker,,,,,,,,p16 — elevated in HPV-driven HNSC (surrogate for E6/E7 inactivation),PMID:21079132
@@ -313,7 +313,7 @@ SARC,dedifferentiated_liposarcoma,,target,trabectedin,small_molecule,approved,ap
 SARC,myxoid_liposarcoma,DDIT3,biomarker,,,,,,,,FUS-DDIT3 (formerly FUS-CHOP) fusion — pathognomonic for MRCLS,PMID:20181787
 SARC,myxoid_liposarcoma,MAGE-A4,biomarker,,,,,,,,Expressed in ~40% of MRCLS — gates afami-cel / MAGE-A4 TCR-T eligibility,PMID:39141605
 SARC,myxoid_liposarcoma,CTAG1B,biomarker,,,,,,,,NY-ESO-1 — expressed in majority of MRCLS; TCR-T target,PMID:25668005
-SARC,myxoid_liposarcoma,PRAME,biomarker,,,,,,,,CT antigen expressed in MRCLS; TCR-T / ADC target,PMID:34428009
+SARC,myxoid_liposarcoma,PRAME,biomarker,,,,,,,,CT antigen expressed in MRCLS; candidate immunotherapy target,PMID:27499900
 SARC,myxoid_liposarcoma,PPARG,biomarker,,,,,,,,Adipogenic master regulator; lineage confirmation,PMID:20181787
 SARC,myxoid_liposarcoma,MAGE-A4,target,afami-cel (afamitresgene autoleucel),TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HLA-A*02+ MAGE-A4+ MRCLS,First-in-class engineered TCR-T — approved in synovial sarcoma; MRCLS cohorts in basket trials,PMID:39141605
 SARC,myxoid_liposarcoma,CTAG1B,target,letetresgene autoleucel,TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HLA-A*02+ NY-ESO-1+ MRCLS,NY-ESO-1 TCR-T — phase 2 in synovial / MRCLS,PMID:25668005
@@ -321,7 +321,7 @@ SARC,myxoid_liposarcoma,,target,trabectedin,small_molecule,approved,approved_ind
 SARC,synovial_sarcoma,SS18,biomarker,,,,,,,,SS18-SSX1/2/4 fusion (typically t(X;18)) — pathognomonic for synovial sarcoma,PMID:23583762
 SARC,synovial_sarcoma,MAGE-A4,biomarker,,,,,,,,Expressed in majority of synovial sarcoma — gates afami-cel eligibility,PMID:39141605
 SARC,synovial_sarcoma,CTAG1B,biomarker,,,,,,,,NY-ESO-1 — widely expressed; lete-cel target,PMID:25668005
-SARC,synovial_sarcoma,PRAME,biomarker,,,,,,,,Broadly expressed CT antigen; candidate TCR-T target,PMID:34428009
+SARC,synovial_sarcoma,PRAME,biomarker,,,,,,,,Broadly expressed CT antigen; expression and HLA class I patterns support PRAME-specific TCR-T development,PMID:30524904
 SARC,synovial_sarcoma,TLE1,biomarker,,,,,,,,Diagnostic IHC marker — near-universal nuclear staining in synovial sarcoma,PMID:17255762
 SARC,synovial_sarcoma,BCL2,biomarker,,,,,,,,Broadly overexpressed — candidate for BCL2-targeted therapy trials,PMID:11297487
 SARC,synovial_sarcoma,MAGE-A4,target,afami-cel (Tecelra),TCR-T,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,HLA-A*02+ MAGE-A4+ advanced synovial sarcoma,First engineered TCR-T approved by FDA (2024) — SPEARHEAD-1 trial,PMID:39141605
@@ -332,7 +332,7 @@ SARC,dsrct,EWSR1,biomarker,,,,,,,,EWSR1-WT1 t(11;22)(p13;q12) fusion — pathogn
 SARC,dsrct,WT1,biomarker,,,,,,,,C-terminal WT1 IHC — positive due to the EWSR1-WT1 fusion; diagnostic,PMID:11559696
 SARC,dsrct,DES,biomarker,,,,,,,,Dot-like desmin IHC — characteristic DSRCT pattern,PMID:11559696
 SARC,dsrct,VIM,biomarker,,,,,,,,Vimentin positivity alongside keratin — DSRCT polyphenotypic pattern,PMID:11559696
-SARC,dsrct,WT1,target,,TCR-T,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,WT1+ DSRCT,WT1-directed TCR-T and peptide vaccines in early trials,PMID:35379757
+SARC,dsrct,WT1,target,,vaccine,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,WT1+ sarcoma; DSRCT-specific WT1 biology from EWSR1-WT1 fusion,WT1 peptide vaccine evidence is sarcoma-wide rather than DSRCT-specific; DSRCT-specific therapeutic rationale comes from EWSR1-WT1 biology,PMID:35069874; PMID:39139449
 SARC,gist,KIT,biomarker,,,,,,,,CD117 — activating mutation in majority of GIST; gates imatinib / sunitinib / avapritinib eligibility,PMID:12522257
 SARC,gist,PDGFRA,biomarker,,,,,,,,Imatinib-sensitive mutations (e.g. V561D); D842V requires avapritinib,PMID:12522257
 SARC,gist,SDHB,biomarker,,,,,,,,Loss identifies SDH-deficient (WT) GIST — paediatric/young adult subtype with different biology,PMID:21252315
@@ -350,11 +350,11 @@ SARC,ewing_sarcoma,FLI1,biomarker,,,,,,,,Fusion partner — IHC positive in Ewin
 SARC,ewing_sarcoma,NKX2-2,biomarker,,,,,,,,Downstream EWSR1-FLI1 target; lineage marker,PMID:21339729
 SARC,ewing_sarcoma,CD99,biomarker,,,,,,,,Membranous CD99 staining — sensitive but not specific Ewing IHC,PMID:20142596
 SARC,ewing_sarcoma,CAV1,biomarker,,,,,,,,Caveolin-1 — marker of Ewing differentiation,PMID:21339729
-SARC,ewing_sarcoma,PRAME,biomarker,,,,,,,,CT antigen expressed in Ewing; TCR-T target,PMID:34428009
+SARC,ewing_sarcoma,PRAME,biomarker,,,,,,,,Candidate Ewing sarcoma-associated CT antigen; expression/immune-reactivity evidence supports careful antigen-specific immunotherapy workup,PMID:24973179
 SARC,ewing_sarcoma,,target,trabectedin,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,relapsed Ewing,Alkylating agent — active in Ewing per single-agent and combo trials,PMID:26967202
 SARC,ewing_sarcoma,CDK4,target,palbociclib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,relapsed Ewing,CDK4/6 inhibitor — ongoing phase 2,PMID:31924739
 SARC,ewing_sarcoma,,target,TK216,small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,relapsed Ewing,Small-molecule ETV fusion inhibitor — first-in-class trial,PMID:33872428
-SARC,ewing_sarcoma,PRAME,target,IMA203,TCR-T,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,PRAME+ HLA-A*02+ Ewing,PRAME-directed TCR-T — basket phase 2 including Ewing,PMID:34428009
+SARC,ewing_sarcoma,PRAME,target,IMA203,TCR-T,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,HLA-A*02+ PRAME+ advanced solid tumors including sarcoma,PRAME-directed autologous TCR-T phase 1 trial,PMID:40205198
 SARC,kinase_driven_sarcoma,EGFR,biomarker,,,,,,,,EGFR kinase-domain duplication / activating alteration — kinase-driver evidence; confirm with DNA/RNA structural-variant assay,PMID:26286086; PMID:39863531
 SARC,kinase_driven_sarcoma,EGFR,target,EGFR TKI (afatinib / osimertinib),small_molecule,off_label,off_label,clinical_trial,off-label/trial follow-up; confirm EGFR KDD or activating EGFR alteration and trial availability,EGFR KDD / activating EGFR alteration in kinase-driven sarcoma,EGFR KDD is an oncogenic driver with TKI response precedent strongest outside sarcoma; rare sarcoma-like tumors with EGFR KDD are reported,PMID:26286086; PMID:30255937; PMID:39863531
 THCA,,BRAF,biomarker,,,,,,,,V600E — most common mutation in papillary thyroid carcinoma (~50%); drives RAI resistance,PMID:24557579
@@ -812,20 +812,20 @@ CTCL,,CCR4,target,mogamulizumab,antibody,approved,approved_later_line,later_line
 CTCL,,TNFRSF8,target,brentuximab vedotin,ADC,approved,approved_indication_matched,approved_biomarker_matched,confirm biomarker/indication-specific eligibility,CD30+ CTCL,CD30 MMAE ADC — approved 2017; ALCANZA trial,PMID:28433508
 CTCL,,HDAC1,target,romidepsin,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R CTCL,Class-1 HDAC inhibitor — approved 2009,PMID:19451442
 CTCL,,HDAC1,target,vorinostat,small_molecule,approved,approved_later_line,later_line_approved,confirm prior therapies and indication-specific eligibility,R/R CTCL,Pan-HDAC inhibitor — approved 2006,PMID:17227786
-SARC,MPNST,NF1,biomarker,,,,,,,,Biallelic NF1 loss drives constitutive RAS/MAPK signaling in MPNST (up to 50% NF1-associated; sporadic cases also NF1-null),PMID:37173835
-SARC,MPNST,CDKN2A,biomarker,,,,,,,,CDKN2A/B loss near-obligate in MPNST progression; marker of malignant transformation from plexiform NF,PMID:37173835
-SARC,MPNST,CDKN2B,biomarker,,,,,,,,Co-deleted with CDKN2A in MPNST,PMID:37173835
-SARC,MPNST,TP53,biomarker,,,,,,,,TP53 inactivation frequent in high-grade MPNST,PMID:37173835
+SARC,MPNST,NF1,biomarker,,,,,,,,Biallelic NF1 loss drives constitutive RAS/MAPK signaling in MPNST; NF1-associated and sporadic tumors commonly converge on NF1/RAS-pathway loss,PMID:36598417
+SARC,MPNST,CDKN2A,biomarker,,,,,,,,CDKN2A loss is a recurrent progression event in MPNST evolution; supports malignant transformation from precursor lesions,PMID:36598417
+SARC,MPNST,CDKN2B,biomarker,,,,,,,,CDKN2B/p15INK4b can be inactivated or co-lost with the CDKN2A locus in sporadic and NF1-related MPNST,PMID:14519636
+SARC,MPNST,TP53,biomarker,,,,,,,,TP53 inactivation is a recurrent event in high-grade MPNST genomic evolution,PMID:36598417
 SARC,MPNST,SUZ12,biomarker,,,,,,,,PRC2 loss-of-function (SUZ12/EED) yields global H3K27me3 loss — diagnostically useful IHC correlate,PMID:24857941
 SARC,MPNST,EED,biomarker,,,,,,,,PRC2 loss-of-function partner of SUZ12 — global H3K27me3 loss,PMID:24857941
 SARC,MPNST,SMARCB1,biomarker,,,,,,,,SMARCB1 loss in a subset of MPNST (epithelioid variant); overlaps with epithelioid sarcoma biology,PMID:25348869
-SARC,MPNST,SOX10,biomarker,,,,,,,,Schwann-cell lineage confirmation — frequently retained in MPNST despite differentiation drift,PMID:37173835
-SARC,MPNST,S100B,biomarker,,,,,,,,Schwann-cell lineage marker; loss often accompanies high-grade / dedifferentiated MPNST,PMID:37173835
-SARC,MPNST,MEK1,target,trametinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,unresectable/metastatic NF1-associated MPNST,RAS-pathway dependency from NF1 loss; SARC031 trial investigating trametinib ± SHP2i,PMID:37173835
+SARC,MPNST,SOX10,biomarker,,,,,,,,Schwann-cell lineage confirmation — often retained through progression from neurofibroma to MPNST,PMID:28551330
+SARC,MPNST,S100B,biomarker,,,,,,,,Schwann-cell lineage marker; reduced or lost expression can accompany high-grade / dedifferentiated MPNST,PMID:28551330
+SARC,MPNST,MEK1,target,trametinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,unresectable/metastatic NF1-associated MPNST,RAS/MEK dependency from NF1 loss; combined SHP2+MEK inhibition has preclinical MPNST support,PMID:33032988; PMID:33203698
 SARC,MPNST,MEK1,target,selumetinib,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,NF1-associated MPNST (investigational),FDA-approved for inoperable plexiform NF (the MPNST precursor); extending into MPNST trials,PMID:32029004
 SARC,MPNST,MDM2,target,brigimadlin (BI 907828),small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,MDM2-amplified TP53-retained MPNST,MDM2 inhibition where TP53 wild-type preserved,PMID:35551194
 SARC,MPNST,EZH2,target,tazemetostat,small_molecule,phase_2,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,PRC2-null / SMARCB1-null MPNST,Synthetic lethal with PRC2 loss; FDA-approved for epithelioid sarcoma (SMARCB1-null) precedent,PMID:32507290
-SARC,MPNST,PTPN11,target,SHP2 inhibitors (trials),small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,RAS-driven MPNST (MEK-combo trials),SHP2 inhibition as MEK-resistance mitigator,PMID:37173835
+SARC,MPNST,PTPN11,target,SHP2 inhibitors (trials),small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,RAS-driven MPNST (MEK-combo trials),SHP2 inhibition as MEK-resistance mitigator in NF1-associated MPNST models,PMID:33032988; PMID:39793045
 SARC,MPNST,BRD4,target,BET inhibitors (trials),small_molecule,phase_1,trial_follow_up,clinical_trial,clinical-trial follow-up; not default standard,MPNST (preclinical / early-phase),BRD4 dependency in PRC2-null contexts — synergy with MEK inhibition,PMID:29203800
 BCC,,SMO,target,vismodegib,small_molecule,approved,approved_standard,standard_or_frontline,confirm locally-advanced or metastatic eligibility,locally advanced / metastatic BCC,Hedgehog SMO inhibitor; first approved targeted therapy for advanced BCC,PMID:22670903
 BCC,,SMO,target,sonidegib,small_molecule,approved,approved_indication_matched,standard_or_frontline,confirm locally-advanced eligibility,locally advanced BCC,Second SMO inhibitor for advanced BCC,PMID:26159756

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.54"
+__version__ = "1.8.55"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_cancer_genes.py
+++ b/tests/test_cancer_genes.py
@@ -96,6 +96,58 @@ def test_key_gene_known_wrong_pmids_are_replaced():
     assert bad_pmids.isdisjoint(audited_refs)
 
 
+def test_key_gene_nonexistent_pmids_are_replaced():
+    key = cg.cancer_key_genes_df()
+
+    bad_pmids = {"PMID:34428009", "PMID:35379757", "PMID:37173835"}
+    all_refs = set().union(*(_split_refs(v) for v in key["source"]))
+    assert bad_pmids.isdisjoint(all_refs)
+
+    expected_refs = {
+        ("SKCM", "", "PRAME", "biomarker", ""): {"PMID:38338862"},
+        ("SKCM", "", "PRAME", "target", "IMA203"): {"PMID:40205198"},
+        ("SARC", "myxoid_liposarcoma", "PRAME", "biomarker", ""): {"PMID:27499900"},
+        ("SARC", "synovial_sarcoma", "PRAME", "biomarker", ""): {"PMID:30524904"},
+        ("SARC", "ewing_sarcoma", "PRAME", "biomarker", ""): {"PMID:24973179"},
+        ("SARC", "ewing_sarcoma", "PRAME", "target", "IMA203"): {"PMID:40205198"},
+        ("SARC", "dsrct", "WT1", "target", ""): {"PMID:35069874", "PMID:39139449"},
+        ("SARC", "MPNST", "NF1", "biomarker", ""): {"PMID:36598417"},
+        ("SARC", "MPNST", "CDKN2A", "biomarker", ""): {"PMID:36598417"},
+        ("SARC", "MPNST", "CDKN2B", "biomarker", ""): {"PMID:14519636"},
+        ("SARC", "MPNST", "TP53", "biomarker", ""): {"PMID:36598417"},
+        ("SARC", "MPNST", "SOX10", "biomarker", ""): {"PMID:28551330"},
+        ("SARC", "MPNST", "S100B", "biomarker", ""): {"PMID:28551330"},
+        ("SARC", "MPNST", "MEK1", "target", "trametinib"): {
+            "PMID:33032988",
+            "PMID:33203698",
+        },
+        ("SARC", "MPNST", "PTPN11", "target", "SHP2 inhibitors (trials)"): {
+            "PMID:33032988",
+            "PMID:39793045",
+        },
+    }
+    for (code, subtype, symbol, role, agent), expected in expected_refs.items():
+        mask = (
+            (key["cancer_code"] == code)
+            & (key["subtype"].fillna("") == subtype)
+            & (key["symbol"] == symbol)
+            & (key["role"] == role)
+            & (key["agent"].fillna("") == agent)
+        )
+        rows = key[mask]
+        assert len(rows) == 1, (code, subtype, symbol, role, agent)
+        assert _split_refs(rows.iloc[0]["source"]) == expected
+
+    wt1 = key[
+        (key["cancer_code"] == "SARC")
+        & (key["subtype"] == "dsrct")
+        & (key["symbol"] == "WT1")
+        & (key["role"] == "target")
+    ].iloc[0]
+    assert wt1["agent_class"] == "vaccine"
+    assert "TCR-T" not in str(wt1["rationale"])
+
+
 def test_type_gene_sets():
     sets = cg.cancer_type_gene_sets("PRAD")
     assert sets  # non-empty role->{ensembl:symbol}


### PR DESCRIPTION
## Summary

Closes #157. Replaces the three PubMed IDs that did not resolve in `cancer-key-genes.csv` and avoids reusing one citation across heterogeneous claims.

Changes by evidence bucket:

- PRAME expression/biomarker rows now use disease-appropriate sources:
  - melanoma: PMID:38338862
  - myxoid liposarcoma: PMID:27499900
  - synovial sarcoma: PMID:30524904
  - Ewing sarcoma: PMID:24973179
- PRAME IMA203 target rows now use the direct IMA203 phase 1 trial: PMID:40205198.
- DSRCT WT1 target row is narrowed from unsupported TCR-T wording to WT1 peptide-vaccine evidence plus DSRCT WT1 biology context: PMID:35069874; PMID:39139449.
- MPNST biomarker and target rows now split biology/pathology versus therapeutic model evidence:
  - NF1/CDKN2A/TP53: PMID:36598417
  - CDKN2B: PMID:14519636
  - SOX10/S100B: PMID:28551330
  - MEK/SHP2 target logic: PMID:33032988; PMID:33203698; PMID:39793045

Adds a regression test that denies `PMID:34428009`, `PMID:35379757`, and `PMID:37173835` from key-gene sources and checks the replacement refs row-by-row.

## Verification

- `python -m pytest tests/test_cancer_genes.py -q`
- `git diff --check`
- `./lint.sh`
- `./test.sh` -> 627 passed, 1 existing matplotlib open-figure warning