### PR TITLE
Produce expression source summary rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,14 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
 - **Expression** — `cohort_gene_percentiles`, `within_sample_top_fraction`,
   `representative_cohort_samples` over the lazy-downloaded per-cohort bundle;
   `oncoref.expression_builders` for source-matrix ingestion into canonical
-  per-code per-sample TPM parquet plus mapping/parse/QC sidecars. Generic
+  per-code per-sample TPM parquet plus mapping/parse/QC sidecars and
+  per-gene-per-cohort `summary_rows` for reference-expression shards. Generic
   `source_type: geo-matrix` entries in `expression_sources.yaml` are executable
   via `scripts/build_geo_matrix.py`, and `source_type: recount3` entries via
   `scripts/build_recount3_source.py`; downstream packages should read the
-  bundled source registry through `expression_source_registry_entries()` rather
-  than shipping a second YAML copy.
+  bundled source registry through `expression_source_registry_entries()` and
+  consume builder-produced `summary_rows` rather than shipping a second YAML copy
+  or re-deriving the stat suite.
 - **Clean TPM / normalization** — `oncoref.normalization` for the 16/9/75
   compartment transform and `oncoref.gene_families` for clean-TPM censored
   compartment IDs plus the biological housekeeping denominator panel.

--- a/docs/api.md
+++ b/docs/api.md
@@ -210,7 +210,11 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   data-bundle generation scripts. `GeoMatrixSource` /
   `build_source_matrices` own the generic supplementary-matrix path from raw
   source file to canonical per-code per-sample TPM parquet, mapping audit, parse
