### PR TITLE
Add bundle metadata contract surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ oncoref plot cta-curation --out cta_curation_out
 # managed data downloads/cache:
 oncoref data list               # every wheel/bundle/HPA/source dataset
 oncoref data status bundle      # expression-bundle cache state (no download)
+oncoref data metadata           # package/data/cache/release contract JSON
 oncoref data fetch bundle       # download the large expression bundle
 oncoref data fetch hpa          # download HPA reference data (RNA / IHC / single-cell)
 oncoref data dir bundle         # where the data bundle is cached

--- a/docs/api.md
+++ b/docs/api.md
@@ -320,11 +320,16 @@ but it is not the clean-TPM biological denominator.
   `data_bundle.bundle_release_manifest()` to fetch and validate only the small
   release manifest/checksum for the active `DATA_VERSION`, including tarball
   sha256 plus any artifact inventory, builder commit, source-matrix version, and
-  sample-QC policy metadata published with the release.
+  sample-QC policy metadata published with the release. Use
+  `data_bundle.bundle_metadata()` when a downstream package needs one
+  no-heavy-download JSON object containing the static contract, local cache path
+  and completeness state, local artifact inventory, and validated release
+  manifest.
   CLI equivalents are available for CI/notebooks: `oncoref data contract` prints
-  the active bundle contract as JSON, and `oncoref data release-manifest
-  [oncoref|pirlygenes]` prints the validated release manifest/checksum metadata
-  as JSON.
+  the static bundle contract, `oncoref data metadata [oncoref|pirlygenes]`
+  prints the composed dependency state, and `oncoref data release-manifest
+  [oncoref|pirlygenes]` prints only the validated release manifest/checksum
+  metadata.
 - `oncoref.reference_data` / `oncoref.hpa` — HPA reference-data cache and HPA
   tissue/cell-type accessors.
 

--- a/oncoref/cli.py
+++ b/oncoref/cli.py
@@ -119,6 +119,16 @@ def _cmd_data(args: argparse.Namespace) -> int:
         print(json.dumps(data_bundle.bundle_contract(), indent=2, sort_keys=True, default=str))
         return 0
 
+    if args.action == "metadata":
+        source = args.name or "oncoref"
+        try:
+            metadata = data_bundle.bundle_metadata(source)
+        except (ValueError, data_bundle.BundleIntegrityError, OSError) as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        print(json.dumps(metadata, indent=2, sort_keys=True, default=str))
+        return 0
+
     if args.action == "release-manifest":
         source = args.name or "oncoref"
         try:
@@ -598,6 +608,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "list",
             "status",
             "contract",
+            "metadata",
             "release-manifest",
             "dir",
             "fetch",
