### PR TITLE
Add inherited bulk response maps

### DIFF
--- a/oncoref/apd1.py
+++ b/oncoref/apd1.py
@@ -41,17 +41,31 @@ def cancer_apd1_response_df():
     )
 
 
-def cancer_apd1_response(cancer_type=None, *, inherit=True):
+def cancer_apd1_response(cancer_type=None, *, inherit=True, include_inherited=False):
     """Anti-PD-1 monotherapy ORR (%) for one cancer type, or the whole
     ``{code: orr_pct}`` map. ``cancer_type`` is resolved through
     :func:`resolve_cancer_type`; with ``inherit`` (default) a code with no
     curated row of its own inherits its nearest ancestor's value via the registry
     ``parent_code`` chain. Returns ``None`` if neither the code nor any ancestor
-    has a value. Mirrors :func:`oncoref.cancer_tmb`."""
+    has a value. Mirrors :func:`oncoref.cancer_tmb`.
+
+    With ``cancer_type=None`` the default map contains direct source rows only. Pass
+    ``include_inherited=True`` to expand across registry codes with the same resolver
+    used for individual lookups, so source-scoped children such as ``COAD_MSI`` and
+    ``READ_MSI`` are included with inherited values.
+    """
     df = cancer_apd1_response_df()
     vals = df.dropna(subset=["apd1_orr_pct"])
     mapping = dict(zip(vals["cancer_code"].astype(str), vals["apd1_orr_pct"].astype(float)))
     if cancer_type is None:
+        if include_inherited:
+            out = {}
+            codes = sorted(set(cancer_type_registry()["code"].astype(str)) | set(mapping))
+            for code in codes:
+                value = cancer_apd1_response(code, inherit=inherit)
+                if value is not None:
+                    out[code] = value
+            return out
         return mapping
     code = resolve_cancer_type(cancer_type)
     if code in mapping or not inherit:
@@ -166,22 +180,29 @@ def resolve_apd1_response_source(cancer_type, *, inherit=True) -> dict:
     return record
 
 
-def cancer_apd1_response_record(cancer_type=None, *, inherit=True):
+def cancer_apd1_response_record(cancer_type=None, *, inherit=True, include_inherited=False):
     """Metadata-bearing anti-PD-1 objective response lookup.
 
     Mirrors :func:`cancer_apd1_response`, but returns the resolved anchor row as a
     dict instead of only the ORR value. The record includes joined evidence fields
     from the audited ICI estimates table plus requested/resolved-code metadata. With
-    ``cancer_type=None`` the returned map contains direct source rows only; child-code
-    inheritance is available through individual lookups or
-    :func:`resolve_apd1_response_source`.
+    ``cancer_type=None`` the returned map contains direct source rows only by default;
+    pass ``include_inherited=True`` to expand across registry codes with inherited
+    source metadata.
     """
     if cancer_type is None:
         df = cancer_apd1_response_df().dropna(subset=["apd1_orr_pct"])
+        direct_codes = set(df["cancer_code"].astype(str).unique())
+        codes = (
+            sorted(set(cancer_type_registry()["code"].astype(str)) | direct_codes)
+            if include_inherited
+            else sorted(direct_codes)
+        )
+        record_inherit = inherit if include_inherited else False
         return {
             str(code): record
-            for code in sorted(df["cancer_code"].astype(str).unique())
-            if (record := cancer_apd1_response_record(code, inherit=False))
+            for code in codes
+            if (record := cancer_apd1_response_record(code, inherit=record_inherit))
         }
 
     requested_code = resolve_cancer_type(cancer_type)

--- a/oncoref/ici.py
+++ b/oncoref/ici.py
@@ -278,9 +278,13 @@ def _parent_code(code: str, registry) -> str | None:
     return parent or None
 
 
-def _bulk_lookup_codes() -> list[str]:
+def _bulk_lookup_codes(*, include_inherited: bool = False) -> list[str]:
     df = cancer_ici_response_df().dropna(subset=["orr_pct"])
-    return sorted({str(code) for code in df["cancer_code"]})
+    direct_codes = {str(code) for code in df["cancer_code"]}
+    if not include_inherited:
+        return sorted(direct_codes)
+    registry_codes = set(cancer_type_registry()["code"].astype(str))
+    return sorted(registry_codes | direct_codes)
 
 
 def _matching_rows(df, code: str, order) -> dict[str, object]:
@@ -402,6 +406,7 @@ def cancer_ici_response(
     regimen=None,
     fallback=True,
     inherit=True,
+    include_inherited=False,
 ):
     """ICI objective response rate (%) for a cancer type.
 
