### PR TITLE
Make source matrix builder artifacts atomic

### DIFF
--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -38,8 +38,10 @@ referenced and documented as the public build-time API.
 from __future__ import annotations
 
 import gzip
+import os
 import re
 import shutil
+import tempfile
 import urllib.request
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -985,6 +987,41 @@ def _artifact_stem(value: str) -> str:
     return "".join(c if c.isalnum() or c in "._-" else "_" for c in value)
 
 
+def _atomic_write(path: Path, writer: Callable[[Path], None]) -> None:
+    """Write ``path`` via a same-directory temp file, then atomically replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    try:
+        writer(tmp_path)
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _write_csv_atomic(df: pd.DataFrame, path: Path) -> None:
+    _atomic_write(path, lambda tmp_path: df.to_csv(tmp_path, index=False))
+
+
+def _write_parquet_atomic(df: pd.DataFrame, path: Path) -> None:
+    _atomic_write(path, lambda tmp_path: df.to_parquet(tmp_path, index=False))
+
+
+def _reconcile_per_code_artifacts(out_dir: Path, current_codes: Iterable[str]) -> None:
+    """Remove stale per-code matrix/QC sidecars from a per-source output directory."""
+    current_stems = {_artifact_stem(code) for code in current_codes}
+    for suffix in ("_per_sample_tpm.parquet", "_sample_qc.csv"):
+        for path in out_dir.glob(f"*{suffix}"):
+            code_stem = path.name[: -len(suffix)]
+            if code_stem not in current_stems:
+                path.unlink(missing_ok=True)
+
+
 def split_source_matrix_by_code(
     matrix: pd.DataFrame,
     cancer_code: str | list[str],
@@ -1024,6 +1061,8 @@ def build_source_matrices(
     include source-row mapping audit, source-value parse diagnostics, and per-sample
     QC manifests. Samples are not dropped here; read/build-time consumers choose
     ``all``/``pass``/``pass_or_warn`` filtering from the QC manifest.
+    ``output_dir`` is treated as this source's derived-artifact directory; after a
+    successful build, stale per-code matrix/QC sidecars in it are removed.
     """
     cache = Path(cache_dir)
     out_dir = Path(output_dir) if output_dir is not None else cache / "derived"