@@ -606,8 +617,9 @@ def _build_parser() -> argparse.ArgumentParser:
         ],
         help=(
             "list (catalog), status (cache state), contract (bundle contract JSON), "
-            "release-manifest (release metadata JSON), dir (cache roots), fetch (download), "
-            "path (ensure + print), prune (bundle cache cleanup)"
+            "metadata (contract + local/release state JSON), release-manifest "
+            "(release metadata JSON), dir (cache roots), fetch (download), path "
+            "(ensure + print), prune (bundle cache cleanup)"
         ),
     )
     p_data.add_argument(

--- a/oncoref/data_bundle.py
+++ b/oncoref/data_bundle.py
@@ -490,6 +490,38 @@ def bundle_release_manifest(source: str = "oncoref") -> dict | None:
     return _fetch_release_manifest(source_record)
 
 
+def bundle_metadata(
+    source: str = "oncoref",
+    *,
+    include_release_manifest: bool = True,
+) -> dict:
+    """Machine-readable bundle dependency state for downstream packages.
+
+    This composes the static bundle contract, local cache status, and optionally
+    the small validated release manifest for the active ``DATA_VERSION``. It never
+    downloads or extracts the heavy tarball; callers that only need to decide
+    whether a dependency is usable can inspect this first, then call
+    :func:`ensure_local` or :func:`fetch` deliberately.
+    """
+    snap = status()
+    release_manifest = bundle_release_manifest(source) if include_release_manifest else None
+    return {
+        "contract_version": BUNDLE_CONTRACT_VERSION,
+        "package_version": __version__,
+        "data_version": DATA_VERSION,
+        "source_matrix_version": SOURCE_MATRIX_VERSION,
+        "release_source": source,
+        "contract": snap["contract"],
+        "local_cache": {
+            "cache_dir": snap["cache_dir"],
+            "all_local": snap["all_local"],
+            "completion_marker": snap["completion_marker"],
+            "inventory": snap["items"],
+        },
+        "release_manifest": release_manifest,
+    }
+
+
 def _download_and_extract(
     url: str,
     root: Path,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -171,6 +171,27 @@ def test_cli_data_contract_json(capsys):
     assert payload["primary_release_source"]["name"] == "oncoref"
 
 
+def test_cli_data_metadata_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        data_bundle,
+        "bundle_metadata",
+        lambda source="oncoref": {
+            "release_source": source,
+            "data_version": data_bundle.DATA_VERSION,
+            "local_cache": {"all_local": False},
+        },
+    )
+
+    assert cli.main(["data", "metadata", "oncoref"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload == {
+        "release_source": "oncoref",
+        "data_version": data_bundle.DATA_VERSION,
+        "local_cache": {"all_local": False},
+    }
+
+
 def test_cli_data_release_manifest_json(monkeypatch, capsys):
     monkeypatch.setattr(
         data_bundle,

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -184,6 +184,56 @@ def test_bundle_release_manifest_preserves_inventory_and_build_metadata(monkeypa
     assert manifest["inventory"]["pan-cancer-expression.csv"]["file_count"] == 1
 
 
+def test_bundle_metadata_composes_contract_local_status_and_release_manifest(monkeypatch, tmp_path):
+    root = tmp_path / f"v{DATA_VERSION}"
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(root))
+    release_manifest = {
+        "source": "oncoref",
+        "data_version": DATA_VERSION,
+        "tarball": {"sha256": "a" * 64},
+        "inventory": {
+            "pan-cancer-expression.csv": {
+                "path": "pan-cancer-expression.csv",
+                "file_count": 1,
+                "size_bytes": 10,
+            }
+        },
+    }
+    monkeypatch.setattr(
+        data_bundle,
+        "bundle_release_manifest",
+        lambda source="oncoref": release_manifest | {"source": source},
+    )
+
+    metadata = data_bundle.bundle_metadata("oncoref")
+
+    assert metadata["contract_version"] == data_bundle.BUNDLE_CONTRACT_VERSION
+    assert metadata["package_version"] == __version__
+    assert metadata["data_version"] == DATA_VERSION
+    assert metadata["source_matrix_version"] == SOURCE_MATRIX_VERSION
+    assert metadata["release_source"] == "oncoref"
+    assert metadata["contract"] == data_bundle.bundle_contract()
+    assert metadata["local_cache"]["cache_dir"] == str(root)
+    assert metadata["local_cache"]["all_local"] is False
+    assert set(metadata["local_cache"]["inventory"]) == set(data_bundle.DOWNLOADABLE_PATHS)
+    assert metadata["release_manifest"]["tarball"]["sha256"] == "a" * 64
+
+
+def test_bundle_metadata_can_skip_release_manifest(monkeypatch, tmp_path):
+    root = tmp_path / f"v{DATA_VERSION}"
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(root))
+    monkeypatch.setattr(
+        data_bundle,
+        "bundle_release_manifest",
+        lambda source="oncoref": pytest.fail("release manifest should not be fetched"),
+    )
+
+    metadata = data_bundle.bundle_metadata(include_release_manifest=False)
+
+    assert metadata["release_manifest"] is None
+    assert metadata["local_cache"]["cache_dir"] == str(root)
+
+
 def test_bundle_release_manifest_source_validation_and_legacy_absence(monkeypatch):
     with pytest.raises(ValueError, match="unknown bundle release source"):
         data_bundle.bundle_release_manifest("other")


### PR DESCRIPTION
## Summary

Addresses part of #209 by adding one downstream-stable metadata surface for the active expression bundle contract.

- add `data_bundle.bundle_metadata(...)`, composing the static bundle contract, local cache status/inventory, and the validated release manifest without downloading the heavy tarball
- add `oncoref data metadata [oncoref|pirlygenes]` for CI/notebook inspection
- document the distinction between `data contract`, `data metadata`, and `data release-manifest`

Scope note: this improves the bundle/download dependency contract. Registry value parity remains tracked separately in #196, and expression artifact row/value parity remains under #191/#193/#207/#208.

## Verification

- `python -m pytest tests/test_data_bundle.py tests/test_catalog.py -q`
- `./lint.sh`
- `./test.sh` (633 passed, one existing matplotlib open-figure warning)

Refs #209