### PR TITLE
Add recount3 source matrix builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
   `oncoref.expression_builders` for source-matrix ingestion into canonical
   per-code per-sample TPM parquet plus mapping/parse/QC sidecars. Generic
   `source_type: geo-matrix` entries in `expression_sources.yaml` are executable
-  via `scripts/build_geo_matrix.py`; downstream packages should read the bundled
-  source registry through `expression_source_registry_entries()` rather than
-  shipping a second YAML copy.
+  via `scripts/build_geo_matrix.py`, and `source_type: recount3` entries via
+  `scripts/build_recount3_source.py`; downstream packages should read the
+  bundled source registry through `expression_source_registry_entries()` rather
+  than shipping a second YAML copy.
 - **Clean TPM / normalization** — `oncoref.normalization` for the 16/9/75
   compartment transform and `oncoref.gene_families` for clean-TPM censored
   compartment IDs plus the biological housekeeping denominator panel.

--- a/docs/api.md
+++ b/docs/api.md
@@ -212,7 +212,11 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   source file to canonical per-code per-sample TPM parquet, mapping audit, parse
   diagnostics, and sample-QC sidecars. `geo_matrix_source_from_registry` and
   `scripts/build_geo_matrix.py` make `source_type: geo-matrix` entries in the
-  packaged source registry directly buildable. `scripts/rebuild_expression_artifacts.py`
+  packaged source registry directly buildable. `Recount3Source`,
+  `recount3_gene_sums_to_tpm`, `build_recount3_source_matrices`, and
+  `scripts/build_recount3_source.py` do the same for `source_type: recount3`
+  entries, including run-to-sample aggregation and metadata-based routing before
+  writing the standard source-matrix artifact set. `scripts/rebuild_expression_artifacts.py`
   then applies the same sample-QC policy to derived shards by default
   (`--sample-qc pass`) and emits `source-matrix-sample-qc.csv` plus
   `expression-artifact-build-metadata.*` in the staging directory so bundle

--- a/oncoref/data/expression_sources.yaml
+++ b/oncoref/data/expression_sources.yaml
@@ -110,6 +110,8 @@ sources:
     source_type: recount3
     accession: GSE114922
     recount3_srp: SRP149374
+    recount3_route: mds_cd34
+    expected_samples_by_code: {MDS: 82}
     source_cohort: GSE114922_SHIOZAWA_2018
     builder: scripts/build_recount3_source.py
     unit: recount3 Gencode-v26 coverage gene-sums
@@ -249,6 +251,8 @@ sources:
     source_type: recount3
     accession: GSE118014
     recount3_srp: SRP156049
+    recount3_route: all
+    expected_samples_by_code: {NET_PANCREAS: 33}
     source_cohort: GSE118014_ALVAREZ_2018
     builder: scripts/build_recount3_source.py
     unit: recount3 Gencode-v26 coverage gene-sums
@@ -700,6 +704,8 @@ sources:
     source_type: recount3
     accession: GSE120328
     recount3_srp: SRP162356
+    recount3_route: hl_tumor_title
+    expected_samples_by_code: {HL: 5}
     source_cohort: GSE120328_LAMPRECHT_2018
     source_project: GEO
     builder: scripts/build_recount3_source.py
@@ -895,6 +901,8 @@ sources:
     source_type: recount3
     accession: GSE98894
     recount3_srp: SRP107025
+    recount3_route: net_origin
+    expected_samples_by_code: {NET_MIDGUT: 81, NET_PANCREAS: 113, NET_RECTAL: 18}
     source_cohort: GSE98894_ALVAREZ_2018_NET
     builder: scripts/build_recount3_source.py
     unit: recount3 Gencode-v26 coverage gene-sums

--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -37,11 +37,13 @@ referenced and documented as the public build-time API.
 
 from __future__ import annotations
 
+import gzip
 import re
 import shutil
 import urllib.request
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Callable, Literal
 
@@ -55,9 +57,16 @@ from .expression_engine import (
     id_columns,
     sample_columns,
 )
+from .gene_ids import unversioned
 
 SourceExpressionUnit = Literal["TPM", "FPKM", "RPKM", "log2(TPM+1)", "raw_counts"]
 GEO_MATRIX_SOURCE_TYPE = "geo-matrix"
