### PR TITLE
Report QC-empty reference summaries as unavailable

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -63,7 +63,7 @@ import warnings
 from collections import Counter, defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import cache, lru_cache
 from pathlib import Path
 
 import numpy as np
@@ -2400,12 +2400,40 @@ def _reference_mode_availability(
     if reference_source == "summary_rows":
         if sample_qc == "all":
             return (True, "") if code in summary_available else (False, "no_reference_summary_rows")
-        return (True, "") if code in source_matrix_available else (False, "no_source_matrix")
+        if code not in source_matrix_available:
+            return False, "no_source_matrix"
+        n_samples = _source_matrix_effective_sample_count(code, sample_qc)
+        if n_samples == 0:
+            return False, f"no_source_matrix_samples_matching_{sample_qc}_qc"
+        return True, ""
     if mode in {"tpm_clean", "tpm_clean_biological", "tpm_clean_log1p"}:
         return (True, "") if code in percentile_available else (False, "no_percentile_artifact")
     if mode == "tpm_raw":
         return (True, "") if code in source_matrix_available else (False, "no_source_matrix")
     raise AssertionError(f"unhandled reference normalize mode: {mode}")
+
+
+@cache
+def _source_matrix_effective_sample_count(code: str, sample_qc: str) -> int | None:
+    """Return selected sample count for cached source matrices, or ``None`` if unknown.
+
+    Availability should not fetch source matrices. When a matrix is cached, use the same
+    read-time QC contract as :func:`per_sample_expression` so strict reference summaries
+    do not claim availability and then fail after every sample is filtered out.
+    """
+    mode = _validate_sample_qc(sample_qc)
+    if mode == "all":
+        return None
+    try:
+        qc = sample_expression_qc(code, auto_fetch=False)
+    except (FileNotFoundError, source_matrices.SourceMatrixError):
+        return None
+    if qc.empty or "sample_qc_status" not in qc.columns:
+        return 0
+    statuses = qc["sample_qc_status"].astype(str)
+    if mode == "pass":
+        return int((statuses == "pass").sum())
+    return int(statuses.isin(["pass", "warn"]).sum())
 
 
 def _reference_expected_method(mode: str, *, sample_qc: str, reference_source: str) -> str:

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1776,7 +1776,7 @@ def test_cancer_reference_expression_summary_rows_qc_filtered_recomputes(monkeyp
     expression._reference_summary_source_table.cache_clear()
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: [])
     monkeypatch.setattr(expression.source_matrices, "available_cohorts", lambda: ["X"])
-    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code, **k: str(code).upper())
     monkeypatch.setattr(
         expression,
         "cohort_stats",
@@ -1819,6 +1819,65 @@ def test_cancer_reference_expression_summary_rows_qc_filtered_recomputes(monkeyp
     assert out["source_cohort"].tolist() == ["SRC_X"]
     assert out["n_reference_samples"].tolist() == [7]
     assert out["expression"].tolist() == [2.0]
+
+
+def test_cancer_reference_expression_summary_rows_reports_no_samples_after_qc(monkeypatch):
+    stats = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1"],
+            "Symbol": ["A"],
+            "p25": [1.0],
+            "p50": [2.0],
+            "p75": [3.0],
+        }
+    )
+    qc = pd.DataFrame(
+        {
+            "sample_id": ["S1", "S2"],
+            "sample_qc_status": ["warn", "warn"],
+        }
+    )
+    seen = {}
+    expression._source_matrix_effective_sample_count.cache_clear()
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: [])
+    monkeypatch.setattr(expression.source_matrices, "available_cohorts", lambda: ["X"])
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code, **k: str(code).upper())
+    monkeypatch.setattr(expression, "sample_expression_qc", lambda *a, **k: qc.copy())
+    monkeypatch.setattr(
+        expression,
+        "cohort_stats",
+        lambda code, **k: seen.update(code=code, **k) or stats.copy(),
+    )
+
+    empty = expression.cancer_reference_expression(
+        "x", reference_source="summary_rows", sample_qc="pass", on_missing="empty"
+    )
+
+    assert empty.empty
+    assert seen == {}
+    assert empty.attrs["missing_requests"][0]["missing_reason"] == (
+        "no_source_matrix_samples_matching_pass_qc"
+    )
+
+    availability = expression.cancer_reference_expression_availability(
+        "x", reference_source="summary_rows", sample_qc="pass"
+    )
+    assert availability["available"].tolist() == [False]
+    assert availability["missing_reason"].tolist() == ["no_source_matrix_samples_matching_pass_qc"]
+
+    out = expression.cancer_reference_expression(
+        "x", reference_source="summary_rows", sample_qc="pass_or_warn"
+    )
+
+    assert seen == {
+        "code": "X",
+        "normalize": "tpm_clean",
+        "auto_fetch": False,
+        "sample_qc": "pass_or_warn",
+    }
+    assert out["expression"].tolist() == [2.0]
+    assert out["sample_qc"].tolist() == ["pass_or_warn"]
+    expression._source_matrix_effective_sample_count.cache_clear()
 
 
 def test_cancer_reference_expression_wide_merges_by_gene_id_not_symbol(monkeypatch):


### PR DESCRIPTION
## Summary

- Treat live `reference_source="summary_rows"` recomputes with zero selected samples after read-time QC as unavailable instead of letting `cohort_stats` fail later.
- Preserve strict `sample_qc="pass"` semantics while allowing callers to opt into `sample_qc="pass_or_warn"` for proxy/unknown-scale cohorts.
- Add a regression test covering all-warn cohorts and the pass-or-warn escape hatch.

Fixes part of #207.

## Validation

- `python -m pytest tests/test_expression.py -q`
- `./lint.sh`
- `git diff --check`
