### PR TITLE
Carry expression source summary provenance

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -212,7 +212,12 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   source file to canonical per-code per-sample TPM parquet, mapping audit, parse
   diagnostics, and sample-QC sidecars. `geo_matrix_source_from_registry` and
   `scripts/build_geo_matrix.py` make `source_type: geo-matrix` entries in the
-  packaged source registry directly buildable. `Recount3Source`,
+  packaged source registry directly buildable; `GeoMatrixSource` also preserves
+  summary-row provenance (`notes`, `pipeline_stem`, `tumor_origin`,
+  `metastasis_site`) so downstream shard writers do not need a parallel source
+  registry. `tumor_origin` is validated against
+  `TUMOR_ORIGIN_VALUES` (`primary`, `metastasis`, `recurrence`, `cell_line`,
+  `pdx`, `normal_tissue`, `mixed`). `Recount3Source`,
   `recount3_gene_sums_to_tpm`, `build_recount3_source_matrices`, and
   `scripts/build_recount3_source.py` do the same for `source_type: recount3`
   entries, including run-to-sample aggregation and metadata-based routing before

--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -62,6 +62,17 @@ from .gene_ids import unversioned
 SourceExpressionUnit = Literal["TPM", "FPKM", "RPKM", "log2(TPM+1)", "raw_counts"]
 GEO_MATRIX_SOURCE_TYPE = "geo-matrix"
 RECOUNT3_SOURCE_TYPE = "recount3"
+TUMOR_ORIGIN_VALUES: frozenset[str] = frozenset(
+    {
+        "primary",
+        "metastasis",
+        "recurrence",
+        "cell_line",
+        "pdx",
+        "normal_tissue",
+        "mixed",
+    }
+)
 RECOUNT3_ANNOTATION = "G026"  # recount3 Gencode v26 gene summaries
 _RECOUNT3_S3_BASE = "https://recount-opendata.s3.amazonaws.com/recount3/release/human"
 _RECOUNT3_ANNOTATION_GTF = (
@@ -149,6 +160,10 @@ class GeoMatrixSource:
     source_scale_class: str | None = None
     linear_tpm_comparable: bool | None = None
     tpm_proxy: bool | None = None
+    notes: str = ""
+    pipeline_stem: str = ""
+    tumor_origin: str = "primary"
+    metastasis_site: str | None = None
 
 
 @dataclass(frozen=True)
@@ -163,6 +178,10 @@ class Recount3Source:
     citation: str | None = None
     sample_to_cancer_code: Callable[[dict[str, str], str], str | None] | None = None
     expected_n: Mapping[str, int] | None = None
+    notes: str = ""
+    pipeline_stem: str = ""
+    tumor_origin: str = "primary"
+    metastasis_site: str | None = None
 
 
 @dataclass(frozen=True)
@@ -265,6 +284,23 @@ def _coerce_source_expression_unit(unit: str) -> SourceExpressionUnit:
     return coerced  # type: ignore[return-value]
 
 
+def _coerce_tumor_origin(value: str | None) -> str:
+    origin = str(value or "primary").strip()
+    if origin not in TUMOR_ORIGIN_VALUES:
+        raise ValueError(
+            f"tumor_origin={origin!r} is not supported; allowed values are "
+            f"{sorted(TUMOR_ORIGIN_VALUES)}"
+        )
+    return origin
+
+
+def _coerce_optional_text(value) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def geo_matrix_source_from_entry(entry: Mapping) -> GeoMatrixSource:
     """Convert one registry YAML entry into an executable :class:`GeoMatrixSource`."""
     if entry.get("source_type") != GEO_MATRIX_SOURCE_TYPE:
@@ -294,6 +330,10 @@ def geo_matrix_source_from_entry(entry: Mapping) -> GeoMatrixSource:
         source_scale_class=entry.get("source_scale_class"),
         linear_tpm_comparable=entry.get("linear_tpm_comparable"),
         tpm_proxy=entry.get("tpm_proxy"),
+        notes=str(entry.get("notes") or ""),
+        pipeline_stem=str(entry.get("pipeline_stem") or ""),
+        tumor_origin=_coerce_tumor_origin(entry.get("tumor_origin")),
+        metastasis_site=_coerce_optional_text(entry.get("metastasis_site")),
     )
 
 