+RECOUNT3_SOURCE_TYPE = "recount3"
+RECOUNT3_ANNOTATION = "G026"  # recount3 Gencode v26 gene summaries
+_RECOUNT3_S3_BASE = "https://recount-opendata.s3.amazonaws.com/recount3/release/human"
+_RECOUNT3_ANNOTATION_GTF = (
+    f"{_RECOUNT3_S3_BASE}/annotations/gene_sums/human.gene_sums.{RECOUNT3_ANNOTATION}.gtf.gz"
+)
 
 _SOURCE_SYMBOL_COLUMN_CANDIDATES = (
     "Symbol",
@@ -143,10 +152,24 @@ class GeoMatrixSource:
 
 
 @dataclass(frozen=True)
+class Recount3Source:
+    """One recount3 study routed into one or more oncoref cancer codes."""
+
+    source_id: str
+    srp: str
+    source_cohort: str
+    cancer_code: str | list[str]
+    source_project: str | None = None
+    citation: str | None = None
+    sample_to_cancer_code: Callable[[dict[str, str], str], str | None] | None = None
+    expected_n: Mapping[str, int] | None = None
+
+
+@dataclass(frozen=True)
 class SourceMatrixBuildResult:
     """Artifacts produced by :func:`build_source_matrices`."""
 
-    source: GeoMatrixSource
+    source: GeoMatrixSource | Recount3Source
     matrices: dict[str, pd.DataFrame]
     matrix_paths: dict[str, Path]
     mapping_audit: pd.DataFrame
@@ -282,6 +305,94 @@ def geo_matrix_source_from_registry(
     for entry in _source_entries_from_registry(registry_path):
         if entry.get("id") == source_id:
             return geo_matrix_source_from_entry(entry)
+    raise KeyError(f"source id {source_id!r} not found in expression source registry")
+
+
+def recount3_source_entries(registry_path: str | Path | None = None) -> list[dict]:
+    """Raw ``source_type: recount3`` entries from ``expression_sources.yaml``."""
+    return [
+        entry
+        for entry in _source_entries_from_registry(registry_path)
+        if entry.get("source_type") == RECOUNT3_SOURCE_TYPE
+    ]
+
+
+def _net_origin_recount3_route(attrs: dict[str, str], _title: str) -> str | None:
+    origin = attrs.get("origin", "").lower()
+    for needle, code in (
+        ("small intest", "NET_MIDGUT"),
+        ("ileum", "NET_MIDGUT"),
+        ("jejunum", "NET_MIDGUT"),
+        ("duodenum", "NET_MIDGUT"),
+        ("pancrea", "NET_PANCREAS"),
+        ("rect", "NET_RECTAL"),
+    ):
+        if needle in origin:
+            return code
+    return None
+
+
+def _compile_recount3_sample_route(
+    route_name: str | None,
+    cancer_code: str | list[str],
+) -> Callable[[dict[str, str], str], str | None]:
+    codes = [cancer_code] if isinstance(cancer_code, str) else list(cancer_code)
+
+    if route_name in {None, "", "all"}:
+        if len(codes) != 1:
+            raise ValueError("recount3 route='all' requires exactly one cancer code")
+        code = str(codes[0])
+        return lambda _attrs, _title: code
+    if route_name == "mds_cd34":
+        return lambda attrs, _title: (
+            "MDS"
+            if (
+                attrs.get("cell type", "").startswith("CD34+")
+                and attrs.get("disease status") == "Myelodysplastic Syndrome"
+            )
+            else None
+        )
+    if route_name == "hl_tumor_title":
+        return lambda _attrs, title: "HL" if str(title).endswith("_TU") else None
+    if route_name == "net_origin":
+        return _net_origin_recount3_route
+    raise ValueError(f"unsupported recount3 route {route_name!r}")
+
+
+def recount3_source_from_entry(entry: Mapping) -> Recount3Source:
+    """Convert one registry YAML entry into an executable :class:`Recount3Source`."""
+    if entry.get("source_type") != RECOUNT3_SOURCE_TYPE:
+        raise ValueError(
+            f"source {entry.get('id')!r} has source_type={entry.get('source_type')!r}, "
+            f"not {RECOUNT3_SOURCE_TYPE!r}"
+        )
+    cancer_codes = [str(code) for code in entry.get("cancer_codes", [])]
+    if not cancer_codes:
+        raise ValueError(f"source {entry.get('id')!r} has no cancer_codes")
+    cancer_code: str | list[str] = cancer_codes[0] if len(cancer_codes) == 1 else cancer_codes
+    route = _compile_recount3_sample_route(entry.get("recount3_route"), cancer_code)
+    expected_raw = entry.get("expected_samples_by_code") or {}
+    expected = {str(code): int(n) for code, n in dict(expected_raw).items()}
+    return Recount3Source(
+        source_id=str(entry["id"]),
+        srp=str(entry["recount3_srp"]),
+        source_cohort=str(entry["source_cohort"]),
+        cancer_code=cancer_code,
+        source_project=entry.get("source_project") or entry.get("accession"),
+        citation=entry.get("citation"),
+        sample_to_cancer_code=route,
+        expected_n=expected,
+    )
+
+
+def recount3_source_from_registry(
+    source_id: str,
+    registry_path: str | Path | None = None,
+) -> Recount3Source:
+    """Load one ``source_type: recount3`` entry from ``expression_sources.yaml``."""
+    for entry in _source_entries_from_registry(registry_path):
+        if entry.get("id") == source_id:
+            return recount3_source_from_entry(entry)
     raise KeyError(f"source id {source_id!r} not found in expression source registry")
 
 
@@ -497,6 +608,158 @@ def _download(url: str, dest: Path, *, force: bool = False) -> Path:
     return dest
 
 
+def recount3_gene_sums_url(srp: str) -> str:
+    """S3 URL of the recount3 SRA gene-sums matrix for one study accession."""
+    return (
+        f"{_RECOUNT3_S3_BASE}/data_sources/sra/gene_sums/{srp[-2:]}/{srp}/"
+        f"sra.gene_sums.{srp}.{RECOUNT3_ANNOTATION}.gz"
+    )
+
+
+def recount3_metadata_url(srp: str, kind: str = "sra") -> str:
+    """S3 URL of a recount3 SRA metadata table for one study accession."""
+    return f"{_RECOUNT3_S3_BASE}/data_sources/sra/metadata/{srp[-2:]}/{srp}/sra.{kind}.{srp}.MD.gz"
+
+
+def _recount3_gene_id(value: str) -> str:
+    text = str(value).strip()
+    if text.endswith("_PAR_Y"):
+        text = text[: -len("_PAR_Y")]
+    return unversioned(text)
+
+
+@lru_cache(maxsize=2)
+def fetch_recount3_gene_annotation(
+    cache_dir: str | Path,
+    *,
+    force_download: bool = False,
+) -> pd.DataFrame:
+    """Gencode-v26 recount3 gene annotation indexed by unversioned Ensembl ID.
+
+    The recount3 gene-sums GTF stores the exonic disjoint-base length in the
+    score column. That length is the denominator used by
+    :func:`recount3_gene_sums_to_tpm`.
+    """
+    cache = Path(cache_dir)
+    path = _download(
+        _RECOUNT3_ANNOTATION_GTF,
+        cache / f"human.gene_sums.{RECOUNT3_ANNOTATION}.gtf.gz",
+        force=force_download,
+    )
+    rows: list[tuple[str, int, str]] = []
+    name_re = re.compile(r'gene_id "([^"]+)".*?gene_name "([^"]+)"')
+    with gzip.open(path, "rt") as handle:
+        for line in handle:
+            if line.startswith("#"):
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 9 or fields[2] != "gene":
+                continue
+            match = name_re.search(fields[8])
+            if match is None:
+                continue
+            rows.append((_recount3_gene_id(match.group(1)), int(float(fields[5])), match.group(2)))
+    ann = pd.DataFrame(rows, columns=["Ensembl_Gene_ID", "bp_length", "Symbol"])
+    ann = ann.groupby("Ensembl_Gene_ID", as_index=False).agg(
+        bp_length=("bp_length", "sum"),
+        Symbol=("Symbol", "first"),
+    )
+    return ann.set_index("Ensembl_Gene_ID")
+
+
+def fetch_recount3_gene_sums(
+    srp: str,
+    cache_dir: str | Path,
+    *,
+    force_download: bool = False,
+) -> pd.DataFrame:
+    """recount3 gene-sums matrix: rows are versioned Gencode IDs, columns are runs."""
+    cache = Path(cache_dir)
+    path = _download(
+        recount3_gene_sums_url(srp),
+        cache / f"sra.gene_sums.{srp}.{RECOUNT3_ANNOTATION}.gz",
+        force=force_download,
+    )
+    return pd.read_csv(path, sep="\t", comment="#", index_col=0)
+
+
+def fetch_recount3_sample_metadata(
+    srp: str,
+    cache_dir: str | Path,
+    *,
+    force_download: bool = False,
+) -> pd.DataFrame:
+    """recount3 ``sra`` metadata table for one study accession."""
+    cache = Path(cache_dir)
+    path = _download(
+        recount3_metadata_url(srp),
+        cache / f"sra.sra.{srp}.MD.gz",
+        force=force_download,
+    )
+    return pd.read_csv(path, sep="\t", comment="#", low_memory=False)
+
+
+def recount3_gene_sums_to_tpm(
+    gene_sums: pd.DataFrame,
+    bp_length: pd.Series,
+) -> pd.DataFrame:
+    """Length-normalize recount3 coverage gene-sums to per-sample TPM.
+
+    recount3 gene-sums are coverage area over exonic bases, so this divides by
+    recount3's exonic ``bp_length`` and then renormalizes each sample to one
+    million. Version and ``_PAR_Y`` duplicates are collapsed before normalization.
+    """
+    gs = gene_sums.copy()
+    gs.index = [_recount3_gene_id(idx) for idx in gs.index]
+    gs = gs.groupby(level=0).sum()
+    lengths_kb = (pd.Series(bp_length, dtype=float) / 1000.0).rename("gene_length_kb")
+    frame = gs.reset_index().rename(columns={"index": "Ensembl_Gene_ID"})
+    tpm = normalize_source_matrix_to_tpm(
+        frame,
+        unit="raw_counts",
+        row_id_col="Ensembl_Gene_ID",
+        value_cols=list(gs.columns),
+        gene_lengths_kb=lengths_kb,
+    )
+    return tpm.set_index("Ensembl_Gene_ID")[list(gs.columns)]
+
+
+def parse_recount3_sample_attributes(packed: str) -> dict[str, str]:
+    """Unpack recount3's ``key;;value|key;;value`` sample attribute field."""
+    out: dict[str, str] = {}
+    for item in str(packed).split("|"):
+        if ";;" not in item:
+            continue
+        key, value = item.split(";;", 1)
+        out[key.strip()] = value.strip()
+    return out
+
+
+def aggregate_recount3_runs_to_samples(
+    gene_sums: pd.DataFrame,
+    metadata: pd.DataFrame,
+    *,
+    keep_runs: set[str] | None = None,
+    run_col: str = "external_id",
+    sample_col: str = "sample_acc",
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Sum recount3 run-level coverage columns into biological samples."""
+    meta = metadata.copy()
+    meta[run_col] = meta[run_col].astype(str)
+    runs = [col for col in gene_sums.columns if col in set(meta[run_col])]
+    if keep_runs is not None:
+        runs = [run for run in runs if run in keep_runs]
+    meta = meta[meta[run_col].isin(runs)].copy()
+    run_to_sample = dict(zip(meta[run_col], meta[sample_col].astype(str)))
+    sample_gene_sums = gene_sums[runs].copy()
+    sample_gene_sums.columns = [run_to_sample[col] for col in sample_gene_sums.columns]
+    sample_gene_sums = sample_gene_sums.T.groupby(level=0).sum().T
+    sample_meta = meta.drop_duplicates(sample_col).copy()
+    sample_meta[sample_col] = sample_meta[sample_col].astype(str)
+    sample_meta = sample_meta.set_index(sample_col).reindex(sample_gene_sums.columns)
+    return sample_gene_sums, sample_meta
+
+
 def _artifact_stem(value: str) -> str:
     return "".join(c if c.isalnum() or c in "._-" else "_" for c in value)
 
@@ -640,6 +903,159 @@ def build_source_matrices(
 
     if not matrices:
         raise ValueError("no samples were routed to a cancer code")
+    sample_qc = pd.concat(qc_frames, ignore_index=True) if qc_frames else pd.DataFrame()
+    return SourceMatrixBuildResult(
+        source=source,
+        matrices=matrices,
+        matrix_paths=matrix_paths,
+        mapping_audit=audit,
+        parse_diagnostics=parse_diagnostics,
+        sample_qc=sample_qc,
+        sidecar_paths=sidecar_paths,
+    )
+
+
+def build_recount3_source_matrices(
+    source: Recount3Source,
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    force_download: bool = False,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build oncoref source-matrix artifacts for one recount3 study.
+
+    recount3 inputs are run-level coverage gene-sums, not ordinary expression
+    matrices. This builder fetches annotation, gene sums, and SRA metadata,
+    routes runs by source-specific metadata rules, sums runs into biological
+    samples, converts coverage gene-sums to TPM, canonicalizes genes, and writes
+    the same per-code parquet + audit/QC sidecars as :func:`build_source_matrices`.
+    """
+    cache = Path(cache_dir)
+    out_dir = Path(output_dir) if output_dir is not None else cache / "derived"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if force_download:
+        annotation = fetch_recount3_gene_annotation(cache, force_download=True)
+        gene_sums = fetch_recount3_gene_sums(source.srp, cache, force_download=True)
+        metadata = fetch_recount3_sample_metadata(source.srp, cache, force_download=True)
+    else:
+        annotation = fetch_recount3_gene_annotation(cache)
+        gene_sums = fetch_recount3_gene_sums(source.srp, cache)
+        metadata = fetch_recount3_sample_metadata(source.srp, cache)
+    route = source.sample_to_cancer_code
+    if route is None:
+        route = _compile_recount3_sample_route(None, source.cancer_code)
+
+    if "external_id" not in metadata.columns or "sample_acc" not in metadata.columns:
+        raise ValueError("recount3 metadata must include external_id and sample_acc columns")
+    attr_values = (
+        metadata["sample_attributes"]
+        if "sample_attributes" in metadata.columns
+        else pd.Series([""] * len(metadata), index=metadata.index)
+    )
+    title_values = (
+        metadata["sample_title"]
+        if "sample_title" in metadata.columns
+        else pd.Series([""] * len(metadata), index=metadata.index)
+    )
+    attrs = {
+        str(run): parse_recount3_sample_attributes(raw)
+        for run, raw in zip(metadata["external_id"], attr_values)
+    }
+    titles = dict(zip(metadata["external_id"].astype(str), title_values))
+    run_code = {run: route(attrs.get(run, {}), str(titles.get(run, ""))) for run in attrs}
+    keep_runs = {run for run, code in run_code.items() if code is not None}
+    if not keep_runs:
+        raise ValueError(f"no recount3 runs routed for source {source.source_id!r}")
+
+    sample_gene_sums, sample_meta = aggregate_recount3_runs_to_samples(
+        gene_sums,
+        metadata,
+        keep_runs=keep_runs,
+    )
+    sample_code: dict[str, str] = {}
+    for sample_id, row in sample_meta.iterrows():
+        code = run_code.get(str(row["external_id"]))
+        if code is not None:
+            sample_code[str(sample_id)] = str(code)
+    counts = pd.Series(list(sample_code.values()), dtype="object").value_counts().to_dict()
+    for code, expected in (source.expected_n or {}).items():
+        got = int(counts.get(code, 0))
+        if got != int(expected):
+            raise ValueError(f"{source.source_id} routed {code} n={got}; expected {expected}")
+
+    tpm = recount3_gene_sums_to_tpm(sample_gene_sums, annotation["bp_length"])
+    symbol = annotation["Symbol"].reindex(tpm.index).fillna(pd.Series(tpm.index, index=tpm.index))
+    tpm_frame = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": tpm.index.astype(str),
+            "Symbol": symbol.to_numpy(),
+        }
+    )
+    for col in tpm.columns:
+        tpm_frame[str(col)] = tpm[col].to_numpy(dtype=float)
+
+    value_cols = [str(col) for col in tpm.columns]
+    _, parse_diagnostics = coerce_source_expression_values(
+        tpm_frame,
+        value_cols=value_cols,
+        row_id_col="Ensembl_Gene_ID",
+        symbol_col="Symbol",
+    )
+    matrix, audit = canonicalize_source_gene_matrix(
+        tpm_frame,
+        row_id_col="Ensembl_Gene_ID",
+        symbol_col="Symbol",
+        value_cols=value_cols,
+        high_expression_threshold=high_expression_threshold,
+    )
+    matrix.attrs["source_value_parse_diagnostics"] = parse_diagnostics
+
+    stem = _artifact_stem(source.source_cohort)
+    sidecar_paths: dict[str, Path] = {}
+    audit_path = out_dir / f"{stem}_mapping_audit.csv"
+    parse_path = out_dir / f"{stem}_parse_diagnostics.csv"
+    audit.to_csv(audit_path, index=False)
+    parse_diagnostics.to_csv(parse_path, index=False)
+    sidecar_paths["mapping_audit"] = audit_path
+    sidecar_paths["parse_diagnostics"] = parse_path
+
+    meta = source_metadata(
+        source_cohort=source.source_cohort,
+        source_type=RECOUNT3_SOURCE_TYPE,
+        unit="recount3 gene_sums to TPM",
+        source_scale_class="linear_rnaseq_tpm",
+        linear_tpm_comparable=True,
+        tpm_proxy=False,
+    )
+
+    from .expression import sample_expression_qc_from_matrix
+
+    matrices: dict[str, pd.DataFrame] = {}
+    matrix_paths: dict[str, Path] = {}
+    qc_frames: list[pd.DataFrame] = []
+    for code, cols in split_source_matrix_by_code(
+        matrix,
+        source.cancer_code,
+        sample_to_cancer_code=lambda sample: sample_code.get(str(sample)),
+    ).items():
+        if not cols:
+            continue
+        sub = matrix[[*id_columns(matrix), *cols]].copy()
+        sub.attrs = {}
+        path = out_dir / f"{_artifact_stem(code)}_per_sample_tpm.parquet"
+        sub.to_parquet(path, index=False)
+        qc = sample_expression_qc_from_matrix(sub, cancer_type=code, source_metadata=meta)
+        qc_path = out_dir / f"{_artifact_stem(code)}_sample_qc.csv"
+        qc.to_csv(qc_path, index=False)
+        matrices[code] = sub
+        matrix_paths[code] = path
+        sidecar_paths[f"{code}_sample_qc"] = qc_path
+        qc_frames.append(qc)
+
+    if not matrices:
+        raise ValueError("no recount3 samples were routed to a cancer code")
     sample_qc = pd.concat(qc_frames, ignore_index=True) if qc_frames else pd.DataFrame()
     return SourceMatrixBuildResult(
         source=source,

--- a/scripts/build_recount3_source.py
+++ b/scripts/build_recount3_source.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+"""Build a registry-backed recount3 expression source matrix.
+
+This script is intentionally thin: recount3 URL resolution, metadata routing,
+run aggregation, gene-sums-to-TPM conversion, gene mapping, parse diagnostics,
+and sample QC live in :mod:`oncoref.expression_builders`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from oncoref.expression_builders import (
+    build_recount3_source_matrices,
+    recount3_source_from_registry,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source_id_arg", nargs="?", help="Source id from expression_sources.yaml")
+    parser.add_argument("--source-id", help="Source id from expression_sources.yaml")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Optional expression_sources.yaml path; defaults to the packaged registry.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="recount3 cache directory. Defaults to ~/.cache/oncoref/expression/<source-id>/.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for per-code parquet matrices and sidecars. Defaults to cache_dir/derived.",
+    )
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    source_id = args.source_id or args.source_id_arg
+    if source_id is None:
+        raise SystemExit("provide --source-id <id>")
+
+    source = recount3_source_from_registry(source_id, registry_path=args.registry)
+    cache_dir = args.cache_dir or Path.home() / ".cache" / "oncoref" / "expression" / source_id
+    result = build_recount3_source_matrices(
+        source,
+        cache_dir=cache_dir,
+        output_dir=args.output_dir,
+        force_download=args.force_download,
+        high_expression_threshold=args.high_expression_threshold,
+    )
+    summary = {
+        "source_id": source_id,
+        "source_cohort": source.source_cohort,
+        "matrix_paths": {code: str(path) for code, path in result.matrix_paths.items()},
+        "sidecar_paths": {name: str(path) for name, path in result.sidecar_paths.items()},
+        "sample_counts": {
+            code: len([c for c in matrix.columns if c not in {"Ensembl_Gene_ID", "Symbol"}])
+            for code, matrix in result.matrices.items()
+        },
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -191,6 +191,146 @@ def test_geo_matrix_source_from_registry_loads_packaged_geo_entry():
     assert source.file_name == "GSE328026_TPMs_all_Samples.txt.gz"
 
 
+def test_recount3_source_from_registry_loads_packaged_routes():
+    source = expression_builders.recount3_source_from_registry("gse98894-midnet")
+
+    assert source.source_id == "gse98894-midnet"
+    assert source.srp == "SRP107025"
+    assert source.cancer_code == ["NET_MIDGUT", "NET_PANCREAS", "NET_RECTAL"]
+    assert source.expected_n == {"NET_MIDGUT": 81, "NET_PANCREAS": 113, "NET_RECTAL": 18}
+    assert source.sample_to_cancer_code({"origin": "ileum"}, "") == "NET_MIDGUT"
+    assert source.sample_to_cancer_code({"origin": "pancreas"}, "") == "NET_PANCREAS"
+    assert source.sample_to_cancer_code({"origin": "rectal"}, "") == "NET_RECTAL"
+    assert source.sample_to_cancer_code({"origin": "lung"}, "") is None
+
+
+def test_recount3_gene_sums_to_tpm_length_normalizes_and_collapses_versions():
+    gene_sums = pd.DataFrame(
+        {"S1": [1000.0, 1000.0], "S2": [0.0, 500.0]},
+        index=["ENSG00000000001.5", "ENSG00000000002.3"],
+    )
+    bp_length = pd.Series({"ENSG00000000001": 1000.0, "ENSG00000000002": 2000.0})
+
+    tpm = expression_builders.recount3_gene_sums_to_tpm(gene_sums, bp_length)
+
+    np.testing.assert_allclose(tpm.sum(axis=0).to_numpy(), [1e6, 1e6])
+    np.testing.assert_allclose(tpm["S1"].to_numpy(), [2e6 / 3, 1e6 / 3], rtol=1e-9)
+    np.testing.assert_allclose(tpm["S2"].to_numpy(), [0.0, 1e6])
+
+    dup = pd.DataFrame(
+        {"S1": [600.0, 400.0]},
+        index=["ENSG00000000003.1", "ENSG00000000003.1_PAR_Y"],
+    )
+    collapsed = expression_builders.recount3_gene_sums_to_tpm(
+        dup,
+        pd.Series({"ENSG00000000003": 1000.0}),
+    )
+    assert collapsed.index.tolist() == ["ENSG00000000003"]
+    np.testing.assert_allclose(collapsed["S1"].to_numpy(), [1e6])
+
+
+def test_recount3_parse_attributes_and_aggregate_runs_to_samples():
+    attrs = expression_builders.parse_recount3_sample_attributes(
+        "origin;;pancreas|type;;liver metastasis|n;;1"
+    )
+    assert attrs == {"origin": "pancreas", "type": "liver metastasis", "n": "1"}
+    assert expression_builders.parse_recount3_sample_attributes("") == {}
+
+    gene_sums = pd.DataFrame(
+        {"R1": [10.0, 1.0], "R2": [20.0, 3.0], "R3": [5.0, 5.0], "R4": [99.0, 99.0]},
+        index=["g1", "g2"],
+    )
+    meta = pd.DataFrame(
+        {
+            "external_id": ["R1", "R2", "R3", "R4"],
+            "sample_acc": ["A", "A", "B", "C"],
+        }
+    )
+
+    sample_gs, sample_meta = expression_builders.aggregate_recount3_runs_to_samples(
+        gene_sums,
+        meta,
+        keep_runs={"R1", "R2", "R3"},
+    )
+
+    assert set(sample_gs.columns) == {"A", "B"}
+    np.testing.assert_allclose(sample_gs.loc["g1", "A"], 30.0)
+    np.testing.assert_allclose(sample_gs.loc["g2", "A"], 4.0)
+    np.testing.assert_allclose(sample_gs.loc["g1", "B"], 5.0)
+    assert list(sample_meta.index) == list(sample_gs.columns)
+
+
+def test_build_recount3_source_matrices_writes_canonical_artifacts(tmp_path, monkeypatch):
+    annotation = pd.DataFrame(
+        {
+            "bp_length": [1000.0, 2000.0],
+            "Symbol": ["TP53", "EGFR"],
+        },
+        index=["ENSG00000141510", "ENSG00000146648"],
+    )
+    gene_sums = pd.DataFrame(
+        {
+            "R1": [100.0, 50.0],
+            "R2": [50.0, 25.0],
+            "R3": [0.0, 80.0],
+            "R4": [999.0, 999.0],
+        },
+        index=["ENSG00000141510.1", "ENSG00000146648.2"],
+    )
+    metadata = pd.DataFrame(
+        {
+            "external_id": ["R1", "R2", "R3", "R4"],
+            "sample_acc": ["SAMPLE_A", "SAMPLE_A", "SAMPLE_B", "CONTROL"],
+            "sample_attributes": [
+                "code;;CODE_A",
+                "code;;CODE_A",
+                "code;;CODE_B",
+                "code;;CONTROL",
+            ],
+            "sample_title": ["A1", "A2", "B1", "C1"],
+        }
+    )
+    monkeypatch.setattr(
+        expression_builders,
+        "fetch_recount3_gene_annotation",
+        lambda _cache: annotation,
+    )
+    monkeypatch.setattr(
+        expression_builders,
+        "fetch_recount3_gene_sums",
+        lambda _srp, _cache: gene_sums,
+    )
+    monkeypatch.setattr(
+        expression_builders,
+        "fetch_recount3_sample_metadata",
+        lambda _srp, _cache: metadata,
+    )
+    source = expression_builders.Recount3Source(
+        source_id="synthetic-recount3",
+        srp="SRP000000",
+        source_cohort="SYNTHETIC_RECOUNT3",
+        cancer_code=["CODE_A", "CODE_B"],
+        sample_to_cancer_code=lambda attrs, _title: (
+            attrs.get("code") if attrs.get("code") != "CONTROL" else None
+        ),
+        expected_n={"CODE_A": 1, "CODE_B": 1},
+    )
+
+    result = expression_builders.build_recount3_source_matrices(source, cache_dir=tmp_path)
+
+    assert set(result.matrix_paths) == {"CODE_A", "CODE_B"}
+    assert result.sidecar_paths["mapping_audit"].exists()
+    assert result.sidecar_paths["parse_diagnostics"].exists()
+    code_a = pd.read_parquet(result.matrix_paths["CODE_A"])
+    code_b = pd.read_parquet(result.matrix_paths["CODE_B"])
+    assert list(code_a.columns) == ["Ensembl_Gene_ID", "Symbol", "SAMPLE_A"]
+    assert list(code_b.columns) == ["Ensembl_Gene_ID", "Symbol", "SAMPLE_B"]
+    assert set(code_a["Ensembl_Gene_ID"]) == {"ENSG00000141510", "ENSG00000146648"}
+    assert np.isclose(code_a["SAMPLE_A"].sum(), 1_000_000.0)
+    assert np.isclose(code_b["SAMPLE_B"].sum(), 1_000_000.0)
+    assert set(result.sample_qc["cancer_code"]) == {"CODE_A", "CODE_B"}
+
+
 def test_build_geo_matrix_script_uses_registry_config(tmp_path, capsys):
     source_path = tmp_path / "source.tsv"
     pd.DataFrame(
@@ -241,6 +381,49 @@ sources:
     assert np.isclose(out["tumor_a"].sum(), 1_000_000.0)
     stdout = capsys.readouterr().out
     assert '"sample_counts": {' in stdout
+    assert '"CODE_A": 1' in stdout
+
+
+def test_build_recount3_script_uses_registry_config(tmp_path, monkeypatch, capsys):
+    mod = _load_script("build_recount3_source")
+    source = expression_builders.Recount3Source(
+        source_id="synthetic-recount3",
+        srp="SRP000000",
+        source_cohort="SYNTHETIC_RECOUNT3",
+        cancer_code="CODE_A",
+    )
+
+    def _fake_build(source_obj, *, cache_dir, output_dir=None, **_kwargs):
+        assert source_obj is source
+        assert Path(cache_dir) == tmp_path / "cache"
+        assert output_dir is None
+        matrix = pd.DataFrame(
+            {
+                "Ensembl_Gene_ID": ["ENSG00000141510"],
+                "Symbol": ["TP53"],
+                "S1": [1_000_000.0],
+            }
+        )
+        return expression_builders.SourceMatrixBuildResult(
+            source=source,
+            matrices={"CODE_A": matrix},
+            matrix_paths={"CODE_A": tmp_path / "CODE_A_per_sample_tpm.parquet"},
+            mapping_audit=pd.DataFrame(),
+            parse_diagnostics=pd.DataFrame(),
+            sample_qc=pd.DataFrame(),
+            sidecar_paths={"mapping_audit": tmp_path / "mapping_audit.csv"},
+        )
+
+    monkeypatch.setattr(
+        mod,
+        "recount3_source_from_registry",
+        lambda source_id, registry_path=None: source,
+    )
+    monkeypatch.setattr(mod, "build_recount3_source_matrices", _fake_build)
+
+    assert mod.main(["synthetic-recount3", "--cache-dir", str(tmp_path / "cache")]) == 0
+    stdout = capsys.readouterr().out
+    assert '"source_id": "synthetic-recount3"' in stdout
     assert '"CODE_A": 1' in stdout
 
 


### PR DESCRIPTION
## Summary

- add `Recount3Source` plus recount3 URL, metadata, run aggregation, and gene-sums-to-TPM helpers to `oncoref.expression_builders`
- add `build_recount3_source_matrices()` to emit the same per-code source-matrix parquet, mapping-audit, parse-diagnostic, and sample-QC sidecars as the generic GEO builder
- make packaged `source_type: recount3` registry entries executable with explicit routing keys and expected sample-count guards
- add `scripts/build_recount3_source.py` as the thin registry-backed CLI
- document the new source-family builder in README/API docs

Refs #296. This moves the recount3 source-family slice of pirlygenes' ingestion fleet into oncoref; Treehouse/GDC/remaining source-specific builders stay under #296 for follow-up PRs.

## Verification

- `./lint.sh`
- `python -m pytest tests/test_build_generators.py tests/test_expression_sources.py tests/test_api_structure.py -q`
- `./test.sh` (`681 passed`, one existing matplotlib open-figure warning)
