### PR TITLE
Clarify housekeeping normalization wording

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -1301,7 +1301,8 @@ def per_sample_expression(
         biological view the summaries are built on);
       - ``"tpm_clean_log1p"`` — clean TPM, ``log1p``-transformed;
       - ``"tpm_clean_hk"`` — clean TPM divided per sample by the biological
-        clean-TPM housekeeping-panel geometric mean (unit-free ratio-to-baseline,
+        clean-TPM housekeeping-panel median-of-ratios size factor against the
+        fixed HPA-derived reference profile (unit-free ratio-to-baseline,
         robust to library-depth drift);
       - ``"tpm_raw"`` — the matrix as shipped (raw TPM), no normalization.
 
@@ -1382,9 +1383,11 @@ def _load_per_sample_matrix(path: str, mtime: float, normalize: str) -> pd.DataF
 
 
 def _housekeeping_normalize(df: pd.DataFrame, sample_cols) -> pd.DataFrame:
-    """Divide each clean-TPM sample column by the biological housekeeping-panel geometric
-    mean. Commutes with the proteoform sum (the denominator is per-column), so it can
-    be applied before or after collapse."""
+    """Divide each clean-TPM sample column by its housekeeping median-of-ratios factor.
+
+    The factor is per-column, so this commutes with the proteoform sum and can be
+    applied before or after collapse.
+    """
     from .normalization import tpm_to_housekeeping_normalized
 
     panel_ids = _clean_tpm_housekeeping_panel_ids()


### PR DESCRIPTION
## Summary

- Update expression API docs for `tpm_clean_hk` to describe the current median-of-ratios housekeeping size-factor contract.
- Remove stale geometric-mean wording from the internal expression helper docstring.

Refs #202. This does not close the source-aware HK audit/panel calibration work that remains in #202.

## Validation

- `./lint.sh`
- `python -m pytest tests/test_expression.py::test_housekeeping_normalize_divides_by_panel_size_factor tests/test_expression.py::test_housekeeping_normalize_blanks_sparse_housekeeping_denominator tests/test_normalization.py::test_tpm_to_housekeeping_normalized tests/test_normalization.py::test_tpm_to_housekeeping_normalized_legacy_geomean_method_is_explicit`
- `./test.sh` (653 passed, 1 existing matplotlib open-figure warning)