### PR TITLE
Handle PAR and leading-digit source row IDs

### DIFF
--- a/oncoref/expression_engine.py
+++ b/oncoref/expression_engine.py
@@ -192,10 +192,13 @@ def detect_source_row_id_type(values: Iterable) -> str:
     if s.empty:
         return "unknown"
     upper = s.str.upper()
-    ensg = upper.str.match(r"^ENSG\d+(?:\.\d+)?$")
+    ensg = upper.str.match(r"^ENSG\d+(?:\.\d+)?(?:_PAR_[XY])?$")
     enst = upper.str.match(r"^ENST\d+(?:\.\d+)?$")
     entrez = upper.str.match(r"^\d+$")
-    symbol = upper.str.match(r"^[A-Z][A-Z0-9_.-]*$") & ~(ensg | enst | entrez)
+    leading_digit_ncrna = upper.str.match(r"^(?:\d+SK|\d+SL|\d+(?:_\d+)?S(?:_RRNA)?)$")
+    symbol = (upper.str.match(r"^[A-Z][A-Z0-9_.-]*$") | leading_digit_ncrna) & ~(
+        ensg | enst | entrez
+    )
     patterns = {
         "ensembl_gene_id": ensg,
         "ensembl_transcript_id": enst,
@@ -304,7 +307,7 @@ def _source_value_columns(
 def _resolve_gene_id(raw_id: str) -> tuple[str | None, str | None, str, str | None]:
     from .gene_ids import resolve_ensembl_id, unversioned
 
-    raw = unversioned(raw_id).upper()
+    raw = unversioned(str(raw_id).upper().removesuffix("_PAR_X").removesuffix("_PAR_Y"))
     canonical = resolve_ensembl_id(raw)
     hit = _canonical_gene_index().get(canonical)
     if hit is None:

--- a/tests/test_expression_engine.py
+++ b/tests/test_expression_engine.py
@@ -64,10 +64,12 @@ def test_detect_source_row_id_type():
     assert ee.detect_source_row_id_type(["ENSG00000141510.17", "ENSG00000278311"]) == (
         "ensembl_gene_id"
     )
+    assert ee.detect_source_row_id_type(["ENSG00000182162.11_PAR_Y"]) == "ensembl_gene_id"
     assert ee.detect_source_row_id_type(["ENST00000264036", "ENST00000367770.8"]) == (
         "ensembl_transcript_id"
     )
     assert ee.detect_source_row_id_type(["TP53", "GGNBP2"]) == "symbol"
+    assert ee.detect_source_row_id_type(["7SK", "7SL", "5S_rRNA", "5_8S_rRNA"]) == "symbol"
     assert ee.detect_source_row_id_type(["7157", "1234"]) == "entrez_id"
     assert ee.detect_source_row_id_type(["ENSG00000141510", "TP53"]) == "mixed"
 
@@ -159,6 +161,41 @@ def test_map_source_gene_rows_normalizes_case_varied_ensembl_identifiers():
 
     matrix, _ = ee.canonicalize_source_gene_matrix(df, row_id_col="gene_id", value_cols=["s1"])
     assert set(matrix["Ensembl_Gene_ID"]) == {"ENSG00000141510", "ENSG00000171862"}
+
+
+def test_map_source_gene_rows_folds_pseudoautosomal_ensembl_suffixes():
+    df = pd.DataFrame(
+        {
+            "gene_id": ["ENSG00000182162", "ENSG00000182162.11_PAR_Y"],
+            "s1": [2.0, 3.0],
+        }
+    )
+    audit = ee.map_source_gene_rows(df, row_id_col="gene_id", value_cols=["s1"])
+    by_id = audit.set_index("source_row_id")
+
+    assert by_id.loc["ENSG00000182162.11_PAR_Y", "source_row_id_type"] == "ensembl_gene_id"
+    assert by_id.loc["ENSG00000182162.11_PAR_Y", "canonical_ensembl_gene_id"] == ("ENSG00000182162")
+    assert by_id.loc["ENSG00000182162.11_PAR_Y", "canonical_symbol"] == "P2RY8"
+
+    matrix, _ = ee.canonicalize_source_gene_matrix(df, row_id_col="gene_id", value_cols=["s1"])
+    row = matrix.set_index("Ensembl_Gene_ID").loc["ENSG00000182162"]
+    assert row["Symbol"] == "P2RY8"
+    assert row["s1"] == 5.0
+
+
+def test_map_source_gene_rows_resolves_leading_digit_ncrna_symbols():
+    df = pd.DataFrame({"gene_id": ["7SL", "5_8S_rRNA", "45S"], "s1": [3.0, 4.0, 5.0]})
+    audit = ee.map_source_gene_rows(df, row_id_col="gene_id", value_cols=["s1"])
+    by_id = audit.set_index("source_row_id")
+
+    assert by_id.loc["7SL", "source_row_id_type"] == "symbol"
+    assert by_id.loc["7SL", "canonical_ensembl_gene_id"] == "ENSG00000276168"
+    assert by_id.loc["7SL", "canonical_symbol"] == "RN7SL1"
+    assert by_id.loc["5_8S_rRNA", "source_row_id_type"] == "symbol"
+    assert by_id.loc["5_8S_rRNA", "mapping_status"] == "ambiguous"
+    assert by_id.loc["5_8S_rRNA", "unresolved_reason"] == "ambiguous_symbol"
+    assert by_id.loc["45S", "source_row_id_type"] == "symbol"
+    assert by_id.loc["45S", "unresolved_reason"] == "unknown_symbol"
 
 
 def test_map_source_gene_rows_preserves_identifier_unresolved_reasons():


### PR DESCRIPTION
## Summary

- treat `ENSG..._PAR_X` / `ENSG..._PAR_Y` row IDs as Ensembl gene IDs and fold them to the base ENSG before canonical lookup
- classify known leading-digit ncRNA symbol shapes (`7SK`, `7SL`, `5S_rRNA`, `5_8S_rRNA`, `45S`) as symbols so they reach the normal symbol/synonym resolver
- add regression coverage for PAR linear summing and leading-digit ncRNA symbol handling

## Notes

`5S_rRNA` / `5_8S_rRNA` remain ambiguous when they refer to multiple canonical loci; this PR fixes row-type detection and resolver reachability, not arbitrary paralog selection.

Closes #312

## Verification

- `./lint.sh`
- `python -m pytest tests/test_build_generators.py tests/test_expression_engine.py -q`
- `./test.sh`
