### PR TITLE
Clarify stack ownership boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,34 @@ RNA-seq expression, HPA normal-tissue expression, and HPA-derived
 cancer-testis antigen references — behind one small Python API, a data
 fetch/cache CLI, and a set of reference plots.
 
+## Where oncoref fits
+
+The openvax/PIRL tools are split by ownership boundary, not by file format.
+Newcomers should think of the stack as three layers:
+
+- **oncoref** is the empirical base: what is true, measured, or canonically named
+  about cancer types, cohorts, genes, and reference datasets. It owns gene
+  identity and canonicalization, the cancer-type ontology/registry, expression
+  reference data and normalization, epidemiology, TMB, ICI/aPD1 response, and
+  source-anchored CTA facts. If a row has an `n`, a confidence interval, a
+  source cohort, or a PMID/DOI anchoring a measurement, it is usually an oncoref
+  fact.
+- [**pirlygenes**](https://github.com/pirl-unc/pirlygenes) owns curated gene
+  sets and panels: which genes are useful for a purpose. That includes
+  lineage/family/compartment/supertype panels, discriminators, surfaceome, TME
+  and stem-cell markers, response-signature panels, and other opinionated
+  selections keyed to oncoref cancer codes and gene IDs. An empty set can be a
+  valid pirlygenes answer.
+- [**trufflepig**](https://github.com/pirl-unc/trufflepig) owns per-sample
+  interpretation: QC narration, library-prep/source warnings, deconvolution,
+  scoring, and rule tables that fire against one tumor sample.
+
+That division keeps the dependency direction simple: pirlygenes and trufflepig
+can depend on oncoref, but oncoref never imports its consumers. When a shared
+fact is wrong, incomplete, or poorly anchored, fix it in oncoref. When a panel
+or rule is purpose-specific, keep it in the downstream package and key it to
+oncoref's ontology and gene identifiers.
+
 ## oncoref is the base layer
 
 `oncoref` is **designed as the base layer** of the openvax/PIRL stack — the
@@ -101,7 +129,8 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
 - **CTA coverage / peptides** — `oncoref.cta_coverage` for patient coverage and
   `oncoref.cta_peptides` for CTA-specific 9-mer count maps and load.
 - **Generic antigen-panel coverage** — `oncoref.antigen_coverage` for explicit
-  non-CTA panels.
+  non-CTA gene lists supplied by the caller. This computes coverage for a panel;
+  it does not make oncoref the owner of downstream panel curation.
 - **HPA normal tissue** — `hpa_rna_consensus`, `hpa_normal_tissue` (IHC),
   `hpa_single_cell`, and per-gene lookups (`gene_tissue_ntpm`,
   `gene_protein_tissues`, `gene_cell_type_ntpm`) over HPA v23, fetched on demand
@@ -112,6 +141,10 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
   package, but resolution needs a downloaded human release once:
   `pyensembl install --release 111 --species homo_sapiens` (the accessors return
   `None` until then).
+- **Legacy/compat response signatures** — `oncoref.response_signatures` ships a
+  small historical checkpoint-response signature surface used by oncoref plots.
+  New therapy-response signature panels belong in pirlygenes unless they are
+  recast as source-anchored empirical fact tables.
 - **Plots** (`pip install oncoref[plots]`) — `oncoref.plots.apd1_vs_tmb`,
   `apd1_orr_bars`, `incidence_vs_mortality`, the CTA/coverage figures, and
   `oncoref.cta_curation_plots.render`.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Newcomers should think of the stack as three layers:
 - [**pirlygenes**](https://github.com/pirl-unc/pirlygenes) owns curated gene
   sets and panels: which genes are useful for a purpose. That includes
   lineage/family/compartment/supertype panels, discriminators, surfaceome, TME
-  and stem-cell markers, response-signature panels, and other opinionated
-  selections keyed to oncoref cancer codes and gene IDs. An empty set can be a
-  valid pirlygenes answer.
+  and stem-cell markers, response-signature panels, target-to-therapy registries,
+  and other opinionated selections keyed to oncoref cancer codes and gene IDs. An
+  empty set can be a valid pirlygenes answer.
 - [**trufflepig**](https://github.com/pirl-unc/trufflepig) owns per-sample
   interpretation: QC narration, library-prep/source warnings, deconvolution,
   scoring, and rule tables that fire against one tumor sample.
@@ -143,8 +143,9 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
   `None` until then).
 - **Legacy/compat response signatures** — `oncoref.response_signatures` ships a
   small historical checkpoint-response signature surface used by oncoref plots.
-  New therapy-response signature panels belong in pirlygenes unless they are
-  recast as source-anchored empirical fact tables.
+  Treat it as transitional: new therapy-response signature panels belong in
+  pirlygenes, and this small surface should not be extended in oncoref unless it
+  is recast as source-anchored empirical fact/provenance rows.
 - **Plots** (`pip install oncoref[plots]`) — `oncoref.plots.apd1_vs_tmb`,
   `apd1_orr_bars`, `incidence_vs_mortality`, the CTA/coverage figures, and
   `oncoref.cta_curation_plots.render`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,11 +5,15 @@ code should prefer the semantic submodules below. They make the domain boundary
 clear and avoid guessing whether a broad name such as `coverage` or `peptides` is
 general or CTA-specific.
 
-Package boundary: oncoref is the upstream home for shared reference mechanics
-and data that are ready to be reused across the PIRL stack. Downstream packages
-can keep package-specific curation, generated artifacts, and compatibility APIs;
-when a missing data field, gene universe, bundle-integrity rule, or source-QC
-decision affects generated artifacts, the durable fix should live or be exposed
+Package boundary: oncoref is the upstream home for empirical base facts and
+canonical identifiers that are ready to be reused across the PIRL stack.
+pirlygenes owns purpose-specific gene sets and panels; trufflepig owns
+per-sample interpretation, QC narration, and rule firing. As a rule of thumb,
+source-anchored measurements with denominators, confidence intervals, cohorts,
+PMIDs/DOIs, or shared ontology implications belong in oncoref. Opinionated gene
+selections belong in pirlygenes. One-sample rules belong in trufflepig. When a
+missing data field, gene universe, bundle-integrity rule, or source-QC decision
+affects shared reference artifacts, the durable fix should live or be exposed
 here rather than only in a downstream compatibility layer.
 
 ## Cancer Vocabulary
@@ -103,10 +107,12 @@ cta_peptides.cta_specific_9mer_count_map(by="proteoform_key")
 
 ## Generic Antigen Panels
 
-- `oncoref.antigen_coverage` — explicit-gene-panel coverage helpers.
+- `oncoref.antigen_coverage` — coverage helpers for caller-supplied gene lists.
 
 Use this when the panel is not necessarily CTA. The function names require
-`gene_ids=` so a caller cannot accidentally rely on the CTA default.
+`gene_ids=` so a caller cannot accidentally rely on the CTA default. This module
+computes coverage for a supplied list; it does not make oncoref the owner of
+downstream panel curation.
 
 ```python
 from oncoref import antigen_coverage
@@ -336,7 +342,8 @@ but it is not the clean-TPM biological denominator.
 - `oncoref.proteoforms` — identical-protein paralog grouping and expression
   collapse helpers.
 - `oncoref.gene_qc` / `oncoref.gene_families` — technical-RNA and gene-family
-  classification used by normalization.
+  classification used by normalization. These are normalization/QC reference
+  families, not the general home for pirlygenes marker panels.
 
 ## Burden, TMB, Fusions, and Signatures
 
@@ -349,7 +356,9 @@ but it is not the clean-TPM biological denominator.
   “known no supported site-specific estimate” from an unmapped cancer code.
 - `oncoref.incidence` — incidence/mortality burden and burden categories.
 - `oncoref.fusions` — defining fusions and partner-family lookups.
-- `oncoref.response_signatures` — therapy-response gene signatures and scoring.
+- `oncoref.response_signatures` — legacy/compatibility response-signature
+  surface used by oncoref plots. New therapy-response signature panels belong in
+  pirlygenes unless they are recast as source-anchored empirical fact tables.
 
 ## Data Management
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,10 +11,11 @@ pirlygenes owns purpose-specific gene sets and panels; trufflepig owns
 per-sample interpretation, QC narration, and rule firing. As a rule of thumb,
 source-anchored measurements with denominators, confidence intervals, cohorts,
 PMIDs/DOIs, or shared ontology implications belong in oncoref. Opinionated gene
-selections belong in pirlygenes. One-sample rules belong in trufflepig. When a
-missing data field, gene universe, bundle-integrity rule, or source-QC decision
-affects shared reference artifacts, the durable fix should live or be exposed
-here rather than only in a downstream compatibility layer.
+selections and target-to-therapy registries belong in pirlygenes. One-sample
+rules belong in trufflepig. When a missing data field, gene universe,
+bundle-integrity rule, or source-QC decision affects shared reference artifacts,
+the durable fix should live or be exposed here rather than only in a downstream
+compatibility layer.
 
 ## Cancer Vocabulary
 
@@ -357,8 +358,9 @@ but it is not the clean-TPM biological denominator.
 - `oncoref.incidence` — incidence/mortality burden and burden categories.
 - `oncoref.fusions` — defining fusions and partner-family lookups.
 - `oncoref.response_signatures` — legacy/compatibility response-signature
-  surface used by oncoref plots. New therapy-response signature panels belong in
-  pirlygenes unless they are recast as source-anchored empirical fact tables.
+  surface used by oncoref plots. Treat it as transitional: new or extended
+  therapy-response signature panels belong in pirlygenes unless they are recast
+  as source-anchored empirical fact/provenance rows.
 
 ## Data Management
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,13 +5,27 @@ cancer-type ontology, cohorts, expression, clean-TPM normalization, TMB,
 incidence/mortality, ICI response, HPA normal-tissue expression, and
 HPA-derived cancer-testis antigen references.
 
-Downstream packages such as pirlygenes and trufflepig should delegate
-parity-clean shared primitives here, but they may keep curated package-specific
-tables, generated artifacts, and compatibility wrappers until a surface has a
-clear oncoref contract.
+Downstream packages such as [pirlygenes](https://github.com/pirl-unc/pirlygenes)
+and [trufflepig](https://github.com/pirl-unc/trufflepig) should delegate
+parity-clean shared primitives here, but they keep different kinds of work:
+pirlygenes owns curated gene sets and panels, while trufflepig owns per-sample
+interpretation and rule firing.
 
 Use this page as the quick orientation. The [API guide](api.md) is the detailed
 module map, with examples and notes about compatibility modules.
+
+## Stack Boundary
+
+- **oncoref**: empirical base facts and canonical identifiers. Use it for cancer
+  codes, gene IDs, reference expression/normalization, epidemiology, TMB, ICI/aPD1
+  response, HPA normal tissue, and source-anchored CTA facts. If a row has an
+  `n`, confidence interval, source cohort, or PMID/DOI anchoring a measurement, it
+  usually belongs here.
+- **pirlygenes**: curated gene selections. Use it for lineage/family/compartment
+  panels, discriminators, surfaceome, TME and stem-cell markers, response
+  signature panels, and other purpose-specific gene sets keyed to oncoref IDs.
+- **trufflepig**: per-sample application. Use it for sample QC narration,
+  library-prep/source warnings, deconvolution, scoring, and tumor-sample rules.
 
 ## Start Here
 
@@ -39,12 +53,13 @@ ici_response.best_available_ici_response("COAD_MSI")
 | --- | --- | --- |
 | Cancer vocabulary | [`oncoref.cancer_ontology`](api.md#cancer-vocabulary), [`oncoref.cohorts`](api.md#cancer-vocabulary) | Registry records, aliases, hierarchy, subtype axes, cohort IDs, matched normal tissues |
 | ICI response | [`oncoref.ici_response`](api.md#ici-response) | Anti-PD-1 and broader ICI references, regimen-aware lookups, extracted endpoint estimates |
-| CTA references | [`oncoref.cta`](api.md#cta-antigens), [`oncoref.cta_coverage`](api.md#cta-antigens), [`oncoref.cta_peptides`](api.md#cta-antigens) | CTA gene sets, patient coverage, CTA-specific 9-mer counts and load |
-| Antigen panels | [`oncoref.antigen_coverage`](api.md#generic-antigen-panels) | Coverage calculations for explicit non-CTA gene panels |
+| CTA references | [`oncoref.cta`](api.md#cta-antigens), [`oncoref.cta_coverage`](api.md#cta-antigens), [`oncoref.cta_peptides`](api.md#cta-antigens) | HPA-derived CTA facts, patient coverage, CTA-specific 9-mer counts and load |
+| Antigen panels | [`oncoref.antigen_coverage`](api.md#generic-antigen-panels) | Coverage calculations for caller-supplied non-CTA gene lists |
 | Expression | [`oncoref.expression`](api.md#expression-and-normalization), [`oncoref.expression_builders`](api.md#expression-and-normalization) | Per-sample, percentile, representative, within-sample, and reference-expression accessors |
-| Normalization | [`oncoref.normalization`](api.md#expression-and-normalization), [`oncoref.gene_families`](api.md#expression-and-normalization) | Clean TPM, housekeeping normalization, technical-RNA filtering, gene-family panels |
+| Normalization | [`oncoref.normalization`](api.md#expression-and-normalization), [`oncoref.gene_families`](api.md#expression-and-normalization) | Clean TPM, housekeeping normalization, technical-RNA filtering, normalization/QC reference families |
 | Genes and proteoforms | [`oncoref.gene_ids`](api.md#genes-and-proteoforms), [`oncoref.genome`](api.md#genes-and-proteoforms), [`oncoref.proteoforms`](api.md#genes-and-proteoforms) | Gene ID resolution, Ensembl lookup, proteoform grouping |
-| Other references | [`oncoref.tmb`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.incidence`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.fusions`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.response_signatures`](api.md#burden-tmb-fusions-and-signatures) | TMB, incidence/mortality burden, defining fusions, response signatures |
+| Other references | [`oncoref.tmb`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.incidence`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.fusions`](api.md#burden-tmb-fusions-and-signatures) | TMB, incidence/mortality burden, defining fusions |
+| Legacy compatibility | [`oncoref.response_signatures`](api.md#burden-tmb-fusions-and-signatures) | Small historical response-signature surface; new therapy-signature panels belong in pirlygenes |
 | Data management | [`oncoref.catalog`](api.md#data-management), [`oncoref.data_bundle`](api.md#data-management), [`oncoref.reference_data`](api.md#data-management), [`oncoref.hpa`](api.md#data-management) | Dataset inventory, download/cache status, HPA reference data |
 
 ## Install

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,8 @@ module map, with examples and notes about compatibility modules.
   usually belongs here.
 - **pirlygenes**: curated gene selections. Use it for lineage/family/compartment
   panels, discriminators, surfaceome, TME and stem-cell markers, response
-  signature panels, and other purpose-specific gene sets keyed to oncoref IDs.
+  signature panels, target-to-therapy registries, and other purpose-specific
+  gene sets keyed to oncoref IDs.
 - **trufflepig**: per-sample application. Use it for sample QC narration,
   library-prep/source warnings, deconvolution, scoring, and tumor-sample rules.
 
@@ -59,7 +60,7 @@ ici_response.best_available_ici_response("COAD_MSI")
 | Normalization | [`oncoref.normalization`](api.md#expression-and-normalization), [`oncoref.gene_families`](api.md#expression-and-normalization) | Clean TPM, housekeeping normalization, technical-RNA filtering, normalization/QC reference families |
 | Genes and proteoforms | [`oncoref.gene_ids`](api.md#genes-and-proteoforms), [`oncoref.genome`](api.md#genes-and-proteoforms), [`oncoref.proteoforms`](api.md#genes-and-proteoforms) | Gene ID resolution, Ensembl lookup, proteoform grouping |
 | Other references | [`oncoref.tmb`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.incidence`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.fusions`](api.md#burden-tmb-fusions-and-signatures) | TMB, incidence/mortality burden, defining fusions |
-| Legacy compatibility | [`oncoref.response_signatures`](api.md#burden-tmb-fusions-and-signatures) | Small historical response-signature surface; new therapy-signature panels belong in pirlygenes |
+| Legacy compatibility | [`oncoref.response_signatures`](api.md#burden-tmb-fusions-and-signatures) | Transitional historical response-signature surface; new or extended therapy-signature panels belong in pirlygenes |
 | Data management | [`oncoref.catalog`](api.md#data-management), [`oncoref.data_bundle`](api.md#data-management), [`oncoref.reference_data`](api.md#data-management), [`oncoref.hpa`](api.md#data-management) | Dataset inventory, download/cache status, HPA reference data |
 
 ## Install

--- a/oncoref/data_manifest.py
+++ b/oncoref/data_manifest.py
@@ -19,17 +19,26 @@ asserts the buckets partition the frozen pirlygenes inventory exhaustively and
 disjointly — so as oncoref absorbs pirlygenes, nothing is silently dropped or
 double-owned.
 
+Ownership rule:
+  oncoref owns empirical base facts and reference mechanics: canonical gene IDs,
+  cancer ontology, reference expression/normalization, epidemiology, TMB, ICI/aPD1,
+  source-anchored CTA facts, and measurement/provenance tables. pirlygenes owns
+  purpose-specific gene sets/panels. trufflepig owns per-sample rules and QC
+  interpretation.
+
 Held buckets (oncoref domain):
-  WHEEL     — small curated tables shipped in the wheel (no fetch).
+  WHEEL     — small base-layer tables shipped in the wheel (no fetch). A
+              ``legacy-compat`` category marks shipped historical surfaces that
+              remain importable but are not the intended future ownership boundary.
   BUNDLE    — heavy expression artifacts in the version-pinned release tarball.
   HPA       — Human Protein Atlas reference tables fetched per-source on demand.
   SOURCE    — the raw per-sample TPM matrices (a separate large optional bundle).
-  PLANNED   — oncoref-domain tables still to port (they feed the normalization
-              / CTA-regeneration / ontology phases).
+  PLANNED   — oncoref-domain fact tables still to port.
   SUPERSEDED— a pirlygenes table oncoref replaced with its own regenerated one.
 
-OUT_OF_SCOPE — pirlygenes data that is NOT oncoref's domain (target selection,
-  therapy/modality, surfaceome, analysis gene sets) and stays in tsarina/hitlist.
+OUT_OF_SCOPE — pirlygenes or trufflepig data that is NOT oncoref's domain:
+  target-selection panels, marker/signature gene sets, therapy modality catalogs,
+  sample-rule tables, and artifact/QC interpretation rules.
 
 The catalog (:mod:`oncoref.catalog`) manages the fetchable subset; this module
 is the inventory + classification.
@@ -74,18 +83,50 @@ WHEEL: dict[str, tuple[str, str]] = {
     "extra-tx-mappings": ("gene-id", "supplemental transcript→gene mappings"),
     "cdna-identical-gene-groups": ("gene-id", "cDNA-identical gene groups"),
     "proteoform-collapse-overrides": ("gene-id", "manual proteoform-collapse overrides"),
-    # ontology metadata (R-onto / O5)
-    "cancer-key-genes": ("ontology", "per-type biomarkers + therapy targets"),
-    "cancer-driver-genes": ("ontology", "per-type driver genes"),
-    "cancer-driver-variants": ("ontology", "per-type driver variants"),
-    "cancer-type-genes": ("ontology", "role-stratified per-type genes"),
-    "cancer-viral-antigens": ("ontology", "per-oncovirus targetable antigens"),
-    "disease-state-rules": ("ontology", "narrative disease-state rules"),
-    "narrative-gene-sets": ("ontology", "named narrative gene sets"),
+    # Legacy compatibility tables imported before the stack boundary was clarified.
+    # Keep shipped/readable for old callers, but do not treat them as the future
+    # oncoref ownership surface for marker panels, target selection, or sample rules.
+    "cancer-key-genes": (
+        "legacy-compat",
+        "legacy per-type biomarker/target rows; future purpose-specific panels live downstream",
+    ),
+    "cancer-driver-genes": (
+        "legacy-compat",
+        "legacy per-type driver-gene rows; source-anchored fact model still unresolved",
+    ),
+    "cancer-driver-variants": (
+        "legacy-compat",
+        "legacy per-type driver-variant rows; source-anchored fact model still unresolved",
+    ),
+    "cancer-type-genes": (
+        "legacy-compat",
+        "legacy role-stratified per-type gene rows; not a general panel-ownership surface",
+    ),
+    "cancer-viral-antigens": (
+        "legacy-compat",
+        "legacy per-oncovirus targetable-antigen rows; target-selection curation lives downstream",
+    ),
+    "disease-state-rules": (
+        "legacy-compat",
+        "legacy narrative disease-state rules; per-sample rule ownership belongs downstream",
+    ),
+    "narrative-gene-sets": (
+        "legacy-compat",
+        "legacy named narrative gene sets; purpose-specific gene-set ownership belongs to pirlygenes",
+    ),
     "degenerate-subtype-pairs": ("ontology", "expression-degenerate subtype pairs"),
-    "rare-cancer-fusion-rules": ("ontology", "direct fusion rules for rare cancers"),
-    "fusion-surrogate-expression": ("ontology", "expression surrogates for fusions"),
-    "fusion-expression-effects": ("ontology", "downstream-expression rules per fusion"),
+    "rare-cancer-fusion-rules": (
+        "legacy-compat",
+        "legacy direct fusion rules for rare cancers; per-sample interpretation belongs downstream",
+    ),
+    "fusion-surrogate-expression": (
+        "legacy-compat",
+        "legacy fusion-expression surrogate rows; sample-rule use belongs downstream",
+    ),
+    "fusion-expression-effects": (
+        "legacy-compat",
+        "legacy downstream-expression rules per fusion; sample-rule use belongs downstream",
+    ),
     # expression-source metadata + genomics (R-exprmeta)
     "cancer-expression-source-candidates": ("expression", "candidate expression sources per type"),
     "cancer-frameshift-burden": ("genomics", "per-type frameshift-indel burden"),
@@ -149,11 +190,13 @@ SOURCE: dict[str, tuple[str, str]] = {
     "per-sample-tpm-matrices": ("expression", "raw per-sample cohort TPM (build inputs)"),
 }
 
-#: {name: (category, description)} — oncoref-domain tables still to port.
-#: oncoref-domain tables still to port. Empty — every pirlygenes table in
-#: oncoref's domain is now captured (the remaining gap is the per-sample
-#: matrices in SOURCE, distributed per cohort).
-PLANNED: dict[str, tuple[str, str]] = {}
+#: {name: (category, description)} — oncoref-domain fact tables still to port.
+PLANNED: dict[str, tuple[str, str]] = {
+    "therapy-benefit-toxicity-evidence": (
+        "therapy-evidence",
+        "source-anchored therapy benefit/toxicity fact rows; not therapy signature panels",
+    ),
+}
 
 #: pirlygenes tables oncoref replaced with its own regenerated equivalent.
 SUPERSEDED: dict[str, str] = {
@@ -181,13 +224,14 @@ CANCERDATA_ORIGINATED: dict[str, tuple[str, str]] = {
         "HPA-stable biological housekeeping denominator candidates for clean TPM",
     ),
     "cancer-response-signatures": (
-        "response",
-        "curated aPD1 response/resistance expression signatures (T-cell-inflamed, TGF-β, …)",
+        "legacy-compat",
+        "legacy small response-signature surface; new therapy signature panels belong in pirlygenes",
     ),
 }
 
-#: pirlygenes data that is NOT oncoref's domain — target selection / therapy /
-#: surfaceome / analysis gene sets. These stay in tsarina / hitlist.
+#: pirlygenes/trufflepig data that is NOT oncoref's domain — target selection /
+#: therapy modality catalogs, marker/signature panels, surfaceome, and per-sample
+#: interpretation/rule tables. These stay downstream and key to oncoref IDs.
 OUT_OF_SCOPE: frozenset[str] = frozenset(
     {
         # therapeutic modality / drug data
@@ -204,7 +248,6 @@ OUT_OF_SCOPE: frozenset[str] = frozenset(
         "surface-proteins",
         "cancer-surfaceome",
         # therapy signatures / evidence
-        "therapy-benefit-toxicity-evidence",
         "therapy-response-signatures",
         "estimate-signatures",
         "immune-receptor-segments",
@@ -318,10 +361,10 @@ PIRLYGENES_DATA: frozenset[str] = frozenset(
 
 
 def captured() -> set[str]:
-    """oncoref-domain datasets already held (wheel + bundle + superseded)."""
+    """Datasets already held or shipped for compatibility."""
     return set(WHEEL) | set(BUNDLE) | set(SUPERSEDED)
 
 
 def in_scope() -> set[str]:
-    """Every oncoref-domain dataset — captured plus still-planned."""
+    """Base-layer inventory: captured datasets plus still-planned fact tables."""
     return captured() | set(PLANNED)

--- a/oncoref/data_manifest.py
+++ b/oncoref/data_manifest.py
@@ -23,8 +23,8 @@ Ownership rule:
   oncoref owns empirical base facts and reference mechanics: canonical gene IDs,
   cancer ontology, reference expression/normalization, epidemiology, TMB, ICI/aPD1,
   source-anchored CTA facts, and measurement/provenance tables. pirlygenes owns
-  purpose-specific gene sets/panels. trufflepig owns per-sample rules and QC
-  interpretation.
+  purpose-specific gene sets/panels and target-to-therapy registries. trufflepig
+  owns per-sample rules and QC interpretation.
 
 Held buckets (oncoref domain):
   WHEEL     — small base-layer tables shipped in the wheel (no fetch). A
@@ -194,7 +194,7 @@ SOURCE: dict[str, tuple[str, str]] = {
 PLANNED: dict[str, tuple[str, str]] = {
     "therapy-benefit-toxicity-evidence": (
         "therapy-evidence",
-        "source-anchored therapy benefit/toxicity fact rows; not therapy signature panels",
+        "source-anchored therapy benefit/toxicity fact rows; not target registries or panels",
     ),
 }
 
@@ -225,7 +225,7 @@ CANCERDATA_ORIGINATED: dict[str, tuple[str, str]] = {
     ),
     "cancer-response-signatures": (
         "legacy-compat",
-        "legacy small response-signature surface; new therapy signature panels belong in pirlygenes",
+        "transitional response-signature surface; new/extended therapy panels belong in pirlygenes",
     ),
 }
 

--- a/oncoref/response_signatures.py
+++ b/oncoref/response_signatures.py
@@ -14,7 +14,8 @@
 
 These helpers remain importable for existing callers and oncoref's historical
 plots, but they are not the future home for therapy-response signature curation.
-Purpose-specific response panels belong in pirlygenes. oncoref should only own a
+Purpose-specific response panels belong in pirlygenes, and this compatibility
+surface should move there rather than grow in oncoref. oncoref should only own a
 future response-signature table if it is recast as a source-anchored empirical
 fact/provenance table rather than a marker-panel catalog.
 

--- a/oncoref/response_signatures.py
+++ b/oncoref/response_signatures.py
@@ -10,13 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A small curated set of anti-PD-1 response/resistance expression signatures.
+"""Legacy compatibility surface for a small checkpoint-response signature set.
 
-Cancer-type-level reference describing the *biology* of checkpoint response — the
-companion to the aPD1 ORR table oncoref already owns. Deliberately a **few**
-foundational, well-cited signatures (T-cell-inflamed / IFN-γ, cytotoxic effector,
-MHC-I antigen presentation, TGF-β immune exclusion), not pirlygenes' full
-therapy-signature catalog: oncoref stays the base layer, not the analysis layer.
+These helpers remain importable for existing callers and oncoref's historical
+plots, but they are not the future home for therapy-response signature curation.
+Purpose-specific response panels belong in pirlygenes. oncoref should only own a
+future response-signature table if it is recast as a source-anchored empirical
+fact/provenance table rather than a marker-panel catalog.
 
 ``cancer-response-signatures.csv``: ``signature, gene_symbol, direction``
 (``positive`` = response-associated, ``negative`` = resistance-associated),

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -280,12 +280,16 @@ def test_inventory_wheel_always_available():
     assert wheel and all(r["available"] for r in wheel)
 
 
-def test_planned_fully_captured():
-    # Phase R complete: no oncoref-domain table is still 'planned'.
+def test_planned_tables_are_boundary_scoped():
+    # The remaining planned table is an empirical oncoref fact surface. Marker
+    # panels, therapy-signature panels, and one-sample rules stay downstream.
     from oncoref import data_manifest
 
-    assert not data_manifest.PLANNED
-    assert not [r for r in catalog.inventory() if r["held"] == "planned"]
+    assert set(data_manifest.PLANNED) == {"therapy-benefit-toxicity-evidence"}
+    planned = [r for r in catalog.inventory() if r["held"] == "planned"]
+    assert {r["name"] for r in planned} == set(data_manifest.PLANNED)
+    assert all(not r["available"] for r in planned)
+    assert {r["category"] for r in planned} == {"therapy-evidence"}
 
 
 def test_cli_data_list_shows_full_inventory(capsys):


### PR DESCRIPTION
## Summary

- explain the oncoref / pirlygenes / trufflepig ownership boundary in the README and docs home
- update the API guide so antigen coverage, gene families, and response signatures do not read like broad panel ownership surfaces
- mark old migrated gene/rule/signature tables in the data manifest as legacy compatibility or downstream-owned instead of oncoref-domain gaps
- keep therapy-benefit-toxicity evidence as the one planned oncoref empirical fact table

This follows the recent boundary clarification: oncoref owns source-anchored empirical facts and canonical identifiers; pirlygenes owns purpose-specific gene sets/panels; trufflepig owns per-sample rules and QC interpretation.

## Verification

- python -m pytest tests/test_data_manifest.py tests/test_catalog.py tests/test_response_signatures.py
- ./lint.sh
- ./test.sh

Full test run: 646 passed, 1 existing matplotlib warning.