### PR TITLE
Avoid configuring root logging on import

### DIFF
--- a/oncoref/genome.py
+++ b/oncoref/genome.py
@@ -30,9 +30,8 @@ against the newest release first, falling back to older installed releases.
 
 from __future__ import annotations
 
+import logging
 from functools import lru_cache
-
-from pyensembl.shell import collect_all_installed_ensembl_releases
 
 from .gene_ids import resolve_symbol, unversioned
 
@@ -56,15 +55,38 @@ for _k, _v in _DISPLAY_ALIASES.items():
     _REVERSE_ALIASES.setdefault(_v, []).append(_k)
 
 
+def _restore_root_logger(root, handlers, level, disabled) -> None:
+    for handler in list(root.handlers):
+        if handler not in handlers:
+            root.removeHandler(handler)
+            handler.close()
+    for handler in handlers:
+        if handler not in root.handlers:
+            root.addHandler(handler)
+    root.setLevel(level)
+    root.disabled = disabled
+
+
+@lru_cache(maxsize=1)
+def _installed_ensembl_releases():
+    """Collect pyensembl releases without inheriting gtfparse root logging setup."""
+    root = logging.getLogger()
+    handlers = list(root.handlers)
+    level = root.level
+    disabled = root.disabled
+    try:
+        from pyensembl.shell import collect_all_installed_ensembl_releases
+
+        return tuple(collect_all_installed_ensembl_releases())
+    finally:
+        _restore_root_logger(root, handlers, level, disabled)
+
+
 @lru_cache(maxsize=1)
 def genomes():
     """Installed human Ensembl releases, newest first. Empty if none installed."""
     return sorted(
-        (
-            g
-            for g in collect_all_installed_ensembl_releases()
-            if g.species.latin_name == "homo_sapiens"
-        ),
+        (g for g in _installed_ensembl_releases() if g.species.latin_name == "homo_sapiens"),
         key=lambda g: g.release,
         reverse=True,
     )

--- a/tests/test_base_layer.py
+++ b/tests/test_base_layer.py
@@ -13,9 +13,12 @@ fails the build if any consumer leaks into the shipped package.
 """
 
 import ast
+import subprocess
+import sys
 from pathlib import Path
 
 _PACKAGE = Path(__file__).resolve().parents[1] / "oncoref"
+_PROJECT = _PACKAGE.parent
 
 # Downstream consumers that depend on oncoref; importing any of them would
 # invert the dependency pyramid.
@@ -43,3 +46,46 @@ def test_package_imports_no_consumer():
             if mod in _CONSUMERS:
                 offenders.append(f"{py.relative_to(_PACKAGE)} imports {mod}")
     assert not offenders, "oncoref must not import its consumers:\n  " + "\n  ".join(offenders)
+
+
+def test_import_oncoref_does_not_configure_root_logging():
+    code = """
+import logging
+root = logging.getLogger()
+assert len(root.handlers) == 0
+assert root.level == logging.WARNING
+import oncoref
+assert len(root.handlers) == 0, root.handlers
+assert root.level == logging.WARNING, logging.getLevelName(root.level)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=_PROJECT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_genome_release_probe_preserves_root_logging():
+    code = """
+import logging
+from oncoref import genome
+root = logging.getLogger()
+assert len(root.handlers) == 0
+assert root.level == logging.WARNING
+genome.genomes()
+assert len(root.handlers) == 0, root.handlers
+assert root.level == logging.WARNING, logging.getLevelName(root.level)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=_PROJECT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout


### PR DESCRIPTION
## Summary

- make the pyensembl release probe lazy instead of importing pyensembl during package import
- preserve and restore root logger handlers/level around the pyensembl/gtfparse import path
- add subprocess regressions for `import oncoref` and `genome.genomes()` root-logging behavior

Closes #316.

## Verification

- `python -m pytest tests/test_base_layer.py tests/test_genome.py -q`
- `./lint.sh`
- `./test.sh` (693 passed, existing matplotlib open-figure warning)