### PR TITLE
Align TMB evidence provenance semantics

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -308,7 +308,9 @@ but it is not the clean-TPM biological denominator.
   `tmb.cancer_tmb_df()` includes evidence-schema columns (`estimate_type`,
   `source_scope`, `missing_reason`), and `tmb.cancer_tmb_record()` /
   `tmb.resolve_tmb_source()` preserve requested-code metadata for source-scoped
-  lookups such as `COAD_MSI` or `READ_MSI` resolving through `CRC_MSI`.
+  lookups such as `COAD_MSI` or `READ_MSI` resolving through `CRC_MSI`. Direct
+  audited gaps use `inheritance_kind="direct_missing"` so callers can distinguish
+  “known no supported site-specific estimate” from an unmapped cancer code.
 - `oncoref.incidence` — incidence/mortality burden and burden categories.
 - `oncoref.fusions` — defining fusions and partner-family lookups.
 - `oncoref.response_signatures` — therapy-response gene signatures and scoring.

--- a/oncoref/data/cancer-tmb.csv
+++ b/oncoref/data/cancer-tmb.csv
@@ -95,8 +95,8 @@ SARC_DSRCT,0.72,,Bertucci 2022,PMID:35379887,high,EWSR1-WT1-driven; immune-cold;
 SARC_GIST,0.67,,Wu 2024 Nat Commun,PMID:39489749,high,KIT/PDGFRA-driven; very low SNV TMB but high CNV. Overrides pan-SARC.
 NEC_LUNG_LARGECELL,8.6,,George 2018 Nat Commun,PMID:29535388,high,LCNEC; smoking signature; TMB-high tier with SCLC.
 SARC_SMARCA4,10.6,,Cooper 2024,PMID:39802817,high,SMARCA4-deficient thoracic; smoking signature (really an undiff carcinoma); TMB-H. Overrides pan-SARC.
-NET_MIDGUT,1.09,,GEP-NEN TMB 2023,PMID:37720428,medium,Well-diff GEP-NET; low TMB (~1) vs NEC ~5.5.
-NET_RECTAL,1.09,,GEP-NEN TMB 2023,PMID:37720428,medium,Well-diff hindgut NET; ~GEP-NET low TMB.
+NET_MIDGUT,,,Jeong 2023,PMID:37720428,none,Jeong 2023 reports GEP-NEN median 4.7 mut/Mb with IQR 3.1-6.3 across 31 patients including small bowel n=2 and rectum n=7; TMB did not vary by primary tumor site or WHO grade; no supported site-specific midgut median curated.
+NET_RECTAL,,,Jeong 2023,PMID:37720428,none,Jeong 2023 reports GEP-NEN median 4.7 mut/Mb with IQR 3.1-6.3 across 31 patients including rectum n=7; TMB did not vary by primary tumor site or WHO grade; no supported site-specific rectal median curated.
 NET_LUNG,0.4,,Fernandez-Cuesta 2014,PMID:24670920,medium,Typical/atypical pulmonary carcinoid; very low (chromatin-remodeling driven).
 SARC_CIC,1.2,,Antonescu 2017,PMID:29901569,medium,CIC-DUX4-driven; low TMB (range 0.8-1.6). Overrides pan-SARC.
 NBL_MYCNamp,0.6,,Wang 2018 JNCI,PMID:30307503,medium,Pediatric; very low TMB; MYCN amp does NOT raise total TMB.

--- a/oncoref/tmb.py
+++ b/oncoref/tmb.py
@@ -19,15 +19,40 @@ import pandas as pd
 from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
 from .load_dataset import get_data
 
