### PR TITLE
Add registry-backed GEO matrix builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
 - **Expression** — `cohort_gene_percentiles`, `within_sample_top_fraction`,
   `representative_cohort_samples` over the lazy-downloaded per-cohort bundle;
   `oncoref.expression_builders` for source-matrix ingestion into canonical
-  per-code per-sample TPM parquet plus mapping/parse/QC sidecars.
+  per-code per-sample TPM parquet plus mapping/parse/QC sidecars. Generic
+  `source_type: geo-matrix` entries in `expression_sources.yaml` are executable
+  via `scripts/build_geo_matrix.py`.
 - **Clean TPM / normalization** — `oncoref.normalization` for the 16/9/75
   compartment transform and `oncoref.gene_families` for clean-TPM censored
   compartment IDs plus the biological housekeeping denominator panel.

--- a/docs/api.md
+++ b/docs/api.md
@@ -196,7 +196,9 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   data-bundle generation scripts. `GeoMatrixSource` /
   `build_source_matrices` own the generic supplementary-matrix path from raw
   source file to canonical per-code per-sample TPM parquet, mapping audit, parse
-  diagnostics, and sample-QC sidecars. `scripts/rebuild_expression_artifacts.py`
+  diagnostics, and sample-QC sidecars. `geo_matrix_source_from_registry` and
+  `scripts/build_geo_matrix.py` make `source_type: geo-matrix` entries in the
+  packaged source registry directly buildable. `scripts/rebuild_expression_artifacts.py`
   then applies the same sample-QC policy to derived shards by default
   (`--sample-qc pass`) and emits `source-matrix-sample-qc.csv` plus
   `expression-artifact-build-metadata.*` in the staging directory so bundle

--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -37,15 +37,18 @@ referenced and documented as the public build-time API.
 
 from __future__ import annotations
 
+import re
 import shutil
 import urllib.request
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from importlib.resources import files
 from pathlib import Path
 from typing import Callable, Literal
 
 import numpy as np
 import pandas as pd