@@ -382,6 +422,10 @@ def recount3_source_from_entry(entry: Mapping) -> Recount3Source:
         citation=entry.get("citation"),
         sample_to_cancer_code=route,
         expected_n=expected,
+        notes=str(entry.get("notes") or ""),
+        pipeline_stem=str(entry.get("pipeline_stem") or ""),
+        tumor_origin=_coerce_tumor_origin(entry.get("tumor_origin")),
+        metastasis_site=_coerce_optional_text(entry.get("metastasis_site")),
     )
 
 

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -168,6 +168,10 @@ def test_geo_matrix_source_from_entry_compiles_yaml_filters_and_routing():
                     {"match": "^tumor_b", "cancer_code": "CODE_B"},
                 ]
             },
+            "notes": "source-level summary row notes",
+            "pipeline_stem": "synthetic_pipeline",
+            "tumor_origin": "metastasis",
+            "metastasis_site": "liver",
         }
     )
 
@@ -180,6 +184,26 @@ def test_geo_matrix_source_from_entry_compiles_yaml_filters_and_routing():
     assert source.sample_to_cancer_code("tumor_a1") == "CODE_A"
     assert source.sample_to_cancer_code("tumor_b1") == "CODE_B"
     assert source.sample_to_cancer_code("normal_a1") is None
+    assert source.notes == "source-level summary row notes"
+    assert source.pipeline_stem == "synthetic_pipeline"
+    assert source.tumor_origin == "metastasis"
+    assert source.metastasis_site == "liver"
+
+
+def test_geo_matrix_source_from_entry_validates_tumor_origin():
+    with pytest.raises(ValueError, match="tumor_origin"):
+        expression_builders.geo_matrix_source_from_entry(
+            {
+                "id": "synthetic",
+                "source_type": "geo-matrix",
+                "cancer_codes": ["CODE_A"],
+                "source_cohort": "SYNTHETIC",
+                "file_url": "https://example.org/source.tsv.gz",
+                "file_name": "source.tsv.gz",
+                "unit": "TPM",
+                "tumor_origin": "metastatic",
+            }
+        )
 
 
 def test_geo_matrix_source_from_registry_loads_packaged_geo_entry():
@@ -189,6 +213,10 @@ def test_geo_matrix_source_from_registry_loads_packaged_geo_entry():
     assert source.source_cohort == "GSE328026_PECOMA_2026"
     assert source.unit == "TPM"
     assert source.file_name == "GSE328026_TPMs_all_Samples.txt.gz"
+    assert source.notes.startswith("n=69 PEComa tumors")
+    assert source.pipeline_stem == ""
+    assert source.tumor_origin == "primary"
+    assert source.metastasis_site is None
 
 
 def test_recount3_source_from_registry_loads_packaged_routes():
@@ -198,6 +226,7 @@ def test_recount3_source_from_registry_loads_packaged_routes():
     assert source.srp == "SRP107025"
     assert source.cancer_code == ["NET_MIDGUT", "NET_PANCREAS", "NET_RECTAL"]
     assert source.expected_n == {"NET_MIDGUT": 81, "NET_PANCREAS": 113, "NET_RECTAL": 18}
+    assert source.tumor_origin == "primary"
     assert source.sample_to_cancer_code({"origin": "ileum"}, "") == "NET_MIDGUT"
     assert source.sample_to_cancer_code({"origin": "pancreas"}, "") == "NET_PANCREAS"
     assert source.sample_to_cancer_code({"origin": "rectal"}, "") == "NET_RECTAL"


### PR DESCRIPTION
## Summary

- add summary-row provenance fields to `GeoMatrixSource`: `notes`, `pipeline_stem`, `tumor_origin`, and `metastasis_site`
- parse those fields from `expression_sources.yaml`, including existing `notes` values, and normalize empty `metastasis_site` to `None`
- add the same provenance fields to `Recount3Source` so source-specific builders share the same downstream summary-row contract
- expose and document `TUMOR_ORIGIN_VALUES`, validating `tumor_origin` at registry parse time

Refs #306. This is pure provenance passthrough for downstream summary-row production; it does not change matrix construction, mapping, QC, or sample routing.

## Verification

- `./lint.sh`
- `python -m pytest tests/test_build_generators.py tests/test_expression_sources.py tests/test_api_structure.py -q`
