### PR TITLE
Make housekeeping normalization median of ratios

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -296,6 +296,33 @@ gene_families.clean_tpm_biological_housekeeping_genes()
 gene_families.clean_tpm_biological_housekeeping_genes(primary_only=False)
 ```
 
+Housekeeping normalization is defined as a median-of-ratios size factor against a
+fixed, versioned per-gene reference profile:
+
+```python
+from oncoref import normalization
+
+normalization.housekeeping_reference_profile()
+normalization.tpm_to_housekeeping_normalized(matrix)
+```
+
+For each sample, oncoref computes:
+
+```text
+size_factor = median(housekeeping_clean_tpm[g] / reference_tpm[g])
+normalized_expression[g] = clean_tpm[g] / size_factor
+```
+
+The default reference is the HPA v23-derived clean-TPM biological housekeeping
+panel (`HOUSEKEEPING_REFERENCE_PROFILE_VERSION`). This is a sample-scale estimate
+relative to a fixed biological HK profile, not the old "divide by the panel's
+geometric mean" ratio. Prefer log1p clean TPM or percentile-rank clean TPM unless
+the analysis specifically needs an HK-derived size factor.
+
+The old geNorm-style denominator is deliberately buried behind
+`method="legacy_geomean"` for explicit audits of historical outputs. The shorter
+`method="geomean"` spelling is not accepted.
+
 The legacy qPCR/reference-gene panel remains available as
 `legacy_qpcr_housekeeping_*` and through the historical `housekeeping_*` helpers,
 but it is not the clean-TPM biological denominator.

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -248,6 +248,9 @@ from .incidence import (
 )
 from .normalization import (
     BIOLOGICAL_FRACTION,
+    HOUSEKEEPING_NORMALIZATION_METHOD,
+    HOUSEKEEPING_REFERENCE_PROFILE_SOURCE,
+    HOUSEKEEPING_REFERENCE_PROFILE_VERSION,
     OTHER_TECHNICAL_FRACTION,
     RIBOSOMAL_PROTEIN_FRACTION,
     TECHNICAL_FRACTION,
@@ -255,6 +258,7 @@ from .normalization import (
     drop_technical_rna,
     filter_technical_rna,
     fpkm_to_tpm,
+    housekeeping_reference_profile,
     is_expression_value_col,
     log1p_transform,
     log2_transform,
@@ -310,6 +314,9 @@ __all__ = [
     "CANCER_TYPE_ALIASES",
     "CANCER_TYPE_NAMES",
     "EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION",
+    "HOUSEKEEPING_NORMALIZATION_METHOD",
+    "HOUSEKEEPING_REFERENCE_PROFILE_SOURCE",
+    "HOUSEKEEPING_REFERENCE_PROFILE_VERSION",
     "OTHER_TECHNICAL_FRACTION",
     "PROPORTION_METRICS",
     "REFERENCE_EXPRESSION_SCHEMA_VERSION",
@@ -492,6 +499,7 @@ __all__ = [
     "gene_within_sample_top_fraction",
     "genomes",
     "greedy_coverage",
+    "housekeeping_reference_profile",
     # HPA normal-tissue reference data
     "hpa_cell_type_expression",
     "hpa_housekeeping_candidates",

--- a/oncoref/normalization.py
+++ b/oncoref/normalization.py
@@ -101,6 +101,9 @@ OTHER_TECHNICAL_FRACTION = 0.09
 TECHNICAL_FRACTION = round(RIBOSOMAL_PROTEIN_FRACTION + OTHER_TECHNICAL_FRACTION, 10)  # 0.25
 #: Clean-TPM budget for the biological compartment (everything else) — the remainder.
 BIOLOGICAL_FRACTION = round(1.0 - TECHNICAL_FRACTION, 10)  # 0.75
+HOUSEKEEPING_NORMALIZATION_METHOD = "median_of_ratios"
+HOUSEKEEPING_REFERENCE_PROFILE_VERSION = "clean_tpm_biological_hpa_v23_mean_tpm_v1"
+HOUSEKEEPING_REFERENCE_PROFILE_SOURCE = "hpa_v23_rna_consensus_mean_tpm"
 
 
 def _compartment_masks(
@@ -235,6 +238,71 @@ def filter_technical_rna(df: pd.DataFrame) -> pd.DataFrame:
     return df.loc[~mask].reset_index(drop=True)
 
 
+def housekeeping_reference_profile(
+    *,
+    panel_ids=None,
+    primary_only: bool = True,
+) -> pd.DataFrame:
+    """Fixed per-gene reference profile for median-of-ratios HK normalization.
+
+    The default profile is the HPA v23-derived, clean-TPM biological housekeeping
+    panel. ``reference_tpm`` is the curated per-gene mean TPM from the HPA-stable
+    panel table; it is versioned by
+    :data:`HOUSEKEEPING_REFERENCE_PROFILE_VERSION`. Callers with custom panels should
+    pass an explicit matching reference profile to
+    :func:`tpm_to_housekeeping_normalized`.
+
+    Median-of-ratios uses this profile as the denominator for each housekeeping gene:
+    ``size_factor(sample) = median(sample_tpm[g] / reference_tpm[g])``. The normalized
+    expression values are the original values divided by that sample-level size
+    factor.
+    """
+    profile = gene_families.clean_tpm_biological_housekeeping_genes(primary_only=primary_only)
+    if panel_ids is not None:
+        wanted = {str(g).split(".")[0] for g in panel_ids}
+        profile = profile[_unversioned(profile["Ensembl_Gene_ID"]).isin(wanted)]
+    out = profile[["Symbol", "Ensembl_Gene_ID", "mean_tpm"]].copy()
+    out = out.rename(columns={"mean_tpm": "reference_tpm"})
+    out["reference_source"] = HOUSEKEEPING_REFERENCE_PROFILE_SOURCE
+    out["profile_version"] = HOUSEKEEPING_REFERENCE_PROFILE_VERSION
+    return out.reset_index(drop=True)
+
+
+def _housekeeping_reference_map(
+    reference_profile,
+    *,
+    reference_id_col: str,
+    reference_value_col: str,
+) -> dict[str, float]:
+    if reference_profile is None:
+        reference_profile = housekeeping_reference_profile()
+    if isinstance(reference_profile, pd.Series):
+        ref = reference_profile.copy()
+        ref.index = ref.index.astype(str).str.split(".").str[0]
+        return {
+            str(idx): float(value)
+            for idx, value in ref.items()
+            if pd.notna(value) and float(value) > 0.0
+        }
+    if not isinstance(reference_profile, pd.DataFrame):
+        reference_profile = pd.DataFrame(
+            {
+                reference_id_col: list(reference_profile.keys()),
+                reference_value_col: list(reference_profile.values()),
+            }
+        )
+    if reference_id_col not in reference_profile.columns:
+        raise ValueError(f"reference profile needs {reference_id_col!r}")
+    if reference_value_col not in reference_profile.columns:
+        raise ValueError(f"reference profile needs {reference_value_col!r}")
+    ref = reference_profile[[reference_id_col, reference_value_col]].copy()
+    ref[reference_id_col] = _unversioned(ref[reference_id_col])
+    ref[reference_value_col] = pd.to_numeric(ref[reference_value_col], errors="coerce")
+    ref = ref.dropna(subset=[reference_id_col, reference_value_col])
+    ref = ref[ref[reference_value_col] > 0.0].drop_duplicates(reference_id_col, keep="first")
+    return dict(zip(ref[reference_id_col], ref[reference_value_col]))
+
+
 def normalize_to_housekeeping(
     df: pd.DataFrame,
     value_cols=None,
@@ -242,16 +310,23 @@ def normalize_to_housekeeping(
     panel_ids=None,
     panel_name: str | None = None,
     pseudocount: float = 0.1,
+    method: str = HOUSEKEEPING_NORMALIZATION_METHOD,
+    reference_profile=None,
+    reference_id_col: str = "Ensembl_Gene_ID",
+    reference_value_col: str = "reference_tpm",
     min_panel_detected: int | None = None,
     drop_zero_panel_values: bool = False,
     errors: str = "raise",
 ) -> pd.DataFrame:
-    """Rescale each value column to its housekeeping-panel baseline (unitless: 1.0 =
-    panel level). The df-only convenience over :func:`tpm_to_housekeeping_normalized`
-    (the canonical normalizer, which also returns per-column diagnostics) — both use the
-    **geometric mean** of the housekeeping panel, the single housekeeping method (see
-    that function for why geomean over median). A column with no measurable panel gene
-    becomes NaN rather than silently staying on the input scale.
+    """Rescale each value column by a housekeeping-derived sample size factor.
+
+    This is the df-only convenience over :func:`tpm_to_housekeeping_normalized`
+    (the canonical normalizer, which also returns per-column diagnostics). By default
+    both use median-of-ratios against the fixed clean-TPM biological reference profile:
+    compute ``sample_tpm[g] / reference_tpm[g]`` for each usable housekeeping gene,
+    take the median ratio as the sample size factor, then divide every gene in that
+    sample by the factor. A column with no measurable panel gene or no matching
+    reference profile becomes NaN rather than silently staying on the input scale.
 
     ``value_cols`` defaults to every per-sample value column (not just named-TPM
     columns), so a plain ``genes × samples`` frame normalizes as expected.
@@ -274,6 +349,10 @@ def normalize_to_housekeeping(
         panel_ids=panel_ids,
         panel_name=panel_name,
         pseudocount=pseudocount,
+        method=method,
+        reference_profile=reference_profile,
+        reference_id_col=reference_id_col,
+        reference_value_col=reference_value_col,
         min_panel_detected=min_panel_detected,
         drop_zero_panel_values=drop_zero_panel_values,
     )
@@ -615,27 +694,33 @@ def tpm_to_housekeeping_normalized(
     panel_ids=None,
     panel_name: str | None = None,
     pseudocount: float = 0.1,
+    method: str = HOUSEKEEPING_NORMALIZATION_METHOD,
+    reference_profile=None,
+    reference_id_col: str = "Ensembl_Gene_ID",
+    reference_value_col: str = "reference_tpm",
     min_panel_detected: int | None = None,
     drop_zero_panel_values: bool = False,
     warn_on_unreliable: bool = False,
 ) -> tuple[pd.DataFrame, dict]:
-    """Divide each expression column by the **geometric mean** of a housekeeping
-    panel, putting expression on a unit-free ratio-to-baseline scale that survives
-    library-prep depth drift in a way TPM doesn't.
+    """Divide each expression column by a housekeeping-panel size factor.
 
     The single, canonical housekeeping normalizer — the method behind
     ``per_sample_expression(normalize="tpm_clean_hk")`` and the df-only convenience
-    :func:`normalize_to_housekeeping`. The geometric mean (the geNorm convention) is
-    used over the median because it is the natural centre for multiplicative
-    log-normal expression and is dominated by no single deviating reference gene; a
-    small ``pseudocount`` keeps it finite through zeros.
+    :func:`normalize_to_housekeeping`. The default method is ``"median_of_ratios"``:
+    for each column, compute ``sample_tpm[g] / reference_tpm[g]`` over the usable
+    housekeeping genes, take the median ratio as that sample's size factor, and divide
+    all genes in the sample by the factor. The default reference profile is the HPA
+    v23-derived clean-TPM biological housekeeping profile from
+    :func:`housekeeping_reference_profile`.
 
-    The panel defaults to oncoref's legacy qPCR/reference housekeeping gene set
+    ``method="legacy_geomean"`` preserves the old geNorm-style denominator for
+    explicit audits of historical outputs. It is intentionally named as a legacy path;
+    new callers should use median-of-ratios, log1p clean TPM, or percentile ranks.
+
+    With ``method="median_of_ratios"``, ``panel_ids`` defaults to the ids present in
+    the reference profile. With ``method="legacy_geomean"``, it defaults to oncoref's
+    legacy qPCR/reference housekeeping gene set
     (:func:`oncoref.gene_families.housekeeping_gene_ids`), matched by Ensembl id.
-    Clean-TPM callers should pass
-    :func:`oncoref.gene_families.clean_tpm_biological_housekeeping_gene_ids`
-    explicitly, because ribosomal legacy references live in clean TPM's non-biological
-    ribosomal compartment.
     Because HK-normalized values are ratios to this panel, numerical thresholds are
     panel-dependent; prefer clean TPM, log1p(clean TPM), or percentile-rank clean TPM
     when the analysis needs an absolute, compressed, or rank-only expression space.
@@ -650,6 +735,8 @@ def tpm_to_housekeeping_normalized(
     than credible absence, callers can set ``drop_zero_panel_values=True`` and require a
     minimum number of nonzero panel genes via ``min_panel_detected``. Columns that fail
     that reliability gate are blanked to NaN and optionally warn."""
+    if method not in {"median_of_ratios", "legacy_geomean"}:
+        raise ValueError("method must be 'median_of_ratios' or 'legacy_geomean'")
     if df is None:
         return None, {"applied": False, "reason": "no table", "columns": {}}
     out = df.copy()
@@ -659,7 +746,17 @@ def tpm_to_housekeeping_normalized(
     if not value_cols:
         return out, {"applied": False, "reason": "no expression value columns", "columns": {}}
 
-    if panel_ids is None:
+    reference_map: dict[str, float] = {}
+    if method == "median_of_ratios":
+        reference_map = _housekeeping_reference_map(
+            reference_profile,
+            reference_id_col=reference_id_col,
+            reference_value_col=reference_value_col,
+        )
+    if panel_ids is None and method == "median_of_ratios":
+        panel = set(reference_map)
+        panel_name = panel_name or "clean_tpm_biological_housekeeping"
+    elif panel_ids is None:
         panel = set(gene_families.housekeeping_gene_ids())
         panel_name = panel_name or "legacy_qpcr_housekeeping"
     else:
@@ -672,32 +769,56 @@ def tpm_to_housekeeping_normalized(
             "panel": panel_name,
             "columns": {},
         }
-    panel_rows = _unversioned(out[id_col]).isin({str(g).split(".")[0] for g in panel})
+    row_ids = _unversioned(out[id_col])
+    panel_unversioned = {str(g).split(".")[0] for g in panel}
+    if method == "median_of_ratios":
+        panel_unversioned &= set(reference_map)
+    panel_rows = row_ids.isin(panel_unversioned)
     n_panel = int(panel_rows.sum())
     if n_panel == 0:
         return out, {
             "applied": False,
-            "reason": "no housekeeping panel genes present",
+            "reason": "no housekeeping panel genes present with reference profile"
+            if method == "median_of_ratios"
+            else "no housekeeping panel genes present",
             "panel": panel_name,
+            "method": method,
             "columns": {},
         }
 
     columns: dict = {}
     applied = False
+    panel_reference = (
+        row_ids.loc[panel_rows].map(reference_map) if method == "median_of_ratios" else None
+    )
     for col in value_cols:
-        vals = pd.to_numeric(out.loc[panel_rows, col], errors="coerce").dropna()
+        vals_raw = pd.to_numeric(out.loc[panel_rows, col], errors="coerce")
+        measured = vals_raw.notna()
+        vals = vals_raw[measured]
+        refs = panel_reference[measured] if panel_reference is not None else None
+        if refs is not None:
+            valid_ref = refs.notna() & (refs > 0)
+            vals = vals[valid_ref]
+            refs = refs[valid_ref]
         detected = vals[vals > 0]
-        denominator_vals = detected if drop_zero_panel_values else vals
+        denominator_mask = vals > 0 if drop_zero_panel_values else pd.Series(True, index=vals.index)
+        denominator_vals = vals[denominator_mask]
+        denominator_refs = refs[denominator_mask] if refs is not None else None
         n_detected = len(detected)
         n_zero = int((vals == 0).sum())
         reliable = min_panel_detected is None or n_detected >= int(min_panel_detected)
-        denom = (
-            float(np.exp(np.log(denominator_vals.to_numpy() + pseudocount).mean()))
-            if reliable and len(denominator_vals)
-            else 0.0
-        )
+        if not reliable or len(denominator_vals) == 0:
+            denom = 0.0
+        elif method == "median_of_ratios":
+            ratios = denominator_vals.to_numpy(dtype=float) / denominator_refs.to_numpy(dtype=float)
+            ratios = ratios[np.isfinite(ratios)]
+            denom = float(np.median(ratios)) if len(ratios) else 0.0
+        else:
+            denom = float(np.exp(np.log(denominator_vals.to_numpy() + pseudocount).mean()))
         reason = (
-            "divided by housekeeping geometric mean"
+            "divided by housekeeping median-of-ratios size factor"
+            if denom > 0 and method == "median_of_ratios"
+            else "divided by legacy housekeeping geometric mean"
             if denom > 0
             else (
                 f"only {n_detected} nonzero housekeeping panel genes"
@@ -707,12 +828,19 @@ def tpm_to_housekeeping_normalized(
         )
         columns[col] = {
             "denominator": denom,
+            "method": method,
             "panel_genes_present": n_panel,
             "panel_genes_measured": len(vals),
             "panel_genes_detected": n_detected,
             "panel_genes_zero": n_zero,
             "min_panel_detected": min_panel_detected,
             "drop_zero_panel_values": bool(drop_zero_panel_values),
+            "reference_profile_version": HOUSEKEEPING_REFERENCE_PROFILE_VERSION
+            if method == "median_of_ratios"
+            else "",
+            "reference_profile_source": HOUSEKEEPING_REFERENCE_PROFILE_SOURCE
+            if method == "median_of_ratios"
+            else "",
             "reason": reason,
         }
         if denom > 0:
@@ -733,8 +861,19 @@ def tpm_to_housekeeping_normalized(
                 )
     return out, {
         "applied": applied,
-        "reason": "divided by housekeeping geometric mean" if applied else "panel denominator <= 0",
+        "reason": "divided by housekeeping median-of-ratios size factor"
+        if applied and method == "median_of_ratios"
+        else "divided by legacy housekeeping geometric mean"
+        if applied
+        else "panel denominator <= 0",
         "panel": panel_name,
+        "method": method,
+        "reference_profile_version": HOUSEKEEPING_REFERENCE_PROFILE_VERSION
+        if method == "median_of_ratios"
+        else "",
+        "reference_profile_source": HOUSEKEEPING_REFERENCE_PROFILE_SOURCE
+        if method == "median_of_ratios"
+        else "",
         "columns": columns,
         "value_cols": value_cols,
         "panel_genes_present": n_panel,

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -738,25 +738,39 @@ def test_pan_cancer_expression_canonicalizes_alias_genes(monkeypatch):
     assert out.loc[primary, "liver_nTPM_raw"] == pytest.approx(10.0)  # 3 + 7 summed
 
 
-def test_housekeeping_normalize_divides_by_panel_geomean(monkeypatch):
+def test_housekeeping_normalize_divides_by_panel_size_factor(monkeypatch):
     import oncoref.gene_families as gf
+    import oncoref.normalization as norm
 
     monkeypatch.setattr(
         gf, "clean_tpm_biological_housekeeping_gene_ids", lambda: frozenset({"ENSG_HK"})
+    )
+    monkeypatch.setattr(
+        norm,
+        "housekeeping_reference_profile",
+        lambda: pd.DataFrame({"Ensembl_Gene_ID": ["ENSG_HK"], "reference_tpm": [100.0]}),
     )
     df = pd.DataFrame(
         {"Ensembl_Gene_ID": ["ENSG_HK", "ENSG_X"], "Symbol": ["HK", "X"], "s1": [100.0, 50.0]}
     )
     out = expression._housekeeping_normalize(df, ["s1"])
-    # Each column divided by its housekeeping geomean -> the gene/HK *ratio* is preserved.
+    # Each column divided by its housekeeping size factor -> gene/HK ratio is preserved.
     assert out.loc[1, "s1"] / out.loc[0, "s1"] == pytest.approx(0.5)
 
 
 def test_housekeeping_normalize_blanks_sparse_housekeeping_denominator(monkeypatch):
     import oncoref.gene_families as gf
+    import oncoref.normalization as norm
 
     panel = frozenset({"HK1", "HK2", "HK3"})
     monkeypatch.setattr(gf, "clean_tpm_biological_housekeeping_gene_ids", lambda: panel)
+    monkeypatch.setattr(
+        norm,
+        "housekeeping_reference_profile",
+        lambda: pd.DataFrame(
+            {"Ensembl_Gene_ID": ["HK1", "HK2", "HK3"], "reference_tpm": [100.0, 100.0, 100.0]}
+        ),
+    )
     df = pd.DataFrame(
         {
             "Ensembl_Gene_ID": ["HK1", "HK2", "HK3", "ENSG_X"],

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -30,6 +30,22 @@ def test_public_normalization_functions_are_all_exported():
     assert not missing, f"normalization publics not exported from oncoref: {missing}"
 
 
+def test_housekeeping_reference_profile_contract():
+    profile = norm.housekeeping_reference_profile()
+
+    assert not profile.empty
+    assert set(profile.columns) == {
+        "Symbol",
+        "Ensembl_Gene_ID",
+        "reference_tpm",
+        "reference_source",
+        "profile_version",
+    }
+    assert set(profile["profile_version"]) == {norm.HOUSEKEEPING_REFERENCE_PROFILE_VERSION}
+    assert set(profile["reference_source"]) == {norm.HOUSEKEEPING_REFERENCE_PROFILE_SOURCE}
+    assert (profile["reference_tpm"] > 0).all()
+
+
 def _matrix():
     tech = list(gf.gene_family_ids("mitochondrial"))[:2]
     gt = pd.DataFrame(
@@ -175,7 +191,7 @@ def test_clean_tpm_validates():
 def test_value_cols_excludes_proteoform_members():
     # A proteoform-collapsed frame carries a proteoform_members provenance column; the
     # "everything-not-id" value-column rule must not treat it as a sample (it would
-    # crash/poison geomean normalization). Uses the shared ID_COLUMNS constant.
+    # crash/poison housekeeping normalization). Uses the shared ID_COLUMNS constant.
     df = pd.DataFrame(
         {
             "Ensembl_Gene_ID": ["E1"],
@@ -207,14 +223,14 @@ def test_log_and_rank_helpers():
 
 
 def test_normalize_to_housekeeping():
-    # housekeeping genes present -> column scaled by their panel GEOMEAN (the single
-    # housekeeping method; this convenience delegates to tpm_to_housekeeping_normalized).
-    hk = list(gf.housekeeping_gene_ids())[:2]
+    # housekeeping genes present -> column scaled by the median-of-ratios size factor
+    # against the fixed per-gene reference profile.
+    hk = ["HK1", "HK2"]
+    ref = pd.DataFrame({"Ensembl_Gene_ID": hk, "reference_tpm": [5.0, 10.0]})
     gt = pd.DataFrame({"Ensembl_Gene_ID": [*hk, "ENSG00000999999"], "Symbol": ["H1", "H2", "X"]})
-    df = gt.assign(s1=[10.0, 30.0, 100.0])
-    denom = np.exp(np.mean(np.log(np.array([10.0, 30.0]) + 0.1)))  # geomean(+pseudocount)
-    out = norm.normalize_to_housekeeping(df)
-    assert np.allclose(out["s1"], np.array([10.0, 30.0, 100.0]) / denom)
+    df = gt.assign(s1=[10.0, 30.0, 100.0])  # HK ratios: 2.0, 3.0 -> size factor 2.5
+    out = norm.normalize_to_housekeeping(df, panel_ids=hk, reference_profile=ref)
+    assert np.allclose(out["s1"], np.array([10.0, 30.0, 100.0]) / 2.5)
 
 
 def test_normalize_to_housekeeping_raises_when_no_panel_rows():
@@ -242,25 +258,29 @@ def test_normalize_to_housekeeping_raises_without_id_column():
 
 
 def test_normalize_to_housekeeping_raises_for_mixed_failed_columns():
-    hk = list(gf.housekeeping_gene_ids())[:2]
+    hk = ["HK1", "HK2"]
+    ref = pd.DataFrame({"Ensembl_Gene_ID": hk, "reference_tpm": [5.0, 15.0]})
     gt = pd.DataFrame({"Ensembl_Gene_ID": [*hk, "ENSG00000999999"], "Symbol": ["H1", "H2", "X"]})
     df = gt.assign(good=[10.0, 30.0, 100.0], failed=[0.0, 0.0, 100.0])
 
     with pytest.raises(ValueError, match="failed"):
         norm.normalize_to_housekeeping(
             df,
+            panel_ids=hk,
+            reference_profile=ref,
             drop_zero_panel_values=True,
             min_panel_detected=1,
         )
 
     out = norm.normalize_to_housekeeping(
         df,
+        panel_ids=hk,
+        reference_profile=ref,
         drop_zero_panel_values=True,
         min_panel_detected=1,
         errors="nan",
     )
-    denom = np.exp(np.mean(np.log(np.array([10.0, 30.0]) + 0.1)))
-    assert np.allclose(out["good"], np.array([10.0, 30.0, 100.0]) / denom)
+    assert np.allclose(out["good"], np.array([10.0, 30.0, 100.0]) / 2.0)
     assert out["failed"].isna().all()
 
 
@@ -424,9 +444,47 @@ def test_normalize_long_table_groups_independently():
 
 
 def test_tpm_to_housekeeping_normalized():
-    from oncoref import gene_families
+    hk = ["HK1", "HK2"]
+    ref = pd.DataFrame({"Ensembl_Gene_ID": hk, "reference_tpm": [50.0, 100.0]})
+    df = pd.DataFrame(
+        {
+            "Symbol": ["HK1", "HK2", "GENE"],
+            "Ensembl_Gene_ID": [hk[0], hk[1], "ENSG_X"],
+            "s1_TPM": [100.0, 300.0, 50.0],
+        }
+    )
+    out, stats = norm.tpm_to_housekeeping_normalized(
+        df, value_cols=["s1_TPM"], panel_ids=hk, reference_profile=ref
+    )
+    # HK ratios are [2, 3] -> size factor 2.5 -> GENE 50 / 2.5 = 20.
+    assert stats["applied"] is True
+    assert stats["method"] == "median_of_ratios"
+    assert stats["columns"]["s1_TPM"]["denominator"] == pytest.approx(2.5)
+    assert out.loc[out["Symbol"] == "GENE", "s1_TPM"].iloc[0] == pytest.approx(20.0)
 
-    hk = list(gene_families.housekeeping_gene_ids())[:2]
+
+def test_tpm_to_housekeeping_normalized_handles_duplicate_index_labels():
+    hk = ["HK1", "HK2"]
+    ref = pd.DataFrame({"Ensembl_Gene_ID": hk, "reference_tpm": [50.0, 100.0]})
+    df = pd.DataFrame(
+        {
+            "Symbol": ["HK1", "HK2", "GENE"],
+            "Ensembl_Gene_ID": [hk[0], hk[1], "ENSG_X"],
+            "s1_TPM": [100.0, 300.0, 50.0],
+        },
+        index=[0, 0, 1],
+    )
+
+    out, stats = norm.tpm_to_housekeeping_normalized(
+        df, value_cols=["s1_TPM"], panel_ids=hk, reference_profile=ref
+    )
+
+    assert stats["columns"]["s1_TPM"]["denominator"] == pytest.approx(2.5)
+    assert out.loc[out["Symbol"] == "GENE", "s1_TPM"].iloc[0] == pytest.approx(20.0)
+
+
+def test_tpm_to_housekeeping_normalized_legacy_geomean_method_is_explicit():
+    hk = ["HK1", "HK2"]
     df = pd.DataFrame(
         {
             "Symbol": ["HK1", "HK2", "GENE"],
@@ -434,9 +492,16 @@ def test_tpm_to_housekeeping_normalized():
             "s1_TPM": [100.0, 100.0, 50.0],
         }
     )
-    out, stats = norm.tpm_to_housekeeping_normalized(df, value_cols=["s1_TPM"])
-    # geomean of [100,100] (+0.1) ~ 100.1 -> GENE 50 / 100.1 ~ 0.4995
-    assert stats["applied"] is True
+    with pytest.raises(ValueError, match="legacy_geomean"):
+        norm.tpm_to_housekeeping_normalized(
+            df, value_cols=["s1_TPM"], panel_ids=hk, method="geomean"
+        )
+
+    out, stats = norm.tpm_to_housekeeping_normalized(
+        df, value_cols=["s1_TPM"], panel_ids=hk, method="legacy_geomean"
+    )
+    assert stats["method"] == "legacy_geomean"
+    assert stats["columns"]["s1_TPM"]["denominator"] == pytest.approx(100.1, rel=1e-3)
     assert out.loc[out["Symbol"] == "GENE", "s1_TPM"].iloc[0] == pytest.approx(50 / 100.1, rel=1e-3)
 
 
@@ -444,9 +509,8 @@ def test_tpm_to_housekeeping_normalized_blanks_column_with_no_panel():
     # A column whose housekeeping panel rows are all NaN can't be put on the
     # ratio-to-baseline scale; it must become NaN, not silently stay raw-TPM
     # alongside normalized siblings (the scale-mixing trap).
-    from oncoref import gene_families
-
-    hk = list(gene_families.housekeeping_gene_ids())[:2]
+    hk = ["HK1", "HK2"]
+    ref = pd.DataFrame({"Ensembl_Gene_ID": hk, "reference_tpm": [100.0, 100.0]})
     df = pd.DataFrame(
         {
             "Symbol": ["HK1", "HK2", "GENE"],
@@ -455,17 +519,18 @@ def test_tpm_to_housekeeping_normalized_blanks_column_with_no_panel():
             "empty_TPM": [np.nan, np.nan, 50.0],  # panel genes unmeasured here
         }
     )
-    out, stats = norm.tpm_to_housekeeping_normalized(df, value_cols=["good_TPM", "empty_TPM"])
-    # The measurable column is normalized; the panel-less column is fully NaN, not 50.0.
-    assert out.loc[out["Symbol"] == "GENE", "good_TPM"].iloc[0] == pytest.approx(
-        50 / 100.1, rel=1e-3
+    out, stats = norm.tpm_to_housekeeping_normalized(
+        df, value_cols=["good_TPM", "empty_TPM"], panel_ids=hk, reference_profile=ref
     )
+    # The measurable column is normalized; the panel-less column is fully NaN, not 50.0.
+    assert out.loc[out["Symbol"] == "GENE", "good_TPM"].iloc[0] == pytest.approx(50.0)
     assert out["empty_TPM"].isna().all()
     assert stats["columns"]["empty_TPM"]["denominator"] == 0.0
 
 
 def test_tpm_to_housekeeping_normalized_gates_sparse_detected_panel():
     hk = ["HK1", "HK2", "HK3"]
+    ref = pd.DataFrame({"Ensembl_Gene_ID": hk, "reference_tpm": [100.0, 100.0, 100.0]})
     df = pd.DataFrame(
         {
             "Symbol": ["HK1", "HK2", "HK3", "GENE"],
@@ -481,14 +546,13 @@ def test_tpm_to_housekeeping_normalized_gates_sparse_detected_panel():
             value_cols=["good_TPM", "sparse_TPM"],
             panel_ids=hk,
             panel_name="test_housekeeping",
+            reference_profile=ref,
             min_panel_detected=2,
             drop_zero_panel_values=True,
             warn_on_unreliable=True,
         )
 
-    assert out.loc[out["Symbol"] == "GENE", "good_TPM"].iloc[0] == pytest.approx(
-        50 / 100.1, rel=1e-3
-    )
+    assert out.loc[out["Symbol"] == "GENE", "good_TPM"].iloc[0] == pytest.approx(50.0)
     assert out["sparse_TPM"].isna().all()
     assert stats["columns"]["good_TPM"]["panel_genes_detected"] == 2
     assert stats["columns"]["good_TPM"]["panel_genes_zero"] == 1


### PR DESCRIPTION
## Summary

- make `median_of_ratios` the canonical housekeeping normalization method
- add a versioned HPA v23-derived clean-TPM biological housekeeping reference profile
- require the old denominator path to use `method="legacy_geomean"`; `method="geomean"` is rejected
- document the median-of-ratios formula and steer users toward log1p clean TPM / percentile rank when HK scaling is not needed

Closes #204. Relates to #202 and the pirlygenes HK migration notes.

## Validation

- `python -m pytest tests/test_normalization.py tests/test_expression.py`
- `./test.sh` (645 passed, existing matplotlib open-figure warning)