+import yaml
 
 from .expression_engine import (
     canonicalize_source_gene_matrix,
@@ -55,6 +58,7 @@ from .expression_engine import (
 )
 
 SourceExpressionUnit = Literal["TPM", "FPKM", "RPKM", "log2(TPM+1)", "raw_counts"]
+GEO_MATRIX_SOURCE_TYPE = "geo-matrix"
 
 _SOURCE_SYMBOL_COLUMN_CANDIDATES = (
     "Symbol",
@@ -150,6 +154,135 @@ class SourceMatrixBuildResult:
     parse_diagnostics: pd.DataFrame
     sample_qc: pd.DataFrame
     sidecar_paths: dict[str, Path]
+
+
+def _source_entries_from_registry(registry_path: str | Path | None = None) -> list[dict]:
+    if registry_path is None:
+        with files("oncoref").joinpath("data/expression_sources.yaml").open() as handle:
+            payload = yaml.safe_load(handle) or {}
+    else:
+        with Path(registry_path).open() as handle:
+            payload = yaml.safe_load(handle) or {}
+    entries = payload.get("sources", [])
+    if not isinstance(entries, list):
+        raise ValueError("expression source registry must contain a list-valued 'sources' key")
+    return [dict(entry) for entry in entries]
+
+
+def geo_matrix_source_entries(registry_path: str | Path | None = None) -> list[dict]:
+    """Raw ``source_type: geo-matrix`` entries from ``expression_sources.yaml``.
+
+    This is the registry/config half of the source-matrix builder contract. The
+    returned dictionaries preserve the source YAML fields so build scripts can
+    inspect provenance or source-specific notes, while
+    :func:`geo_matrix_source_from_entry` converts one entry into the executable
+    :class:`GeoMatrixSource` object used by :func:`build_source_matrices`.
+    """
+    return [
+        entry
+        for entry in _source_entries_from_registry(registry_path)
+        if entry.get("source_type") == GEO_MATRIX_SOURCE_TYPE
+    ]
+
+
+def _compile_sample_filter(spec: Mapping | None) -> Callable[[list[str]], list[str]] | None:
+    if not spec:
+        return None
+    include = str(spec["include_match"]) if "include_match" in spec else None
+    exclude = str(spec["exclude_match"]) if "exclude_match" in spec else None
+    include_re = re.compile(include) if include else None
+    exclude_re = re.compile(exclude) if exclude else None
+
+    def _filter(samples: list[str]) -> list[str]:
+        out = []
+        for sample in samples:
+            if include_re is not None and not include_re.search(str(sample)):
+                continue
+            if exclude_re is not None and exclude_re.search(str(sample)):
+                continue
+            out.append(str(sample))
+        return out
+
+    return _filter
+
+
+def _compile_sample_to_cancer_code(
+    spec: Mapping | None,
+) -> Callable[[str], str | None] | None:
+    rules = (spec or {}).get("rules", [])
+    if not rules:
+        return None
+    compiled = [(re.compile(str(rule["match"])), str(rule["cancer_code"])) for rule in rules]
+
+    def _dispatch(sample_id: str) -> str | None:
+        for regex, code in compiled:
+            if regex.search(str(sample_id)):
+                return code
+        return None
+
+    return _dispatch
+
+
+def _coerce_source_expression_unit(unit: str) -> SourceExpressionUnit:
+    normalized = str(unit).strip()
+    aliases = {
+        "tpm": "TPM",
+        "fpkm": "FPKM",
+        "rpkm": "RPKM",
+        "raw_counts": "raw_counts",
+        "raw counts": "raw_counts",
+        "log2-tpm": "log2(TPM+1)",
+        "log2_tpm": "log2(TPM+1)",
+        "log2(tpm+1)": "log2(TPM+1)",
+        "log2(tpm + 1)": "log2(TPM+1)",
+    }
+    coerced = aliases.get(normalized.lower(), normalized)
+    if coerced not in {"TPM", "FPKM", "RPKM", "log2(TPM+1)", "raw_counts"}:
+        raise ValueError(f"unsupported geo-matrix source unit: {unit!r}")
+    return coerced  # type: ignore[return-value]
+
+
+def geo_matrix_source_from_entry(entry: Mapping) -> GeoMatrixSource:
+    """Convert one registry YAML entry into an executable :class:`GeoMatrixSource`."""
+    if entry.get("source_type") != GEO_MATRIX_SOURCE_TYPE:
+        raise ValueError(
+            f"source {entry.get('id')!r} has source_type={entry.get('source_type')!r}, "
+            f"not {GEO_MATRIX_SOURCE_TYPE!r}"
+        )
+    cancer_codes = [str(code) for code in entry.get("cancer_codes", [])]
+    if not cancer_codes:
+        raise ValueError(f"source {entry.get('id')!r} has no cancer_codes")
+    cancer_code: str | list[str] = cancer_codes[0] if len(cancer_codes) == 1 else cancer_codes
+    return GeoMatrixSource(
+        cancer_code=cancer_code,
+        source_cohort=str(entry["source_cohort"]),
+        source_project=entry.get("source_project"),
+        citation=entry.get("citation"),
+        file_url=entry.get("file_url"),
+        file_name=str(entry["file_name"]),
+        unit=_coerce_source_expression_unit(str(entry["unit"])),
+        gene_id_col=str(entry.get("gene_id_col", "")),
+        symbol_col=entry.get("symbol_col"),
+        drop_cols=tuple(str(col) for col in entry.get("drop_cols", [])),
+        sep=str(entry.get("sep", "\t")),
+        transposed=bool(entry.get("transposed", False)),
+        sample_filter=_compile_sample_filter(entry.get("sample_filter")),
+        sample_to_cancer_code=_compile_sample_to_cancer_code(entry.get("sample_to_cancer_code")),
+        source_scale_class=entry.get("source_scale_class"),
+        linear_tpm_comparable=entry.get("linear_tpm_comparable"),
+        tpm_proxy=entry.get("tpm_proxy"),
+    )
+
+
+def geo_matrix_source_from_registry(
+    source_id: str,
+    registry_path: str | Path | None = None,
+) -> GeoMatrixSource:
+    """Load one ``source_type: geo-matrix`` entry from ``expression_sources.yaml``."""
+    for entry in _source_entries_from_registry(registry_path):
+        if entry.get("id") == source_id:
+            return geo_matrix_source_from_entry(entry)
+    raise KeyError(f"source id {source_id!r} not found in expression source registry")
 
 
 def _csv_engine(sep: str) -> str:

--- a/scripts/build_geo_matrix.py
+++ b/scripts/build_geo_matrix.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+"""Build a generic registry-backed GEO-style expression source matrix.
+
+This script is intentionally thin: source parsing, unit conversion, gene mapping,
+parse diagnostics, and sample QC live in :mod:`oncoref.expression_builders`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from oncoref.expression_builders import build_source_matrices, geo_matrix_source_from_registry
+
+
+def _load_gene_lengths_kb(path: str | Path | None) -> pd.Series | None:
+    if path is None:
+        return None
+    df = pd.read_csv(Path(path))
+    if df.empty:
+        raise SystemExit(f"gene-length table is empty: {path}")
+    by_lower = {str(col).lower(): col for col in df.columns}
+    id_col = (
+        by_lower.get("ensembl_gene_id")
+        or by_lower.get("gene_id")
+        or by_lower.get("source_row_id")
+        or df.columns[0]
+    )
+    if len(df.columns) < 2 and not any(
+        key in by_lower for key in ("length_kb", "gene_length_kb", "length")
+    ):
+        raise SystemExit(f"gene-length table must contain an id column and a length column: {path}")
+    length_col = (
+        by_lower.get("length_kb")
+        or by_lower.get("gene_length_kb")
+        or by_lower.get("length")
+        or df.columns[1]
+    )
+    lengths = pd.to_numeric(df[length_col], errors="coerce")
+    out = pd.Series(lengths.to_numpy(dtype=float), index=df[id_col].astype(str).to_numpy())
+    out = out[out.notna() & (out > 0)]
+    if out.empty:
+        raise SystemExit(f"gene-length table has no positive numeric lengths: {path}")
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source_id_arg", nargs="?", help="Source id from expression_sources.yaml")
+    parser.add_argument("--source-id", help="Source id from expression_sources.yaml")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Optional expression_sources.yaml path; defaults to the packaged registry.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Source-file cache directory. Defaults to ~/.cache/oncoref/expression/<source-id>/.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for per-code parquet matrices and sidecars. Defaults to cache_dir/derived.",
+    )
+    parser.add_argument(
+        "--source-path",
+        type=Path,
+        default=None,
+        help="Use an already-downloaded source matrix instead of registry file_url/cache lookup.",
+    )
+    parser.add_argument(
+        "--gene-lengths-kb",
+        type=Path,
+        default=None,
+        help=(
+            "CSV mapping source row ids to positive gene lengths in kb. Required for "
+            "unit=raw_counts sources."
+        ),
+    )
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    source_id = args.source_id or args.source_id_arg
+    if source_id is None:
+        raise SystemExit("provide --source-id <id>")
+
+    source = geo_matrix_source_from_registry(source_id, registry_path=args.registry)
+    if source.unit == "raw_counts" and args.gene_lengths_kb is None:
+        raise SystemExit("unit='raw_counts' sources require --gene-lengths-kb")
+
+    cache_dir = args.cache_dir or Path.home() / ".cache" / "oncoref" / "expression" / source_id
+    result = build_source_matrices(
+        source,
+        cache_dir=cache_dir,
+        output_dir=args.output_dir,
+        source_path=args.source_path,
+        force_download=args.force_download,
+        gene_lengths_kb=_load_gene_lengths_kb(args.gene_lengths_kb),
+        high_expression_threshold=args.high_expression_threshold,
+    )
+    summary = {
+        "source_id": source_id,
+        "source_cohort": source.source_cohort,
+        "matrix_paths": {code: str(path) for code, path in result.matrix_paths.items()},
+        "sidecar_paths": {name: str(path) for name, path in result.sidecar_paths.items()},
+        "sample_counts": {
+            code: len([c for c in matrix.columns if c not in {"Ensembl_Gene_ID", "Symbol"}])
+            for code, matrix in result.matrices.items()
+        },
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -150,6 +150,130 @@ def test_source_matrix_unit_helpers_validate_raw_counts_lengths():
         expression_builders.normalize_source_matrix_to_tpm(df, unit="raw_counts")
 
 
+def test_geo_matrix_source_from_entry_compiles_yaml_filters_and_routing():
+    source = expression_builders.geo_matrix_source_from_entry(
+        {
+            "id": "synthetic",
+            "source_type": "geo-matrix",
+            "cancer_codes": ["CODE_A", "CODE_B"],
+            "source_cohort": "SYNTHETIC",
+            "file_url": "https://example.org/source.tsv.gz",
+            "file_name": "source.tsv.gz",
+            "unit": "log2-TPM",
+            "gene_id_col": "",
+            "sample_filter": {"include_match": "tumor", "exclude_match": "bad"},
+            "sample_to_cancer_code": {
+                "rules": [
+                    {"match": "^tumor_a", "cancer_code": "CODE_A"},
+                    {"match": "^tumor_b", "cancer_code": "CODE_B"},
+                ]
+            },
+        }
+    )
+
+    assert source.cancer_code == ["CODE_A", "CODE_B"]
+    assert source.unit == "log2(TPM+1)"
+    assert source.sample_filter(["tumor_a1", "normal_a1", "tumor_bad", "tumor_b1"]) == [
+        "tumor_a1",
+        "tumor_b1",
+    ]
+    assert source.sample_to_cancer_code("tumor_a1") == "CODE_A"
+    assert source.sample_to_cancer_code("tumor_b1") == "CODE_B"
+    assert source.sample_to_cancer_code("normal_a1") is None
+
+
+def test_geo_matrix_source_from_registry_loads_packaged_geo_entry():
+    source = expression_builders.geo_matrix_source_from_registry("gse328026-sarc-pec")
+
+    assert source.cancer_code == "SARC_PEC"
+    assert source.source_cohort == "GSE328026_PECOMA_2026"
+    assert source.unit == "TPM"
+    assert source.file_name == "GSE328026_TPMs_all_Samples.txt.gz"
+
+
+def test_build_geo_matrix_script_uses_registry_config(tmp_path, capsys):
+    source_path = tmp_path / "source.tsv"
+    pd.DataFrame(
+        {
+            "gene": ["TP53", "EGFR"],
+            "tumor_a": ["1", "3"],
+            "normal_a": ["10", "10"],
+        }
+    ).to_csv(source_path, sep="\t", index=False)
+    registry_path = tmp_path / "expression_sources.yaml"
+    registry_path.write_text(
+        """
+sources:
+  - id: synthetic-geo
+    source_type: geo-matrix
+    cancer_codes: [CODE_A]
+    file_url: https://example.org/source.tsv.gz
+    file_name: source.tsv.gz
+    unit: TPM
+    gene_id_col: gene
+    source_cohort: SYNTHETIC_GEO
+    source_project: GEO
+    sample_filter:
+      include_match: "^tumor_"
+""".lstrip()
+    )
+    mod = _load_script("build_geo_matrix")
+
+    status = mod.main(
+        [
+            "--source-id",
+            "synthetic-geo",
+            "--registry",
+            str(registry_path),
+            "--cache-dir",
+            str(tmp_path / "cache"),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--source-path",
+            str(source_path),
+        ]
+    )
+
+    assert status == 0
+    out = pd.read_parquet(tmp_path / "out" / "CODE_A_per_sample_tpm.parquet")
+    assert list(out.columns) == ["Ensembl_Gene_ID", "Symbol", "tumor_a"]
+    assert set(out["Symbol"]) == {"TP53", "EGFR"}
+    assert np.isclose(out["tumor_a"].sum(), 1_000_000.0)
+    stdout = capsys.readouterr().out
+    assert '"sample_counts": {' in stdout
+    assert '"CODE_A": 1' in stdout
+
+
+def test_build_geo_matrix_script_requires_gene_lengths_for_raw_counts(tmp_path):
+    registry_path = tmp_path / "expression_sources.yaml"
+    registry_path.write_text(
+        """
+sources:
+  - id: synthetic-counts
+    source_type: geo-matrix
+    cancer_codes: [CODE_A]
+    file_url: https://example.org/source.tsv.gz
+    file_name: source.tsv.gz
+    unit: raw_counts
+    gene_id_col: gene
+    source_cohort: SYNTHETIC_COUNTS
+""".lstrip()
+    )
+    mod = _load_script("build_geo_matrix")
+
+    with pytest.raises(SystemExit, match="raw_counts"):
+        mod.main(
+            [
+                "--source-id",
+                "synthetic-counts",
+                "--registry",
+                str(registry_path),
+                "--cache-dir",
+                str(tmp_path / "cache"),
+            ]
+        )
+
+
 # ---------- cohort_percentile_vectors ----------
 
 


### PR DESCRIPTION
## Summary

Refs #296. This is the next ingestion-takeover slice after the generic source-matrix core: it makes existing `source_type: geo-matrix` entries in `expression_sources.yaml` executable from oncoref instead of requiring pirlygenes-local registry glue.

- add `geo_matrix_source_entries`, `geo_matrix_source_from_entry`, and `geo_matrix_source_from_registry` to `oncoref.expression_builders`
- compile YAML sample filters and sample-to-cancer-code routing into `GeoMatrixSource` callbacks
- add `scripts/build_geo_matrix.py` as a thin registry-backed CLI over `build_source_matrices`
- keep raw-count builds explicit about gene-length inputs via `--gene-lengths-kb`
- document the registry-backed builder path

This does not close #296 yet: source-specific builders still need to move into `oncoref.expression_builders` one at a time.

## Verification

- `python -m pytest tests/test_build_generators.py -q`
- `python -m pytest tests/test_expression_engine.py tests/test_source_matrices.py tests/test_expression.py tests/test_api_structure.py -q`
- `./lint.sh`