-  diagnostics, and sample-QC sidecars. `geo_matrix_source_from_registry` and
+  diagnostics, sample-QC sidecars, and `SourceMatrixBuildResult.summary_rows`.
+  `summarize_source_matrix` is the standalone producer for those
+  per-gene-per-cohort reference-expression rows: raw TPM stats, clean-TPM
+  16/9/75 stats, `n_samples`, `n_detected`, and source provenance in one schema.
+  `geo_matrix_source_from_registry` and
   `scripts/build_geo_matrix.py` make `source_type: geo-matrix` entries in the
   packaged source registry directly buildable; `GeoMatrixSource` also preserves
   summary-row provenance (`notes`, `pipeline_stem`, `tumor_origin`,

--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -58,6 +58,7 @@ from .expression_engine import (
     sample_columns,
 )
 from .gene_ids import unversioned
+from .normalization import clean_tpm
 
 SourceExpressionUnit = Literal["TPM", "FPKM", "RPKM", "log2(TPM+1)", "raw_counts"]
 GEO_MATRIX_SOURCE_TYPE = "geo-matrix"
@@ -128,6 +129,59 @@ WITHIN_SAMPLE_THRESHOLDS = {
     0.90: "frac_samples_top10pct",
 }
 
+REFERENCE_EXPRESSION_STAT_COLUMNS: tuple[str, ...] = (
+    "TPM_median",
+    "TPM_q1",
+    "TPM_q3",
+    "TPM_mean",
+    "TPM_std",
+    "TPM_min",
+    "TPM_max",
+    "TPM_p5",
+    "TPM_p10",
+    "TPM_p90",
+    "TPM_p95",
+)
+REFERENCE_EXPRESSION_CLEAN_STAT_COLUMNS: tuple[str, ...] = tuple(
+    f"TPM_clean_{col.removeprefix('TPM_')}" for col in REFERENCE_EXPRESSION_STAT_COLUMNS
+)
+REFERENCE_EXPRESSION_COUNT_COLUMNS: tuple[str, ...] = ("n_samples", "n_detected")
+REFERENCE_EXPRESSION_COLUMNS: tuple[str, ...] = (
+    "Ensembl_Gene_ID",
+    "Symbol",
+    "cancer_code",
+    "source_cohort",
+    "source_project",
+    "source_version",
+    "TPM_median",
+    "TPM_q1",
+    "TPM_q3",
+    "TPM_mean",
+    "TPM_clean_median",
+    "TPM_clean_q1",
+    "TPM_clean_q3",
+    *REFERENCE_EXPRESSION_COUNT_COLUMNS,
+    "processing_pipeline",
+    "notes",
+    "TPM_std",
+    "TPM_min",
+    "TPM_max",
+    "TPM_p5",
+    "TPM_p10",
+    "TPM_p90",
+    "TPM_p95",
+    "TPM_clean_mean",
+    "TPM_clean_std",
+    "TPM_clean_min",
+    "TPM_clean_max",
+    "TPM_clean_p5",
+    "TPM_clean_p10",
+    "TPM_clean_p90",
+    "TPM_clean_p95",
+    "tumor_origin",
+    "metastasis_site",
+)
+
 
 @dataclass(frozen=True)
 class GeoMatrixSource:
@@ -191,10 +245,133 @@ class SourceMatrixBuildResult:
     source: GeoMatrixSource | Recount3Source
     matrices: dict[str, pd.DataFrame]
     matrix_paths: dict[str, Path]
+    summary_rows: pd.DataFrame
     mapping_audit: pd.DataFrame
     parse_diagnostics: pd.DataFrame
     sample_qc: pd.DataFrame
     sidecar_paths: dict[str, Path]
+
+
+def _unit_slug(unit: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", str(unit).lower()).strip("_")
+    return slug or "expression"
+
+
+def _summary_processing_pipeline(
+    source: GeoMatrixSource | Recount3Source,
+    *,
+    native_unit: str,
+) -> str:
+    stem = source.pipeline_stem or source.source_cohort.lower()
+    return f"{stem}_{_unit_slug(native_unit)}_to_tpm_oncoref_canonical_clean_tpm_16_9_75"
+
+
+def _summary_source_version(
+    source: GeoMatrixSource | Recount3Source,
+    *,
+    native_unit: str,
+) -> str:
+    pieces = []
+    if source.citation:
+        pieces.append(str(source.citation))
+    pieces.extend(
+        [
+            f"unit={native_unit}",
+            "canonicalized with oncoref expression_engine",
+            "clean_tpm=16/9/75",
+        ]
+    )
+    return "; ".join(pieces)
+
+
+def _summary_notes(
+    source: GeoMatrixSource | Recount3Source,
+    *,
+    n_samples: int,
+) -> str:
+    if source.notes:
+        return source.notes
+    return (
+        f"Per-sample expression from {source.source_cohort} (n={n_samples}). "
+        "Unit-normalized to TPM; summarized as raw TPM and clean TPM."
+    )
+
+
+def _compute_reference_expression_stats(
+    values: pd.DataFrame,
+    *,
+    prefix: str = "TPM_",
+) -> dict[str, np.ndarray]:
+    if values.empty:
+        raise ValueError("cannot summarize an empty value matrix")
+    return {
+        f"{prefix}median": values.median(axis=1).to_numpy(),
+        f"{prefix}q1": values.quantile(0.25, axis=1).to_numpy(),
+        f"{prefix}q3": values.quantile(0.75, axis=1).to_numpy(),
+        f"{prefix}mean": values.mean(axis=1).to_numpy(),
+        f"{prefix}std": values.std(axis=1, ddof=1).to_numpy()
+        if values.shape[1] >= 2
+        else np.full(values.shape[0], np.nan, dtype=float),
+        f"{prefix}min": values.min(axis=1).to_numpy(),
+        f"{prefix}max": values.max(axis=1).to_numpy(),
+        f"{prefix}p5": values.quantile(0.05, axis=1).to_numpy(),
+        f"{prefix}p10": values.quantile(0.10, axis=1).to_numpy(),
+        f"{prefix}p90": values.quantile(0.90, axis=1).to_numpy(),
+        f"{prefix}p95": values.quantile(0.95, axis=1).to_numpy(),
+    }
+
+
+def summarize_source_matrix(
+    matrix: pd.DataFrame,
+    *,
+    cancer_code: str,
+    source: GeoMatrixSource | Recount3Source,
+    native_unit: str | None = None,
+) -> pd.DataFrame:
+    """Return pirlygenes-compatible reference-expression summary rows.
+
+    ``matrix`` is a canonical per-sample TPM matrix for one cancer code. The output
+    is one row per gene with the source-shard stat suite consumed by
+    ``cancer_reference_expression``-style accessors: raw TPM statistics, canonical
+    16/9/75 clean-TPM statistics, detection counts, and source provenance.
+    """
+    ids = id_columns(matrix)
+    if "Ensembl_Gene_ID" not in ids or "Symbol" not in ids:
+        raise ValueError("source matrix must include Ensembl_Gene_ID and Symbol columns")
+    samples = sample_columns(matrix)
+    if not samples:
+        raise ValueError("source matrix has no sample/value columns to summarize")
+    native = native_unit or getattr(source, "unit", "TPM")
+
+    gene_table = matrix[["Ensembl_Gene_ID", "Symbol"]].copy()
+    raw_values = matrix[samples].apply(pd.to_numeric, errors="coerce")
+    clean_values = clean_tpm(raw_values, gene_table=gene_table)
+
+    out = gene_table.copy()
+    out["cancer_code"] = str(cancer_code)
+    out["source_cohort"] = source.source_cohort
+    out["source_project"] = source.source_project
+    out["source_version"] = _summary_source_version(source, native_unit=str(native))
+    for key, arr in _compute_reference_expression_stats(raw_values, prefix="TPM_").items():
+        out[key] = arr
+    for key, arr in _compute_reference_expression_stats(
+        clean_values,
+        prefix="TPM_clean_",
+    ).items():
+        out[key] = arr
+    out["n_samples"] = len(samples)
+    out["n_detected"] = (raw_values > 0).sum(axis=1).astype(int).to_numpy()
+    out["processing_pipeline"] = _summary_processing_pipeline(source, native_unit=str(native))
+    out["notes"] = _summary_notes(source, n_samples=len(samples))
+    out["tumor_origin"] = source.tumor_origin
+    out["metastasis_site"] = source.metastasis_site if source.metastasis_site else pd.NA
+
+    numeric = [
+        *REFERENCE_EXPRESSION_STAT_COLUMNS,
+        *REFERENCE_EXPRESSION_CLEAN_STAT_COLUMNS,
+    ]
+    out[numeric] = out[numeric].round(6)
+    return out.reindex(columns=list(REFERENCE_EXPRESSION_COLUMNS))
 
 
 def _source_entries_from_registry(registry_path: str | Path | None = None) -> list[dict]:
@@ -926,6 +1103,7 @@ def build_source_matrices(
     matrices: dict[str, pd.DataFrame] = {}
     matrix_paths: dict[str, Path] = {}
     qc_frames: list[pd.DataFrame] = []
+    summary_frames: list[pd.DataFrame] = []
     for code, cols in split_source_matrix_by_code(
         matrix,
         source.cancer_code,
@@ -944,14 +1122,31 @@ def build_source_matrices(
         matrix_paths[code] = path
         sidecar_paths[f"{code}_sample_qc"] = qc_path
         qc_frames.append(qc)
+        summary_frames.append(
+            summarize_source_matrix(
+                sub,
+                cancer_code=code,
+                source=source,
+                native_unit=source.unit,
+            )
+        )
 
     if not matrices:
         raise ValueError("no samples were routed to a cancer code")
     sample_qc = pd.concat(qc_frames, ignore_index=True) if qc_frames else pd.DataFrame()
+    summary_rows = (
+        pd.concat(summary_frames, ignore_index=True)
+        if summary_frames
+        else pd.DataFrame(columns=list(REFERENCE_EXPRESSION_COLUMNS))
+    )
+    summary_path = out_dir / f"{stem}_summary_rows.csv"
+    summary_rows.to_csv(summary_path, index=False)
+    sidecar_paths["summary_rows"] = summary_path
     return SourceMatrixBuildResult(
         source=source,
         matrices=matrices,
         matrix_paths=matrix_paths,
+        summary_rows=summary_rows,
         mapping_audit=audit,
         parse_diagnostics=parse_diagnostics,
         sample_qc=sample_qc,
@@ -1079,6 +1274,7 @@ def build_recount3_source_matrices(
     matrices: dict[str, pd.DataFrame] = {}
     matrix_paths: dict[str, Path] = {}
     qc_frames: list[pd.DataFrame] = []
+    summary_frames: list[pd.DataFrame] = []
     for code, cols in split_source_matrix_by_code(
         matrix,
         source.cancer_code,
@@ -1097,14 +1293,31 @@ def build_recount3_source_matrices(
         matrix_paths[code] = path
         sidecar_paths[f"{code}_sample_qc"] = qc_path
         qc_frames.append(qc)
+        summary_frames.append(
+            summarize_source_matrix(
+                sub,
+                cancer_code=code,
+                source=source,
+                native_unit="recount3_gene_sums",
+            )
+        )
 
     if not matrices:
         raise ValueError("no recount3 samples were routed to a cancer code")
     sample_qc = pd.concat(qc_frames, ignore_index=True) if qc_frames else pd.DataFrame()
+    summary_rows = (
+        pd.concat(summary_frames, ignore_index=True)
+        if summary_frames
+        else pd.DataFrame(columns=list(REFERENCE_EXPRESSION_COLUMNS))
+    )
+    summary_path = out_dir / f"{stem}_summary_rows.csv"
+    summary_rows.to_csv(summary_path, index=False)
+    sidecar_paths["summary_rows"] = summary_path
     return SourceMatrixBuildResult(
         source=source,
         matrices=matrices,
         matrix_paths=matrix_paths,
+        summary_rows=summary_rows,
         mapping_audit=audit,
         parse_diagnostics=parse_diagnostics,
         sample_qc=sample_qc,

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -96,8 +96,25 @@ def test_geo_matrix_builder_writes_canonical_per_sample_matrix_and_sidecars(tmp_
     assert result.sidecar_paths["mapping_audit"].exists()
     assert result.sidecar_paths["parse_diagnostics"].exists()
     assert result.sidecar_paths["X_sample_qc"].exists()
+    assert result.sidecar_paths["summary_rows"].exists()
     assert set(result.sample_qc["sample_id"]) == {"sample_1", "sample_2"}
     assert set(result.sample_qc["source_cohort"]) == {"TEST_GEO"}
+    summary = result.summary_rows.set_index("Ensembl_Gene_ID")
+    assert list(result.summary_rows.columns) == list(
+        expression_builders.REFERENCE_EXPRESSION_COLUMNS
+    )
+    assert set(summary["cancer_code"]) == {"X"}
+    assert set(summary["source_cohort"]) == {"TEST_GEO"}
+    assert set(summary["source_project"]) == {"GEO"}
+    assert set(summary["tumor_origin"]) == {"primary"}
+    assert summary.loc["ENSG00000141510", "n_samples"] == 2
+    assert summary.loc["ENSG00000141510", "n_detected"] == 2
+    assert summary.loc["ENSG00000141510", "TPM_median"] == pytest.approx(750_000.0)
+    assert summary.loc["ENSG00000141510", "TPM_clean_median"] == pytest.approx(562_500.0)
+    assert (
+        summary.loc["ENSG00000141510", "processing_pipeline"]
+        == "test_geo_fpkm_to_tpm_oncoref_canonical_clean_tpm_16_9_75"
+    )
 
 
 def test_geo_matrix_builder_routes_samples_and_reads_transposed_matrix(tmp_path):
@@ -148,6 +165,92 @@ def test_source_matrix_unit_helpers_validate_raw_counts_lengths():
     assert np.isclose(out.loc[out["gene_id"] == "g1", "s1"].iloc[0], 666_666.6666666666)
     with pytest.raises(ValueError, match="gene_lengths_kb"):
         expression_builders.normalize_source_matrix_to_tpm(df, unit="raw_counts")
+
+
+def test_source_matrix_builder_emits_summary_rows_for_raw_counts(tmp_path):
+    path = tmp_path / "raw_counts.csv"
+    pd.DataFrame(
+        {
+            "GeneID": ["ENSG00000141510", "ENSG00000146648"],
+            "Symbol": ["TP53", "EGFR"],
+            "sample_1": [10, 10],
+            "sample_2": [30, 10],
+        }
+    ).to_csv(path, index=False)
+    source = expression_builders.GeoMatrixSource(
+        cancer_code="RAW",
+        source_cohort="TEST_RAW",
+        source_project="GEO",
+        citation="PMID:1",
+        file_name=path.name,
+        unit="raw_counts",
+        gene_id_col="GeneID",
+        symbol_col="Symbol",
+        sep=",",
+        pipeline_stem="test_raw",
+        notes="raw count source notes",
+        tumor_origin="metastasis",
+        metastasis_site="liver",
+    )
+
+    result = expression_builders.build_source_matrices(
+        source,
+        cache_dir=tmp_path,
+        source_path=path,
+        gene_lengths_kb={"ENSG00000141510": 1.0, "ENSG00000146648": 2.0},
+    )
+
+    summary = result.summary_rows.set_index("Symbol")
+    assert set(summary["cancer_code"]) == {"RAW"}
+    assert set(summary["notes"]) == {"raw count source notes"}
+    assert set(summary["tumor_origin"]) == {"metastasis"}
+    assert set(summary["metastasis_site"]) == {"liver"}
+    assert set(summary["processing_pipeline"]) == {
+        "test_raw_raw_counts_to_tpm_oncoref_canonical_clean_tpm_16_9_75"
+    }
+    assert summary.loc["TP53", "source_version"].startswith("PMID:1; unit=raw_counts")
+    assert summary.loc["TP53", "n_samples"] == 2
+    assert summary.loc["TP53", "n_detected"] == 2
+    assert summary.loc["TP53", "TPM_median"] > summary.loc["EGFR", "TPM_median"]
+    assert pd.read_csv(result.sidecar_paths["summary_rows"]).shape == result.summary_rows.shape
+
+
+def test_summarize_source_matrix_matches_reference_stat_contract():
+    matrix = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG00000141510", "ENSG00000146648"],
+            "Symbol": ["TP53", "EGFR"],
+            "s0": [0.0, 10.0],
+            "s1": [1.0, 10.0],
+            "s2": [2.0, 10.0],
+            "s3": [3.0, 10.0],
+            "s4": [4.0, 10.0],
+        }
+    )
+    source = expression_builders.GeoMatrixSource(
+        cancer_code="X",
+        source_cohort="TEST_STATS",
+        file_name="unused.tsv",
+        unit="TPM",
+    )
+
+    summary = expression_builders.summarize_source_matrix(
+        matrix,
+        cancer_code="X",
+        source=source,
+    ).set_index("Symbol")
+
+    assert summary.loc["TP53", "TPM_median"] == 2.0
+    assert summary.loc["TP53", "TPM_mean"] == 2.0
+    assert summary.loc["TP53", "TPM_q1"] == 1.0
+    assert summary.loc["TP53", "TPM_q3"] == 3.0
+    assert summary.loc["TP53", "TPM_min"] == 0.0
+    assert summary.loc["TP53", "TPM_max"] == 4.0
+    assert summary.loc["TP53", "TPM_std"] == pytest.approx(round(np.sqrt(2.5), 6))
+    assert summary.loc["TP53", "TPM_p10"] == 0.4
+    assert summary.loc["TP53", "TPM_p90"] == 3.6
+    assert summary.loc["TP53", "n_samples"] == 5
+    assert summary.loc["TP53", "n_detected"] == 4
 
 
 def test_geo_matrix_source_from_entry_compiles_yaml_filters_and_routing():
@@ -437,6 +540,9 @@ def test_build_recount3_script_uses_registry_config(tmp_path, monkeypatch, capsy
             source=source,
             matrices={"CODE_A": matrix},
             matrix_paths={"CODE_A": tmp_path / "CODE_A_per_sample_tpm.parquet"},
+            summary_rows=pd.DataFrame(
+                columns=list(expression_builders.REFERENCE_EXPRESSION_COLUMNS)
+            ),
             mapping_audit=pd.DataFrame(),
             parse_diagnostics=pd.DataFrame(),
             sample_qc=pd.DataFrame(),


### PR DESCRIPTION
## Summary

- add the reference-expression summary-row schema/stat helpers to `oncoref.expression_builders`
- add `summarize_source_matrix(...)` and `SourceMatrixBuildResult.summary_rows`
- have both geo-matrix and recount3 builders emit a combined summary-row CSV sidecar
- document the builder-produced summary rows as the downstream shard handoff

Refs #307. Builds on the provenance fields from #306 / PR #308.

## Verification

- `./lint.sh`
- `python -m pytest tests/test_build_generators.py tests/test_expression.py tests/test_expression_sources.py tests/test_api_structure.py -q`
- `./test.sh` (684 passed, 1 existing matplotlib warning)

## Notes

This keeps sample-QC/read-path manifest filtering out of scope. The summary rows are produced from the routed per-code source matrix, while the separate manifest-filtering work can decide how all/pass/warn samples are selected for downstream artifact rebuilds.