@@ -418,16 +423,40 @@ def cancer_ici_response(
     the registry ``parent_code`` chain. Returns ``None`` (or ``{}``) when nothing is
     found.
 
-    With ``cancer_type=None`` returns the whole direct ``{code: orr}`` map (a single
-    regimen if pinned, else the fallback pick) — ready as a per-source plotting axis.
-    Source-scoped children such as ``COAD_MSI`` and ``READ_MSI`` intentionally are not
-    duplicated in bulk maps; use :func:`resolve_ici_response_source` or an individual
-    lookup for requested-code resolution metadata.
+    With ``cancer_type=None`` returns the whole direct ``{code: orr}`` map by default
+    (a single regimen if pinned, else the fallback pick) — ready as a per-source
+    plotting axis. Source-scoped children such as ``COAD_MSI`` and ``READ_MSI`` are not
+    duplicated in default bulk maps. Pass ``include_inherited=True`` to expand across
+    registry codes with the same resolver used for individual lookups.
     """
     maps = _regimen_maps()
     order = (regimen,) if regimen is not None else REGIMEN_FALLBACK
 
     if cancer_type is None:
+        if include_inherited:
+            out = {}
+            for code in _bulk_lookup_codes(include_inherited=True):
+                if regimen is not None:
+                    value = cancer_ici_response(
+                        code,
+                        regimen=regimen,
+                        inherit=inherit,
+                    )
+                    if value is not None:
+                        out[code] = value
+                elif not fallback:
+                    values = cancer_ici_response(
+                        code,
+                        fallback=False,
+                        inherit=inherit,
+                    )
+                    if values:
+                        out[code] = values
+                else:
+                    value = cancer_ici_response(code, inherit=inherit)
+                    if value is not None:
+                        out[code] = value
+            return out
         if regimen is not None:
             return dict(maps.get(regimen, {}))
         codes = {c for m in maps.values() for c in m}
@@ -491,6 +520,7 @@ def cancer_ici_response_record(
     regimen=None,
     fallback=True,
     inherit=True,
+    include_inherited=False,
 ):
     """Metadata-bearing ICI objective response lookup.
 
@@ -509,29 +539,38 @@ def cancer_ici_response_record(
     resolve through the curated ``CRC_MSI`` row while preserving the fact that the trial
     source is metastatic MSI-H/dMMR colorectal cancer rather than a colon- or
     rectum-specific estimate. With ``cancer_type=None`` the returned bulk map is direct
-    source rows only; use :func:`resolve_ici_response_source` for explicit requested-code
-    source/proxy resolution.
+    source rows only by default; pass ``include_inherited=True`` to expand across
+    registry codes with inherited source/proxy metadata.
     """
     order = (regimen,) if regimen is not None else REGIMEN_FALLBACK
 
     if cancer_type is None:
-        codes = _bulk_lookup_codes()
+        codes = _bulk_lookup_codes(include_inherited=include_inherited)
+        record_inherit = inherit if include_inherited else False
         if regimen is not None:
             return {
                 code: record
                 for code in codes
-                if (record := cancer_ici_response_record(code, regimen=regimen, inherit=False))
+                if (
+                    record := cancer_ici_response_record(
+                        code, regimen=regimen, inherit=record_inherit
+                    )
+                )
             }
         if not fallback:
             return {
                 code: records
                 for code in codes
-                if (records := cancer_ici_response_record(code, fallback=False, inherit=False))
+                if (
+                    records := cancer_ici_response_record(
+                        code, fallback=False, inherit=record_inherit
+                    )
+                )
             }
         return {
             code: record
             for code in codes
-            if (record := cancer_ici_response_record(code, inherit=False))
+            if (record := cancer_ici_response_record(code, inherit=record_inherit))
         }
 
     requested_code = resolve_cancer_type(cancer_type)

--- a/oncoref/ici_response.py
+++ b/oncoref/ici_response.py
@@ -54,9 +54,9 @@ RESPONSE_PROPORTION_METRICS = PROPORTION_METRICS
 """Response metrics that can be responder-weighted pooled."""
 
 
-def apd1_response(cancer_type=None, *, inherit: bool = True):
+def apd1_response(cancer_type=None, *, inherit: bool = True, include_inherited: bool = False):
     """Anti-PD-1 monotherapy ORR (%) for one cancer type, or the full code map."""
-    return cancer_apd1_response(cancer_type, inherit=inherit)
+    return cancer_apd1_response(cancer_type, inherit=inherit, include_inherited=include_inherited)
 
 
 def apd1_response_df():
@@ -64,9 +64,13 @@ def apd1_response_df():
     return cancer_apd1_response_df()
 
 
-def apd1_response_record(cancer_type=None, *, inherit: bool = True):
+def apd1_response_record(
+    cancer_type=None, *, inherit: bool = True, include_inherited: bool = False
+):
     """Anti-PD-1 response with source/evidence metadata."""
-    return cancer_apd1_response_record(cancer_type, inherit=inherit)
+    return cancer_apd1_response_record(
+        cancer_type, inherit=inherit, include_inherited=include_inherited
+    )
 
 
 def apd1_response_source(cancer_type, *, inherit: bool = True):
@@ -84,29 +88,49 @@ def ici_response_estimates_df():
     return cancer_ici_response_estimates_df()
 
 
-def best_available_ici_response(cancer_type=None, *, inherit: bool = True):
+def best_available_ici_response(
+    cancer_type=None, *, inherit: bool = True, include_inherited: bool = False
+):
     """Best-available ICI ORR (%) using ``DEFAULT_ICI_REGIMEN_PRIORITY``.
 
     This is a clearer name for ``cancer_ici_response(..., regimen=None,
     fallback=True)``. It chooses anti-PD-1 monotherapy when present, then anti-PD-L1,
     then anti-PD-1 + anti-CTLA-4.
     """
-    return cancer_ici_response(cancer_type, inherit=inherit)
+    return cancer_ici_response(cancer_type, inherit=inherit, include_inherited=include_inherited)
 
 
-def best_available_ici_response_record(cancer_type=None, *, inherit: bool = True):
+def best_available_ici_response_record(
+    cancer_type=None, *, inherit: bool = True, include_inherited: bool = False
+):
     """Best-available ICI response with source/evidence metadata."""
-    return cancer_ici_response_record(cancer_type, inherit=inherit)
+    return cancer_ici_response_record(
+        cancer_type, inherit=inherit, include_inherited=include_inherited
+    )
 
 
-def ici_response_by_regimen(cancer_type=None, *, inherit: bool = True):
+def ici_response_by_regimen(
+    cancer_type=None, *, inherit: bool = True, include_inherited: bool = False
+):
     """ICI ORR values grouped by regimen instead of using regimen priority."""
-    return cancer_ici_response(cancer_type, fallback=False, inherit=inherit)
+    return cancer_ici_response(
+        cancer_type,
+        fallback=False,
+        inherit=inherit,
+        include_inherited=include_inherited,
+    )
 
 
-def ici_response_records_by_regimen(cancer_type=None, *, inherit: bool = True):
+def ici_response_records_by_regimen(
+    cancer_type=None, *, inherit: bool = True, include_inherited: bool = False
+):
     """ICI response records grouped by regimen instead of using regimen priority."""
-    return cancer_ici_response_record(cancer_type, fallback=False, inherit=inherit)
+    return cancer_ici_response_record(
+        cancer_type,
+        fallback=False,
+        inherit=inherit,
+        include_inherited=include_inherited,
+    )
 
 
 def ici_response_source(cancer_type, *, regimen=None, fallback: bool = True, inherit: bool = True):

--- a/tests/test_apd1.py
+++ b/tests/test_apd1.py
@@ -43,6 +43,11 @@ def test_crc_msi_apd1_is_single_source_scope_row():
     assert apd1.cancer_apd1_response("READ_MSI") == mapping["CRC_MSI"]
     assert apd1.cancer_apd1_response("READ_MSI", inherit=False) is None
 
+    inherited = apd1.cancer_apd1_response(include_inherited=True)
+    assert inherited["COAD_MSI"] == mapping["CRC_MSI"]
+    assert inherited["READ_MSI"] == mapping["CRC_MSI"]
+    assert "READ_MSI" not in apd1.cancer_apd1_response(include_inherited=True, inherit=False)
+
 
 def test_crc_msi_apd1_record_preserves_requested_and_source_codes():
     record = apd1.cancer_apd1_response_record("COAD_MSI")
@@ -80,6 +85,12 @@ def test_apd1_record_inherit_false_and_bulk_direct_rows_only():
     assert "COAD_MSI" not in bulk
     assert "READ_MSI" not in bulk
     assert bulk["CRC_MSI"]["inheritance_kind"] == "direct"
+
+    inherited = apd1.cancer_apd1_response_record(include_inherited=True)
+    assert inherited["COAD_MSI"]["requested_cancer_code"] == "COAD_MSI"
+    assert inherited["COAD_MSI"]["resolved_cancer_code"] == "CRC_MSI"
+    assert inherited["COAD_MSI"]["inheritance_kind"] == "source_scope"
+    assert inherited["COAD_MSI"]["is_inherited_evidence"] is True
 
 
 def test_apd1_record_helpers_are_exported():

--- a/tests/test_ici.py
+++ b/tests/test_ici.py
@@ -135,6 +135,14 @@ def test_crc_msi_ici_is_single_source_scope_row():
     assert ici.cancer_ici_response("READ_MSI", inherit=False) is None
     assert ici.cancer_ici_regimen("READ_MSI") == "PD-1"
 
+    inherited = ici.cancer_ici_response(include_inherited=True)
+    inherited_per = ici.cancer_ici_response(fallback=False, include_inherited=True)
+    assert inherited["COAD_MSI"] == full["CRC_MSI"]
+    assert inherited["READ_MSI"] == full["CRC_MSI"]
+    assert inherited_per["COAD_MSI"] == per["CRC_MSI"]
+    assert inherited_per["READ_MSI"] == per["CRC_MSI"]
+    assert "READ_MSI" not in ici.cancer_ici_response(include_inherited=True, inherit=False)
+
 
 def test_impower110_nsclc_pdl1_is_not_direct_luad_or_lusc():
     pdl1 = ici.cancer_ici_response(regimen="PD-L1")
@@ -171,6 +179,10 @@ def test_btc_ici_is_single_pan_biliary_source_scope_row():
     assert ici.cancer_ici_response("GBC") == full["BTC"]
     assert ici.cancer_ici_response("GBC", regimen="PD-L1") == 4.8
     assert ici.cancer_ici_response("GBC", inherit=False) is None
+
+    inherited_pdl1 = ici.cancer_ici_response(regimen="PD-L1", include_inherited=True)
+    assert inherited_pdl1["GBC"] == 4.8
+    assert inherited_pdl1["CHOL"] == 4.8
 
 
 def test_sgc_ici_is_single_pan_salivary_source_scope_row():
@@ -239,6 +251,16 @@ def test_crc_msi_ici_record_preserves_inheritance_metadata():
 
     assert ici.cancer_ici_response_record("READ_MSI", inherit=False) is None
     assert ici.cancer_ici_response_record("READ_MSI", fallback=False, inherit=False) == {}
+
+    bulk = ici.cancer_ici_response_record(include_inherited=True)
+    assert bulk["COAD_MSI"]["requested_cancer_code"] == "COAD_MSI"
+    assert bulk["COAD_MSI"]["resolved_cancer_code"] == "CRC_MSI"
+    assert bulk["COAD_MSI"]["inheritance_kind"] == "source_scope"
+    assert bulk["COAD_MSI"]["is_inherited_evidence"] is True
+
+    bulk_per_regimen = ici.cancer_ici_response_record(fallback=False, include_inherited=True)
+    assert set(bulk_per_regimen["READ_MSI"]) == {"PD-1", "PD-1+CTLA-4"}
+    assert bulk_per_regimen["READ_MSI"]["PD-1"]["resolved_cancer_code"] == "CRC_MSI"
 
 
 def test_btc_ici_record_preserves_inheritance_metadata():


### PR DESCRIPTION
## Summary

Addresses part of #196 and the pirlygenes review note that individual ICI/aPD1 lookups resolve source-scoped child codes while bulk maps omit them.

- adds opt-in `include_inherited=True` bulk expansion to `cancer_apd1_response`, `cancer_apd1_response_record`, `cancer_ici_response`, and `cancer_ici_response_record`
- threads the same option through the organized `oncoref.ici_response` facade helpers
- preserves existing default source-row-only bulk maps for plotting axes
- keeps inherited record metadata (`requested_cancer_code`, `resolved_cancer_code`, `inheritance_kind`, `is_inherited_evidence`) visible in expanded maps

## Verification

- `python -m pytest tests/test_apd1.py tests/test_ici.py tests/test_api_structure.py -q`
- `./lint.sh`
- `./test.sh`

Full suite result: 630 passed, with the existing matplotlib open-figure warning.