-_TMB_SOURCE_SCOPE_OVERRIDES = {
+_TMB_EVIDENCE_OVERRIDES = {
     # MSI-H/dMMR colorectal estimates are published at the CRC source scope; anatomical
     # children such as COAD_MSI/READ_MSI resolve through this row rather than duplicating
     # the same source estimate.
-    "CRC_MSI": ("aggregate_source_scope", "aggregate_source_scope_estimate"),
-    # The cited GEP-NEN source is not a direct site-specific median for these children.
-    # Keep the numeric value available, but expose that it is a pooled/proxy estimate.
-    "NET_MIDGUT": ("pooled_gep_net_proxy", "proxy_estimate"),
-    "NET_RECTAL": ("pooled_gep_net_proxy", "proxy_estimate"),
+    "CRC_MSI": {
+        "estimate_type": "published_median",
+        "source_scope": "aggregate_source",
+    },
+    # The cited GEP-NEN source is pooled across primary sites and WHO grades.
+    # Preserve the source audit as explicit missing site-specific estimates.
+    "NET_MIDGUT": {
+        "estimate_type": "unknown",
+        "source_scope": "source_rejected_for_site_specific_value",
+        "missing_reason": "no_supported_site_specific_median",
+    },
+    "NET_RECTAL": {
+        "estimate_type": "unknown",
+        "source_scope": "source_rejected_for_site_specific_value",
+        "missing_reason": "no_supported_site_specific_median",
+    },
+    "KIRP": {"estimate_type": "approximate_literature"},
+    "UCS": {"estimate_type": "approximate_literature"},
+    "SARC_RMS_ERMS": {"estimate_type": "approximate_literature"},
+    "SARC_RMS_ARMS": {"estimate_type": "approximate_literature"},
+    "WILMS": {"estimate_type": "approximate_literature"},
+    "MCL": {"estimate_type": "approximate_literature"},
+    "HL": {"estimate_type": "approximate_literature"},
+    "BL": {"estimate_type": "approximate_literature"},
+    "T_ALL": {"estimate_type": "approximate_literature"},
+    "MTC": {"estimate_type": "panel_inferred"},
+    "CRANIO": {"estimate_type": "small_n"},
+    "HCL": {"estimate_type": "small_n"},
+    "UCEC_POLE": {"estimate_type": "order_of_magnitude"},
+    "SARC_CIC": {"source_scope": "renal_cic_rearranged_sarcoma_proxy"},
 }
 
 
@@ -51,21 +76,18 @@ def cancer_tmb_df():
 
 def _tmb_evidence_fields(row) -> dict[str, object]:
     code = str(row.get("cancer_code", ""))
+    override = _TMB_EVIDENCE_OVERRIDES.get(code, {})
     value = row.get("median_tmb_mut_mb")
     if pd.isna(value):
-        notes = str(row.get("notes", "") or "").strip()
         return {
-            "estimate_type": "missing",
-            "source_scope": "none",
-            "missing_reason": notes or "no curated median TMB",
+            "estimate_type": override.get("estimate_type", "unknown"),
+            "source_scope": override.get("source_scope", "no_direct_source"),
+            "missing_reason": override.get("missing_reason", "no_published_per_mb_median_curated"),
         }
-    source_scope, estimate_type = _TMB_SOURCE_SCOPE_OVERRIDES.get(
-        code, ("direct", "curated_estimate")
-    )
     return {
-        "estimate_type": estimate_type,
-        "source_scope": source_scope,
-        "missing_reason": None,
+        "estimate_type": override.get("estimate_type", "published_median"),
+        "source_scope": override.get("source_scope", "cancer_code_direct"),
+        "missing_reason": override.get("missing_reason", float("nan")),
     }
 
 
@@ -113,6 +135,8 @@ def _resolve_tmb_row(requested_code: str, *, inherit: bool):
 
     if requested_code in values:
         return requested_code, "direct", rows.loc[requested_code]
+    if requested_code in rows.index:
+        return requested_code, "direct_missing", rows.loc[requested_code]
     if not inherit:
         return requested_code, "missing", None
 
@@ -138,8 +162,8 @@ def resolve_tmb_source(cancer_type, *, inherit=True) -> dict:
 
     - ``requested_cancer_code``: canonical code requested by the caller.
     - ``resolved_cancer_code``: direct/source-scope/ancestor row used, if any.
-    - ``inheritance_kind``: ``"direct"``, ``"source_scope"``, ``"ancestor"``, or
-      ``"missing"``.
+    - ``inheritance_kind``: ``"direct"``, ``"direct_missing"``, ``"source_scope"``,
+      ``"ancestor"``, or ``"missing"``.
     - source/provenance fields from the selected row when available.
 
     This makes aggregate evidence explicit. For example, ``COAD_MSI`` and

--- a/tests/test_tmb.py
+++ b/tests/test_tmb.py
@@ -31,18 +31,21 @@ def test_tmb_df_exposes_evidence_schema():
     assert {"estimate_type", "source_scope", "missing_reason"} <= set(df.columns)
 
     crc_msi = df.set_index("cancer_code").loc["CRC_MSI"]
-    assert crc_msi["estimate_type"] == "aggregate_source_scope_estimate"
-    assert crc_msi["source_scope"] == "aggregate_source_scope"
+    assert crc_msi["estimate_type"] == "published_median"
+    assert crc_msi["source_scope"] == "aggregate_source"
     assert pd.isna(crc_msi["missing_reason"])
 
     net_midgut = df.set_index("cancer_code").loc["NET_MIDGUT"]
-    assert net_midgut["estimate_type"] == "proxy_estimate"
-    assert net_midgut["source_scope"] == "pooled_gep_net_proxy"
+    assert pd.isna(net_midgut["median_tmb_mut_mb"])
+    assert net_midgut["confidence"] == "none"
+    assert net_midgut["estimate_type"] == "unknown"
+    assert net_midgut["source_scope"] == "source_rejected_for_site_specific_value"
+    assert net_midgut["missing_reason"] == "no_supported_site_specific_median"
 
     missing = df.set_index("cancer_code").loc["PITNET"]
-    assert missing["estimate_type"] == "missing"
-    assert missing["source_scope"] == "none"
-    assert missing["missing_reason"]
+    assert missing["estimate_type"] == "unknown"
+    assert missing["source_scope"] == "no_direct_source"
+    assert missing["missing_reason"] == "no_published_per_mb_median_curated"
 
 
 def test_tmb_resolves_alias():
@@ -87,8 +90,8 @@ def test_crc_msi_tmb_record_preserves_source_scope_metadata():
     assert record["inheritance_kind"] == "source_scope"
     assert record["is_inherited_evidence"] is True
     assert record["median_tmb_mut_mb"] == 46.0
-    assert record["source_scope"] == "aggregate_source_scope"
-    assert record["estimate_type"] == "aggregate_source_scope_estimate"
+    assert record["source_scope"] == "aggregate_source"
+    assert record["estimate_type"] == "published_median"
 
     direct = tmb.resolve_tmb_source("CRC_MSI")
     assert direct["requested_cancer_code"] == "CRC_MSI"
@@ -111,6 +114,21 @@ def test_tmb_record_missing_and_bulk_direct_rows():
     assert "CRC_MSI" in bulk
     assert "COAD_MSI" not in bulk
     assert bulk["CRC_MSI"]["inheritance_kind"] == "direct"
+
+
+def test_net_site_specific_tmb_rows_are_audited_gaps():
+    mapping = tmb.cancer_tmb()
+    assert "NET_MIDGUT" not in mapping
+    assert "NET_RECTAL" not in mapping
+    assert tmb.cancer_tmb("NET_MIDGUT") is None
+    assert tmb.cancer_tmb("NET_RECTAL") is None
+
+    midgut = tmb.resolve_tmb_source("NET_MIDGUT")
+    assert midgut["has_tmb_source"] is True
+    assert midgut["inheritance_kind"] == "direct_missing"
+    assert midgut["estimate_type"] == "unknown"
+    assert midgut["source_scope"] == "source_rejected_for_site_specific_value"
+    assert midgut["missing_reason"] == "no_supported_site_specific_median"
 
 
 def test_tmb_unknown_value_returns_none():


### PR DESCRIPTION
## Summary

Addresses the TMB portion of #196 in a focused step.

- switches TMB evidence labels to pirlygenes-compatible semantics (`published_median`, `cancer_code_direct`, `unknown`, `no_direct_source`)
- keeps `CRC_MSI` as the single aggregate TMB source row for COAD_MSI/READ_MSI inheritance
- changes `NET_MIDGUT` and `NET_RECTAL` from numeric pooled/proxy TMB values to explicit audited gaps
- exposes direct curated-gap rows through `resolve_tmb_source(..., inherit=True)` with `inheritance_kind="direct_missing"`
- documents the direct-missing behavior in the API guide

## Source audit

Jeong 2023 / PMID:37720428 reports a pooled GEP-NEN median TMB of 4.7 mut/Mb (IQR 3.1-6.3) across 31 patients and states TMB did not vary by primary tumor site or WHO grade. The cohort includes rectum n=7 and small bowel n=2, but it does not provide a supported midgut- or rectum-specific median.

## Validation

- `source /Users/iskander/code/shared-virtual-env/bin/activate && ./test.sh`
  - 642 passed, 1 existing matplotlib warning

Refs #196.