### PR TITLE
Add metadata-bearing anti-PD1 response records

### DIFF
--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -28,7 +28,12 @@ from . import (
     ici_response,
     source_matrices,
 )
-from .apd1 import cancer_apd1_response, cancer_apd1_response_df
+from .apd1 import (
+    cancer_apd1_response,
+    cancer_apd1_response_df,
+    cancer_apd1_response_record,
+    resolve_apd1_response_source,
+)
 from .cancer_types import (
     CANCER_TYPE_ALIASES,
     CANCER_TYPE_NAMES,
@@ -229,8 +234,10 @@ from .ici import (
     cancer_ici_response,
     cancer_ici_response_df,
     cancer_ici_response_estimates_df,
+    cancer_ici_response_record,
     ici_regimens,
     pooled_ici_response,
+    resolve_ici_response_source,
 )
 from .incidence import (
     burden_category,
@@ -348,6 +355,7 @@ __all__ = [
     # anti-PD-1 response
     "cancer_apd1_response",
     "cancer_apd1_response_df",
+    "cancer_apd1_response_record",
     # incidence / mortality
     "cancer_burden",
     "cancer_burden_df",
@@ -359,6 +367,7 @@ __all__ = [
     "cancer_ici_response",
     "cancer_ici_response_df",
     "cancer_ici_response_estimates_df",
+    "cancer_ici_response_record",
     "cancer_lineage_group",
     "cancer_lineage_group_overrides",
     "cancer_lineage_groups",
@@ -532,8 +541,10 @@ __all__ = [
     "recommended_hpa_housekeeping_panel",
     "renormalize_to_million",
     "representative_cohort_samples",
+    "resolve_apd1_response_source",
     "resolve_cancer_type",
     "resolve_ensembl_id",
+    "resolve_ici_response_source",
     "resolve_symbol",
     "resolve_tmb_source",
     "response_signature_direction",

--- a/oncoref/apd1.py
+++ b/oncoref/apd1.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import pandas as pd
+
 from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
 from .ici import response_anchor_evidence_df
 from .load_dataset import get_data
@@ -67,3 +69,130 @@ def cancer_apd1_response(cancer_type=None, *, inherit=True):
             break
         cur = str(reg.loc[cur].get("parent_code", "") or "").strip() or None
     return None
+
+
+def _parent_code(code: str, registry) -> str | None:
+    if code not in registry.index:
+        return None
+    parent = registry.loc[code].get("parent_code", "")
+    if pd.isna(parent):
+        return None
+    parent = str(parent).strip()
+    return parent or None
+
+
+def _public_value(value):
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if hasattr(value, "item"):
+        return value.item()
+    return value
+
+
+def _record_from_row(row, *, requested_code: str, resolved_code: str, inheritance_kind: str):
+    record = {key: _public_value(row[key]) for key in row.index}
+    record["requested_cancer_code"] = requested_code
+    record["resolved_cancer_code"] = resolved_code
+    record["selected_regimen"] = record.get("drug_target")
+    record["selected_drug_target"] = record.get("drug_target")
+    record["inheritance_kind"] = inheritance_kind
+    record["is_inherited_evidence"] = requested_code != resolved_code
+    return record
+
+
+def _matching_row(df: pd.DataFrame, code: str):
+    hit = df[df["cancer_code"].astype(str) == code]
+    return None if hit.empty else hit.iloc[0]
+
+
+def _resolve_apd1_response_row(requested_code: str, *, inherit: bool):
+    df = cancer_apd1_response_df().dropna(subset=["apd1_orr_pct"])
+    direct = _matching_row(df, requested_code)
+    if direct is not None or not inherit:
+        return requested_code, "direct" if direct is not None else "missing", direct
+
+    source_code = cancer_evidence_source_code(requested_code)
+    if source_code != requested_code:
+        source = _matching_row(df, source_code)
+        if source is not None:
+            return source_code, "source_scope", source
+
+    registry = cancer_type_registry().set_index("code")
+    cur = _parent_code(requested_code, registry)
+    seen = {requested_code}
+    while cur and cur not in seen:
+        seen.add(cur)
+        inherited = _matching_row(df, cur)
+        if inherited is not None:
+            return cur, "ancestor", inherited
+        cur = _parent_code(cur, registry)
+    return requested_code, "missing", None
+
+
+def resolve_apd1_response_source(cancer_type, *, inherit=True) -> dict:
+    """Resolve the evidence source row used for an anti-PD-1 response lookup.
+
+    Returns lookup metadata without reducing the result to a numeric ORR:
+    ``requested_cancer_code``, ``resolved_cancer_code``, ``inheritance_kind`` and
+    source/provenance fields from :func:`cancer_apd1_response_df` when available.
+    Source-scoped molecular children such as ``COAD_MSI`` and ``READ_MSI`` resolve
+    through the curated ``CRC_MSI`` row while preserving that the evidence is inherited
+    from an aggregate/source-scope estimate.
+    """
+    requested_code = resolve_cancer_type(cancer_type)
+    resolved_code, inheritance_kind, row = _resolve_apd1_response_row(
+        requested_code, inherit=inherit
+    )
+    if row is None:
+        return {
+            "requested_cancer_code": requested_code,
+            "resolved_cancer_code": None,
+            "inheritance_kind": inheritance_kind,
+            "is_inherited_evidence": False,
+            "selected_regimen": None,
+            "selected_drug_target": None,
+            "has_apd1_response_source": False,
+        }
+    record = _record_from_row(
+        row,
+        requested_code=requested_code,
+        resolved_code=resolved_code,
+        inheritance_kind=inheritance_kind,
+    )
+    record["has_apd1_response_source"] = True
+    return record
+
+
+def cancer_apd1_response_record(cancer_type=None, *, inherit=True):
+    """Metadata-bearing anti-PD-1 objective response lookup.
+
+    Mirrors :func:`cancer_apd1_response`, but returns the resolved anchor row as a
+    dict instead of only the ORR value. The record includes joined evidence fields
+    from the audited ICI estimates table plus requested/resolved-code metadata. With
+    ``cancer_type=None`` the returned map contains direct source rows only; child-code
+    inheritance is available through individual lookups or
+    :func:`resolve_apd1_response_source`.
+    """
+    if cancer_type is None:
+        df = cancer_apd1_response_df().dropna(subset=["apd1_orr_pct"])
+        return {
+            str(code): record
+            for code in sorted(df["cancer_code"].astype(str).unique())
+            if (record := cancer_apd1_response_record(code, inherit=False))
+        }
+
+    requested_code = resolve_cancer_type(cancer_type)
+    resolved_code, inheritance_kind, row = _resolve_apd1_response_row(
+        requested_code, inherit=inherit
+    )
+    if row is None:
+        return None
+    return _record_from_row(
+        row,
+        requested_code=requested_code,
+        resolved_code=resolved_code,
+        inheritance_kind=inheritance_kind,
+    )

--- a/oncoref/ici_response.py
+++ b/oncoref/ici_response.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 from .apd1 import (
     cancer_apd1_response,
     cancer_apd1_response_df,
+    cancer_apd1_response_record,
+    resolve_apd1_response_source,
 )
 from .ici import (
     PROPORTION_METRICS,
@@ -60,6 +62,16 @@ def apd1_response(cancer_type=None, *, inherit: bool = True):
 def apd1_response_df():
     """Curated anti-PD-1 monotherapy ORR anchor table."""
     return cancer_apd1_response_df()
+
+
+def apd1_response_record(cancer_type=None, *, inherit: bool = True):
+    """Anti-PD-1 response with source/evidence metadata."""
+    return cancer_apd1_response_record(cancer_type, inherit=inherit)
+
+
+def apd1_response_source(cancer_type, *, inherit: bool = True):
+    """Direct/proxy/ancestor anti-PD-1 evidence-source resolution."""
+    return resolve_apd1_response_source(cancer_type, inherit=inherit)
 
 
 def ici_response_anchor_df():
@@ -115,10 +127,13 @@ __all__ = [
     "RESPONSE_PROPORTION_METRICS",
     "apd1_response",
     "apd1_response_df",
+    "apd1_response_record",
+    "apd1_response_source",
     "best_available_ici_response",
     "best_available_ici_response_record",
     "cancer_apd1_response",
     "cancer_apd1_response_df",
+    "cancer_apd1_response_record",
     "cancer_ici_regimen",
     "cancer_ici_response",
     "cancer_ici_response_df",
@@ -131,6 +146,7 @@ __all__ = [
     "ici_response_records_by_regimen",
     "ici_response_source",
     "pooled_ici_response",
+    "resolve_apd1_response_source",
     "resolve_ici_response_source",
     "selected_ici_regimen",
 ]

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.55"
+__version__ = "1.8.56"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_apd1.py
+++ b/tests/test_apd1.py
@@ -4,7 +4,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-from oncoref import apd1
+from oncoref import apd1, ici_response
 
 
 def test_apd1_map_nonempty_floats():
@@ -42,6 +42,53 @@ def test_crc_msi_apd1_is_single_source_scope_row():
     assert apd1.cancer_apd1_response("COAD_MSI") == mapping["CRC_MSI"]
     assert apd1.cancer_apd1_response("READ_MSI") == mapping["CRC_MSI"]
     assert apd1.cancer_apd1_response("READ_MSI", inherit=False) is None
+
+
+def test_crc_msi_apd1_record_preserves_requested_and_source_codes():
+    record = apd1.cancer_apd1_response_record("COAD_MSI")
+
+    assert record["requested_cancer_code"] == "COAD_MSI"
+    assert record["resolved_cancer_code"] == "CRC_MSI"
+    assert record["inheritance_kind"] == "source_scope"
+    assert record["is_inherited_evidence"] is True
+    assert record["selected_regimen"] == "PD-1"
+    assert record["selected_drug_target"] == "PD-1"
+    assert record["apd1_orr_pct"] == 43.8
+    assert record["source_anchor"] == "PMID:33264544"
+
+    source = apd1.resolve_apd1_response_source("READ_MSI")
+    assert source["requested_cancer_code"] == "READ_MSI"
+    assert source["resolved_cancer_code"] == "CRC_MSI"
+    assert source["has_apd1_response_source"] is True
+
+
+def test_apd1_record_inherit_false_and_bulk_direct_rows_only():
+    assert apd1.cancer_apd1_response_record("READ_MSI", inherit=False) is None
+    missing = apd1.resolve_apd1_response_source("READ_MSI", inherit=False)
+    assert missing == {
+        "requested_cancer_code": "READ_MSI",
+        "resolved_cancer_code": None,
+        "inheritance_kind": "missing",
+        "is_inherited_evidence": False,
+        "selected_regimen": None,
+        "selected_drug_target": None,
+        "has_apd1_response_source": False,
+    }
+
+    bulk = apd1.cancer_apd1_response_record()
+    assert "CRC_MSI" in bulk
+    assert "COAD_MSI" not in bulk
+    assert "READ_MSI" not in bulk
+    assert bulk["CRC_MSI"]["inheritance_kind"] == "direct"
+
+
+def test_apd1_record_helpers_are_exported():
+    import oncoref
+
+    assert oncoref.cancer_apd1_response_record is apd1.cancer_apd1_response_record
+    assert oncoref.resolve_apd1_response_source is apd1.resolve_apd1_response_source
+    assert ici_response.apd1_response_record("COAD_MSI")["resolved_cancer_code"] == "CRC_MSI"
+    assert ici_response.apd1_response_source("COAD_MSI")["inheritance_kind"] == "source_scope"
 
 
 def test_btc_apd1_is_single_pan_biliary_source_scope_row():


### PR DESCRIPTION
## Summary

- Add `cancer_apd1_response_record(...)` and `resolve_apd1_response_source(...)` for metadata-bearing anti-PD1 response lookups
- Preserve requested/resolved code metadata for source-scope inheritance such as `COAD_MSI` / `READ_MSI` -> `CRC_MSI`
- Export the helpers through `oncoref.ici_response` and top-level compatibility imports, alongside existing ICI/TMB record helpers

## Context

Part of #196. This does not close the broad registry parity issue; the current pirlygenes parity run still reports 19/26 non-ok comparisons, including TMB/aPD1/burden table/value differences and expression artifact deltas. This PR fills the missing anti-PD1 record/source API surface so downstream code can inspect provenance without using only scalar ORR values.

## Verification

- `python -m pytest tests/test_apd1.py -q`
- `python -m pytest tests/test_apd1.py tests/test_ici.py tests/test_tmb.py -q`
- `./lint.sh`
- `./test.sh` (630 passed, 1 existing matplotlib open-figure warning)
- `python /Users/iskander/code/pirlygenes/scripts/compare_oncoref_pirlygenes.py --oncoref-path /Users/iskander/code/oncoref` (still 19/26 non-ok; output written under pirlygenes parity outputs)