@@ -1084,8 +1123,8 @@ def build_source_matrices(
     sidecar_paths: dict[str, Path] = {}
     audit_path = out_dir / f"{stem}_mapping_audit.csv"
     parse_path = out_dir / f"{stem}_parse_diagnostics.csv"
-    audit.to_csv(audit_path, index=False)
-    parse_diagnostics.to_csv(parse_path, index=False)
+    _write_csv_atomic(audit, audit_path)
+    _write_csv_atomic(parse_diagnostics, parse_path)
     sidecar_paths["mapping_audit"] = audit_path
     sidecar_paths["parse_diagnostics"] = parse_path
 
@@ -1114,10 +1153,10 @@ def build_source_matrices(
         sub = matrix[[*id_columns(matrix), *cols]].copy()
         sub.attrs = {}
         path = out_dir / f"{_artifact_stem(code)}_per_sample_tpm.parquet"
-        sub.to_parquet(path, index=False)
+        _write_parquet_atomic(sub, path)
         qc = sample_expression_qc_from_matrix(sub, cancer_type=code, source_metadata=meta)
         qc_path = out_dir / f"{_artifact_stem(code)}_sample_qc.csv"
-        qc.to_csv(qc_path, index=False)
+        _write_csv_atomic(qc, qc_path)
         matrices[code] = sub
         matrix_paths[code] = path
         sidecar_paths[f"{code}_sample_qc"] = qc_path
@@ -1140,7 +1179,8 @@ def build_source_matrices(
         else pd.DataFrame(columns=list(REFERENCE_EXPRESSION_COLUMNS))
     )
     summary_path = out_dir / f"{stem}_summary_rows.csv"
-    summary_rows.to_csv(summary_path, index=False)
+    _write_csv_atomic(summary_rows, summary_path)
+    _reconcile_per_code_artifacts(out_dir, matrices)
     sidecar_paths["summary_rows"] = summary_path
     return SourceMatrixBuildResult(
         source=source,
@@ -1255,8 +1295,8 @@ def build_recount3_source_matrices(
     sidecar_paths: dict[str, Path] = {}
     audit_path = out_dir / f"{stem}_mapping_audit.csv"
     parse_path = out_dir / f"{stem}_parse_diagnostics.csv"
-    audit.to_csv(audit_path, index=False)
-    parse_diagnostics.to_csv(parse_path, index=False)
+    _write_csv_atomic(audit, audit_path)
+    _write_csv_atomic(parse_diagnostics, parse_path)
     sidecar_paths["mapping_audit"] = audit_path
     sidecar_paths["parse_diagnostics"] = parse_path
 
@@ -1285,10 +1325,10 @@ def build_recount3_source_matrices(
         sub = matrix[[*id_columns(matrix), *cols]].copy()
         sub.attrs = {}
         path = out_dir / f"{_artifact_stem(code)}_per_sample_tpm.parquet"
-        sub.to_parquet(path, index=False)
+        _write_parquet_atomic(sub, path)
         qc = sample_expression_qc_from_matrix(sub, cancer_type=code, source_metadata=meta)
         qc_path = out_dir / f"{_artifact_stem(code)}_sample_qc.csv"
-        qc.to_csv(qc_path, index=False)
+        _write_csv_atomic(qc, qc_path)
         matrices[code] = sub
         matrix_paths[code] = path
         sidecar_paths[f"{code}_sample_qc"] = qc_path
@@ -1311,7 +1351,8 @@ def build_recount3_source_matrices(
         else pd.DataFrame(columns=list(REFERENCE_EXPRESSION_COLUMNS))
     )
     summary_path = out_dir / f"{stem}_summary_rows.csv"
-    summary_rows.to_csv(summary_path, index=False)
+    _write_csv_atomic(summary_rows, summary_path)
+    _reconcile_per_code_artifacts(out_dir, matrices)
     sidecar_paths["summary_rows"] = summary_path
     return SourceMatrixBuildResult(
         source=source,

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -52,6 +52,21 @@ def _matrix(genes, samples, values):
 # ---------- source-matrix ingestion builders ----------
 
 
+def test_atomic_write_preserves_existing_artifact_on_failure(tmp_path):
+    path = tmp_path / "artifact.csv"
+    path.write_text("old\n")
+
+    def _write_then_fail(tmp_path):
+        tmp_path.write_text("new\n")
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        expression_builders._atomic_write(path, _write_then_fail)
+
+    assert path.read_text() == "old\n"
+    assert not list(tmp_path.glob("*.tmp"))
+
+
 def test_geo_matrix_builder_writes_canonical_per_sample_matrix_and_sidecars(tmp_path):
     path = tmp_path / "geo.csv"
     pd.DataFrame(
@@ -115,6 +130,83 @@ def test_geo_matrix_builder_writes_canonical_per_sample_matrix_and_sidecars(tmp_
         summary.loc["ENSG00000141510", "processing_pipeline"]
         == "test_geo_fpkm_to_tpm_oncoref_canonical_clean_tpm_16_9_75"
     )
+
+
+def test_geo_matrix_builder_reconciles_stale_per_code_artifacts(tmp_path):
+    out_dir = tmp_path / "derived"
+    out_dir.mkdir()
+    stale_matrix = out_dir / "STALE_per_sample_tpm.parquet"
+    stale_qc = out_dir / "STALE_sample_qc.csv"
+    stale_matrix.write_text("stale matrix")
+    stale_qc.write_text("stale qc")
+    path = tmp_path / "geo.csv"
+    pd.DataFrame(
+        {
+            "GeneID": ["ENSG00000141510", "ENSG00000146648"],
+            "Symbol": ["TP53", "EGFR"],
+            "sample_1": ["2", "3"],
+        }
+    ).to_csv(path, index=False)
+    source = expression_builders.GeoMatrixSource(
+        cancer_code="LIVE",
+        source_cohort="TEST_GEO_STALE",
+        source_project="GEO",
+        file_name=path.name,
+        unit="TPM",
+        gene_id_col="GeneID",
+        symbol_col="Symbol",
+        sep=",",
+    )
+
+    result = expression_builders.build_source_matrices(
+        source,
+        cache_dir=tmp_path,
+        source_path=path,
+    )
+
+    assert set(result.matrix_paths) == {"LIVE"}
+    assert not stale_matrix.exists()
+    assert not stale_qc.exists()
+    assert (out_dir / "LIVE_per_sample_tpm.parquet").exists()
+    assert (out_dir / "LIVE_sample_qc.csv").exists()
+
+
+def test_geo_matrix_builder_preserves_stale_artifacts_when_no_samples_route(tmp_path):
+    out_dir = tmp_path / "derived"
+    out_dir.mkdir()
+    stale_matrix = out_dir / "STALE_per_sample_tpm.parquet"
+    stale_qc = out_dir / "STALE_sample_qc.csv"
+    stale_matrix.write_text("stale matrix")
+    stale_qc.write_text("stale qc")
+    path = tmp_path / "geo.csv"
+    pd.DataFrame(
+        {
+            "GeneID": ["ENSG00000141510"],
+            "Symbol": ["TP53"],
+            "sample_1": ["2"],
+        }
+    ).to_csv(path, index=False)
+    source = expression_builders.GeoMatrixSource(
+        cancer_code=["LIVE"],
+        source_cohort="TEST_GEO_EMPTY",
+        source_project="GEO",
+        file_name=path.name,
+        unit="TPM",
+        gene_id_col="GeneID",
+        symbol_col="Symbol",
+        sep=",",
+        sample_to_cancer_code=lambda _sample: None,
+    )
+
+    with pytest.raises(ValueError, match="no samples were routed"):
+        expression_builders.build_source_matrices(
+            source,
+            cache_dir=tmp_path,
+            source_path=path,
+        )
+
+    assert stale_matrix.exists()
+    assert stale_qc.exists()
 
 
 def test_geo_matrix_builder_routes_samples_and_reads_transposed_matrix(tmp_path):
@@ -447,10 +539,18 @@ def test_build_recount3_source_matrices_writes_canonical_artifacts(tmp_path, mon
         ),
         expected_n={"CODE_A": 1, "CODE_B": 1},
     )
+    out_dir = tmp_path / "derived"
+    out_dir.mkdir()
+    stale_matrix = out_dir / "STALE_per_sample_tpm.parquet"
+    stale_qc = out_dir / "STALE_sample_qc.csv"
+    stale_matrix.write_text("stale matrix")
+    stale_qc.write_text("stale qc")
 
     result = expression_builders.build_recount3_source_matrices(source, cache_dir=tmp_path)
 
     assert set(result.matrix_paths) == {"CODE_A", "CODE_B"}
+    assert not stale_matrix.exists()
+    assert not stale_qc.exists()
     assert result.sidecar_paths["mapping_audit"].exists()
     assert result.sidecar_paths["parse_diagnostics"].exists()
     code_a = pd.read_parquet(result.matrix_paths["CODE_A"])


### PR DESCRIPTION
## Summary

- write source-builder CSV/parquet artifacts through same-directory temp files and atomic replace
- reconcile stale per-code matrix/QC sidecars after a successful GEO or recount3 source build
- preserve existing per-code artifacts when a build fails before routing any samples

Closes #313.

## Verification

- `python -m pytest tests/test_build_generators.py -q`
- `./lint.sh`
- `./test.sh` (691 passed, existing matplotlib open-figure warning)