### PR TITLE
Add all-source reference expression view

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -327,13 +327,15 @@ private filtered bundle.
 
 Use `reference_source="summary_rows_all", sample_qc="all"` when downstream code
 needs the full source-union table rather than one selected source per cancer
-code. This mode returns one row per gene, cancer code, normalization, and source
-cohort, preserving sidecar provenance such as `n_samples`, `n_detected`,
-`processing_pipeline`, and `notes`. It also accepts `source_kind=...`,
-`source_cohort=...`, `exclude_microarray_proxy=True`, and long-form `pool=True`
-for an explicit n-sample-weighted pooled view. Because these sidecars are
-all-sample artifacts, this source-union mode intentionally rejects
-`sample_qc="pass"` and `sample_qc="pass_or_warn"`; QC-filtered all-source
+code. This long-only mode returns one row per gene, cancer code, normalization,
+and source cohort; even with `include_provenance=False`, it keeps
+`source_cohort` and sample-count columns because they are part of the source-row
+identity. With provenance enabled, it also preserves sidecar fields such as
+`processing_pipeline` and `notes`. It accepts `source_kind=...`,
+`source_cohort=...`, `exclude_microarray_proxy=True`, and `pool=True` for an
+explicit n-sample-weighted pooled view. Because these sidecars are all-sample
+artifacts, this source-union mode intentionally rejects `format="wide"`,
+`sample_qc="pass"`, and `sample_qc="pass_or_warn"`; QC-filtered all-source
 reference artifacts remain part of the expression-artifact rebuild work.
 
 Use `expression.cancer_reference_expression_availability()` before delegating a

--- a/docs/api.md
+++ b/docs/api.md
@@ -325,6 +325,17 @@ build-time drop. This keeps the source sidecars as all-sample evidence while
 allowing downstream code to ask for QC-passing summaries without maintaining a
 private filtered bundle.
 
+Use `reference_source="summary_rows_all", sample_qc="all"` when downstream code
+needs the full source-union table rather than one selected source per cancer
+code. This mode returns one row per gene, cancer code, normalization, and source
+cohort, preserving sidecar provenance such as `n_samples`, `n_detected`,
+`processing_pipeline`, and `notes`. It also accepts `source_kind=...`,
+`source_cohort=...`, `exclude_microarray_proxy=True`, and long-form `pool=True`
+for an explicit n-sample-weighted pooled view. Because these sidecars are
+all-sample artifacts, this source-union mode intentionally rejects
+`sample_qc="pass"` and `sample_qc="pass_or_warn"`; QC-filtered all-source
+reference artifacts remain part of the expression-artifact rebuild work.
+
 Use `expression.cancer_reference_expression_availability()` before delegating a
 downstream reference-expression accessor that must distinguish unavailable
 oncoref artifacts from empty gene filters. It returns one row per requested

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -70,7 +70,7 @@ import numpy as np
 import pandas as pd
 
 from . import data_bundle, source_matrices
-from .cancer_types import cohort_aggregates, resolve_cancer_type
+from .cancer_types import cohort_aggregates, cohort_registry_df, resolve_cancer_type
 from .expression_builders import (
     PERCENTILE_BREAKPOINTS as _PERCENTILE_BREAKPOINTS,
 )
@@ -2044,6 +2044,10 @@ def cancer_reference_expression(
     gene_id_style: str = "oncoref",
     gene_universe: str = "artifact",
     include_gene_universe_flags: bool = False,
+    source_kind: str | Iterable[str] | None = None,
+    source_cohort: str | Iterable[str] | None = None,
+    exclude_microarray_proxy: bool = False,
+    pool: bool = False,
 ) -> pd.DataFrame:
     """Observed tumor expression references as cohort-level clean TPM summaries.
 
@@ -2068,6 +2072,12 @@ def cancer_reference_expression(
     name). For ``sample_qc="pass"`` or ``"pass_or_warn"``, it recomputes the same
     reference summaries from source matrices at read time so QC-filtered views are not
     silently backed by all-sample build artifacts.
+    ``reference_source="summary_rows_all"`` is the source-union view over those
+    sidecars: it preserves one row per ``(gene, cancer_code, source_cohort)`` and
+    supports ``source_kind``, ``source_cohort``, ``exclude_microarray_proxy``, and
+    long-form ``pool=True``. Because the shipped sidecars are all-sample summaries,
+    this mode requires ``sample_qc="all"``; use ``summary_rows`` for the current
+    QC-filtered richest-source recompute path.
 
     Raw-TPM mode needs the per-sample source matrix available; pass
     ``auto_fetch=True`` to download it. Raw-TPM summaries default to
@@ -2094,6 +2104,19 @@ def cancer_reference_expression(
     reference_source = _validate_reference_source(reference_source)
     _validate_gene_id_style(gene_id_style)
     gene_universe = _validate_artifact_gene_universe(gene_universe)
+    source_kinds = _normalize_source_filter_values(source_kind)
+    source_cohorts = _normalize_source_filter_values(source_cohort)
+    if reference_source == "summary_rows_all" and sample_qc != "all":
+        raise ValueError('reference_source="summary_rows_all" requires sample_qc="all"')
+    if (source_kinds or source_cohorts or exclude_microarray_proxy or pool) and (
+        reference_source != "summary_rows_all"
+    ):
+        raise ValueError(
+            "source_kind, source_cohort, exclude_microarray_proxy, and pool are "
+            "only supported with reference_source='summary_rows_all'"
+        )
+    if pool and format != "long":
+        raise ValueError("pool=True requires format='long'")
     if format not in ("long", "wide"):
         raise ValueError("format must be 'long' or 'wide'")
     if on_missing not in ("omit", "empty", "raise"):
@@ -2107,7 +2130,13 @@ def cancer_reference_expression(
         cancer_types, modes, reference_source=reference_source, sample_qc=sample_qc
     )
     availability = _reference_expression_availability_for_requests(
-        requests, modes, sample_qc=sample_qc, reference_source=reference_source
+        requests,
+        modes,
+        sample_qc=sample_qc,
+        reference_source=reference_source,
+        source_kinds=source_kinds,
+        source_cohorts=source_cohorts,
+        exclude_microarray_proxy=exclude_microarray_proxy,
     )
     missing = availability.loc[~availability["available"]].reset_index(drop=True)
     if on_missing == "raise" and not missing.empty:
@@ -2139,6 +2168,9 @@ def cancer_reference_expression(
                 auto_fetch=auto_fetch,
                 sample_qc=sample_qc,
                 reference_source=reference_source,
+                source_kinds=source_kinds,
+                source_cohorts=source_cohorts,
+                exclude_microarray_proxy=exclude_microarray_proxy,
             )
             ref = ref[_gene_filter_mask(ref, genes)].reset_index(drop=True)
             ref = _apply_artifact_gene_universe(
@@ -2171,15 +2203,23 @@ def cancer_reference_expression(
                     part["missing_reason"] = str(request_row.missing_reason)
                 part = part.rename(columns={"p50": "expression", "p25": "q1", "p75": "q3"})
                 if include_provenance:
-                    provenance = _reference_expression_provenance(
-                        code,
-                        mode,
-                        method,
-                        sample_qc=sample_qc,
-                        reference_source=reference_source,
-                    )
-                    for col, value in provenance.items():
-                        part[col] = value
+                    if method == _REFERENCE_SUMMARY_ALL_METHOD:
+                        for col in _REFERENCE_PROVENANCE_COLUMNS:
+                            if col in ref.columns:
+                                part[col] = ref[col].to_numpy()
+                    else:
+                        provenance = _reference_expression_provenance(
+                            code,
+                            mode,
+                            method,
+                            sample_qc=sample_qc,
+                            reference_source=reference_source,
+                        )
+                        for col, value in provenance.items():
+                            part[col] = value
+                    for col in _REFERENCE_PROVENANCE_COLUMNS:
+                        if col not in part.columns:
+                            part[col] = pd.NA
                 long_parts.append(
                     part[
                         _reference_long_columns(
@@ -2206,6 +2246,8 @@ def cancer_reference_expression(
             out = pd.DataFrame(columns=cols)
         else:
             out = pd.concat(long_parts, ignore_index=True)
+        if pool and not out.empty:
+            out = _pool_reference_expression_rows(out)
         _attach_reference_expression_attrs(
             out,
             availability if on_missing != "omit" else None,
@@ -2249,6 +2291,9 @@ def cancer_reference_expression_availability(
     *,
     sample_qc: str = "pass",
     reference_source: str = "artifact",
+    source_kind: str | Iterable[str] | None = None,
+    source_cohort: str | Iterable[str] | None = None,
+    exclude_microarray_proxy: bool = False,
 ) -> pd.DataFrame:
     """Availability/provenance table for :func:`cancer_reference_expression`.
 
@@ -2260,11 +2305,28 @@ def cancer_reference_expression_availability(
     modes = _reference_normalize_modes(normalize)
     sample_qc = _validate_sample_qc(sample_qc)
     reference_source = _validate_reference_source(reference_source)
+    source_kinds = _normalize_source_filter_values(source_kind)
+    source_cohorts = _normalize_source_filter_values(source_cohort)
+    if reference_source == "summary_rows_all" and sample_qc != "all":
+        raise ValueError('reference_source="summary_rows_all" requires sample_qc="all"')
+    if (source_kinds or source_cohorts or exclude_microarray_proxy) and (
+        reference_source != "summary_rows_all"
+    ):
+        raise ValueError(
+            "source_kind, source_cohort, and exclude_microarray_proxy are only "
+            "supported with reference_source='summary_rows_all'"
+        )
     requests = _reference_expression_requests(
         cancer_types, modes, reference_source=reference_source, sample_qc=sample_qc
     )
     return _reference_expression_availability_for_requests(
-        requests, modes, sample_qc=sample_qc, reference_source=reference_source
+        requests,
+        modes,
+        sample_qc=sample_qc,
+        reference_source=reference_source,
+        source_kinds=source_kinds,
+        source_cohorts=source_cohorts,
+        exclude_microarray_proxy=exclude_microarray_proxy,
     )
 
 
@@ -2307,15 +2369,20 @@ _REFERENCE_PROVENANCE_COLUMNS = [
     "metastasis_site",
     "n_reference_genes",
     "n_reference_samples",
+    "n_samples",
+    "n_detected",
+    "processing_pipeline",
+    "notes",
     "reference_method",
     "sample_qc",
     "data_version",
     "source_matrix_version",
 ]
 
-_REFERENCE_SOURCES = {"artifact", "summary_rows"}
+_REFERENCE_SOURCES = {"artifact", "summary_rows", "summary_rows_all"}
 _REFERENCE_SUMMARY_DATASET = "cancer-reference-expression"
 _REFERENCE_SUMMARY_METHOD = "source_summary_rows"
+_REFERENCE_SUMMARY_ALL_METHOD = "source_summary_rows_all"
 _REFERENCE_RECOMPUTED_METHOD = "source_matrix_stats"
 _REFERENCE_TUMOR_ORIGIN_RANK = {
     "primary": 0,
@@ -2369,7 +2436,7 @@ def _reference_expression_requests(
 def _reference_available_codes_for_modes(
     modes: list[str], *, reference_source: str, sample_qc: str
 ) -> list[str]:
-    if reference_source == "summary_rows":
+    if reference_source in {"summary_rows", "summary_rows_all"}:
         if sample_qc == "all":
             return _reference_summary_available_codes()
         return sorted(source_matrices.available_cohorts())
@@ -2387,11 +2454,22 @@ def _reference_expression_availability_for_requests(
     *,
     sample_qc: str,
     reference_source: str,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
 ) -> pd.DataFrame:
     percentile_available = set(available_percentile_cohorts())
     source_matrix_available = set(source_matrices.available_cohorts())
     summary_available = (
-        set(_reference_summary_available_codes()) if reference_source == "summary_rows" else set()
+        set(
+            _reference_summary_available_codes(
+                source_kinds=source_kinds,
+                source_cohorts=source_cohorts,
+                exclude_microarray_proxy=exclude_microarray_proxy,
+            )
+        )
+        if reference_source in {"summary_rows", "summary_rows_all"}
+        else set()
     )
     rows: list[dict] = []
     for request in requests:
@@ -2449,6 +2527,10 @@ def _reference_expression_availability_for_requests(
         "metastasis_site",
         "n_reference_genes",
         "n_reference_samples",
+        "n_samples",
+        "n_detected",
+        "processing_pipeline",
+        "notes",
         "reference_method",
         "sample_qc",
         "artifact_schema_version",
@@ -2473,7 +2555,7 @@ def _reference_mode_availability(
     sample_qc: str,
     reference_source: str,
 ) -> tuple[bool, str]:
-    if reference_source == "summary_rows":
+    if reference_source in {"summary_rows", "summary_rows_all"}:
         if sample_qc == "all":
             return (True, "") if code in summary_available else (False, "no_reference_summary_rows")
         if code not in source_matrix_available:
@@ -2513,6 +2595,8 @@ def _source_matrix_effective_sample_count(code: str, sample_qc: str) -> int | No
 
 
 def _reference_expected_method(mode: str, *, sample_qc: str, reference_source: str) -> str:
+    if reference_source == "summary_rows_all":
+        return _REFERENCE_SUMMARY_ALL_METHOD
     if reference_source == "summary_rows":
         return _REFERENCE_SUMMARY_METHOD if sample_qc == "all" else _REFERENCE_RECOMPUTED_METHOD
     if mode in {"tpm_clean", "tpm_clean_biological"}:
@@ -2597,7 +2681,22 @@ def _reference_expression_frame(
     auto_fetch: bool,
     sample_qc: str,
     reference_source: str,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
 ) -> tuple[pd.DataFrame, str]:
+    if reference_source == "summary_rows_all":
+        return (
+            _reference_summary_expression_frame(
+                code,
+                mode,
+                all_sources=True,
+                source_kinds=source_kinds,
+                source_cohorts=source_cohorts,
+                exclude_microarray_proxy=exclude_microarray_proxy,
+            ),
+            _REFERENCE_SUMMARY_ALL_METHOD,
+        )
     if reference_source == "summary_rows":
         if sample_qc == "all":
             return _reference_summary_expression_frame(code, mode), _REFERENCE_SUMMARY_METHOD
@@ -2628,8 +2727,18 @@ def _reference_summary_frame() -> pd.DataFrame:
     return get_data(_REFERENCE_SUMMARY_DATASET, copy=False)
 
 
-def _reference_summary_available_codes() -> list[str]:
-    table = _reference_summary_source_table()
+def _reference_summary_available_codes(
+    *,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
+) -> list[str]:
+    table = _filter_reference_summary_sources(
+        _reference_summary_source_table(),
+        source_kinds=source_kinds,
+        source_cohorts=source_cohorts,
+        exclude_microarray_proxy=exclude_microarray_proxy,
+    )
     if table.empty:
         return []
     return sorted(table["cancer_code"].astype(str).unique())
@@ -2647,6 +2756,8 @@ def _reference_summary_source_table() -> pd.DataFrame:
         "metastasis_site",
         "n_reference_genes",
         "n_reference_samples",
+        "processing_pipeline",
+        "notes",
         "selected",
     ]
     if df.empty:
@@ -2654,6 +2765,9 @@ def _reference_summary_source_table() -> pd.DataFrame:
     work = df.copy()
     work["cancer_code"] = work["cancer_code"].astype(str)
     work["source_cohort"] = work["source_cohort"].fillna("").astype(str)
+    for optional_col in ("processing_pipeline", "notes"):
+        if optional_col not in work.columns:
+            work[optional_col] = pd.NA
     grouped = (
         work.groupby(["cancer_code", "source_cohort"], dropna=False, sort=False)
         .agg(
@@ -2663,6 +2777,8 @@ def _reference_summary_source_table() -> pd.DataFrame:
             metastasis_site=("metastasis_site", "first"),
             n_reference_genes=("Ensembl_Gene_ID", "nunique"),
             n_reference_samples=("n_samples", "max"),
+            processing_pipeline=("processing_pipeline", "first"),
+            notes=("notes", "first"),
         )
         .reset_index()
     )
@@ -2710,8 +2826,89 @@ def _reference_summary_selected_rows(code: str) -> pd.DataFrame:
     return df.loc[mask].copy()
 
 
-def _reference_summary_expression_frame(code: str, mode: str) -> pd.DataFrame:
-    rows = _reference_summary_selected_rows(code)
+def _normalize_source_filter_values(values: str | Iterable[str] | None) -> set[str] | None:
+    if values is None:
+        return None
+    raw = [values] if isinstance(values, str) else list(values)
+    return {str(v) for v in raw if str(v)}
+
+
+@lru_cache(maxsize=1)
+def _source_cohort_kind_map() -> dict[str, str]:
+    cr = cohort_registry_df()
+    if cr.empty or "cohort_id" not in cr.columns or "kind" not in cr.columns:
+        return {}
+    return dict(zip(cr["cohort_id"].astype(str), cr["kind"].astype(str)))
+
+
+_register_derived_cache(_source_cohort_kind_map.cache_clear)
+
+
+def _filter_reference_summary_sources(
+    table: pd.DataFrame,
+    *,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
+) -> pd.DataFrame:
+    out = table.copy()
+    if out.empty:
+        return out
+    if source_cohorts:
+        out = out.loc[out["source_cohort"].astype(str).isin(source_cohorts)]
+    if source_kinds:
+        kind_map = _source_cohort_kind_map()
+        out = out.loc[out["source_cohort"].astype(str).map(kind_map).isin(source_kinds)]
+    if exclude_microarray_proxy:
+        pipeline = out.get("processing_pipeline", pd.Series("", index=out.index)).fillna("")
+        text = pipeline.astype(str).str.lower()
+        out = out.loc[~text.str.contains("microarray|tpm_proxy|tpm-proxy", regex=True)]
+    return out
+
+
+def _reference_summary_all_rows(
+    code: str,
+    *,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
+) -> pd.DataFrame:
+    sources = _filter_reference_summary_sources(
+        _reference_summary_source_table(),
+        source_kinds=source_kinds,
+        source_cohorts=source_cohorts,
+        exclude_microarray_proxy=exclude_microarray_proxy,
+    )
+    sources = sources.loc[sources["cancer_code"].astype(str) == str(code)]
+    if sources.empty:
+        return pd.DataFrame(columns=_reference_summary_frame().columns)
+    allowed = set(sources["source_cohort"].astype(str))
+    df = _reference_summary_frame()
+    mask = (df["cancer_code"].astype(str) == str(code)) & (
+        df["source_cohort"].fillna("").astype(str).isin(allowed)
+    )
+    return df.loc[mask].copy()
+
+
+def _reference_summary_expression_frame(
+    code: str,
+    mode: str,
+    *,
+    all_sources: bool = False,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
+) -> pd.DataFrame:
+    rows = (
+        _reference_summary_all_rows(
+            code,
+            source_kinds=source_kinds,
+            source_cohorts=source_cohorts,
+            exclude_microarray_proxy=exclude_microarray_proxy,
+        )
+        if all_sources
+        else _reference_summary_selected_rows(code)
+    )
     if rows.empty:
         return pd.DataFrame(columns=["Ensembl_Gene_ID", "Symbol", "p25", "p50", "p75"])
     if mode == "tpm_raw":
@@ -2720,11 +2917,140 @@ def _reference_summary_expression_frame(code: str, mode: str) -> pd.DataFrame:
         col_map = {"TPM_clean_q1": "p25", "TPM_clean_median": "p50", "TPM_clean_q3": "p75"}
     else:
         raise AssertionError(f"unhandled reference normalize mode: {mode}")
-    out = rows[["Ensembl_Gene_ID", "Symbol", *col_map]].rename(columns=col_map).copy()
+    provenance_cols = [
+        "cancer_code",
+        "source_cohort",
+        "source_project",
+        "source_version",
+        "n_samples",
+        "n_detected",
+        "processing_pipeline",
+        "notes",
+        "tumor_origin",
+        "metastasis_site",
+    ]
+    keep = ["Ensembl_Gene_ID", "Symbol", *col_map]
+    if all_sources:
+        keep.extend(c for c in provenance_cols if c in rows.columns)
+    out = rows[keep].rename(columns=col_map).copy()
     if mode == "tpm_clean_log1p":
         for col in ("p25", "p50", "p75"):
             out[col] = np.log1p(pd.to_numeric(out[col], errors="coerce"))
+    if all_sources:
+        out = _attach_summary_row_provenance(out, code=code)
     return out
+
+
+def _attach_summary_row_provenance(df: pd.DataFrame, *, code: str) -> pd.DataFrame:
+    if df.empty:
+        return df
+    out = df.copy()
+    source_counts = (
+        out.groupby("source_cohort", dropna=False)
+        .agg(
+            n_reference_genes=("Ensembl_Gene_ID", "nunique"),
+            n_reference_samples=("n_samples", "max"),
+        )
+        .reset_index()
+    )
+    source_meta = source_counts.set_index("source_cohort").to_dict("index")
+    meta_by_source = {
+        str(source): _selected_expression_source_metadata(code, source_cohort=str(source))
+        for source in out["source_cohort"].fillna("").astype(str).unique()
+    }
+    source_key = out["source_cohort"].fillna("").astype(str)
+    out["source_type"] = source_key.map(
+        lambda source: meta_by_source.get(source, {}).get("source_type")
+    )
+    out["source_unit"] = source_key.map(lambda source: meta_by_source.get(source, {}).get("unit"))
+    out["source_scale_class"] = source_key.map(
+        lambda source: meta_by_source.get(source, {}).get("source_scale_class")
+    )
+    out["linear_tpm_comparable"] = source_key.map(
+        lambda source: bool(meta_by_source.get(source, {}).get("linear_tpm_comparable"))
+    )
+    out["n_reference_genes"] = source_key.map(
+        lambda source: source_meta.get(source, {}).get("n_reference_genes")
+    )
+    out["n_reference_samples"] = source_key.map(
+        lambda source: source_meta.get(source, {}).get("n_reference_samples")
+    )
+    out["reference_method"] = _REFERENCE_SUMMARY_ALL_METHOD
+    out["sample_qc"] = "all"
+    out["data_version"] = DATA_VERSION
+    out["source_matrix_version"] = SOURCE_MATRIX_VERSION
+    return out
+
+
+def _first_nonempty(values: pd.Series) -> object:
+    for value in values:
+        if pd.notna(value) and str(value):
+            return value
+    return pd.NA
+
+
+def _join_nonempty(values: pd.Series) -> str:
+    vals = sorted({str(v) for v in values if pd.notna(v) and str(v)})
+    return ";".join(vals)
+
+
+def _pool_reference_expression_rows(long: pd.DataFrame) -> pd.DataFrame:
+    """Pool source-union reference rows by gene with n-sample weighted means."""
+    if long.empty:
+        return long
+    out_rows: list[dict[str, object]] = []
+    group_cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code", "normalization"]
+    for keys, group in long.groupby(group_cols, dropna=False, sort=False):
+        row = dict(zip(group_cols, keys))
+        expr = pd.to_numeric(group["expression"], errors="coerce")
+        weights = pd.to_numeric(
+            group.get(
+                "n_reference_samples", group.get("n_samples", pd.Series(1, index=group.index))
+            ),
+            errors="coerce",
+        ).fillna(0.0)
+        valid = expr.notna() & (weights > 0)
+        if valid.any():
+            row["expression"] = float(np.average(expr[valid], weights=weights[valid]))
+            pooled_n = float(weights[valid].sum())
+        else:
+            row["expression"] = np.nan
+            pooled_n = 0.0
+        row["q1"] = np.nan
+        row["q3"] = np.nan
+        row["source_cohort"] = "POOLED"
+        row["source_project"] = "pooled_source_union"
+        row["source_version"] = _join_nonempty(group.get("source_version", pd.Series(dtype=object)))
+        row["source_type"] = "pooled"
+        row["source_unit"] = _first_nonempty(group.get("source_unit", pd.Series(dtype=object)))
+        scale_classes = {
+            str(v)
+            for v in group.get("source_scale_class", pd.Series(dtype=object))
+            if pd.notna(v) and str(v)
+        }
+        row["source_scale_class"] = scale_classes.pop() if len(scale_classes) == 1 else "mixed"
+        comparable = group.get("linear_tpm_comparable", pd.Series(False, index=group.index))
+        row["linear_tpm_comparable"] = bool(pd.Series(comparable).fillna(False).all())
+        row["tumor_origin"] = _join_nonempty(group.get("tumor_origin", pd.Series(dtype=object)))
+        row["metastasis_site"] = _join_nonempty(
+            group.get("metastasis_site", pd.Series(dtype=object))
+        )
+        row["n_reference_genes"] = 1
+        row["n_reference_samples"] = pooled_n
+        row["n_samples"] = pooled_n
+        if "n_detected" in group.columns:
+            row["n_detected"] = float(pd.to_numeric(group["n_detected"], errors="coerce").sum())
+        else:
+            row["n_detected"] = np.nan
+        row["processing_pipeline"] = "pooled_n_weighted"
+        row["notes"] = _join_nonempty(group.get("notes", pd.Series(dtype=object)))
+        row["reference_method"] = "pooled_source_summary_rows"
+        row["sample_qc"] = _first_nonempty(group.get("sample_qc", pd.Series(dtype=object)))
+        row["data_version"] = DATA_VERSION
+        row["source_matrix_version"] = SOURCE_MATRIX_VERSION
+        out_rows.append(row)
+    cols = [c for c in long.columns if c in out_rows[0]]
+    return pd.DataFrame(out_rows, columns=cols)
 
 
 def _reference_summary_source_metadata(code: str) -> dict[str, str | bool | int | float | None]:

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2115,10 +2115,12 @@ def cancer_reference_expression(
             "source_kind, source_cohort, exclude_microarray_proxy, and pool are "
             "only supported with reference_source='summary_rows_all'"
         )
-    if pool and format != "long":
-        raise ValueError("pool=True requires format='long'")
     if format not in ("long", "wide"):
         raise ValueError("format must be 'long' or 'wide'")
+    if reference_source == "summary_rows_all" and format != "long":
+        raise ValueError('reference_source="summary_rows_all" requires format="long"')
+    if pool and format != "long":
+        raise ValueError("pool=True requires format='long'")
     if on_missing not in ("omit", "empty", "raise"):
         raise ValueError("on_missing must be 'omit', 'empty', or 'raise'")
     if include_request_metadata and format != "long":
@@ -2127,7 +2129,13 @@ def cancer_reference_expression(
         raise ValueError("include_gene_universe_flags=True requires format='long'")
 
     requests = _reference_expression_requests(
-        cancer_types, modes, reference_source=reference_source, sample_qc=sample_qc
+        cancer_types,
+        modes,
+        reference_source=reference_source,
+        sample_qc=sample_qc,
+        source_kinds=source_kinds,
+        source_cohorts=source_cohorts,
+        exclude_microarray_proxy=exclude_microarray_proxy,
     )
     availability = _reference_expression_availability_for_requests(
         requests,
@@ -2202,6 +2210,13 @@ def cancer_reference_expression(
                     part["available"] = bool(request_row.available)
                     part["missing_reason"] = str(request_row.missing_reason)
                 part = part.rename(columns={"p50": "expression", "p25": "q1", "p75": "q3"})
+                source_union_identity = method == _REFERENCE_SUMMARY_ALL_METHOD
+                if source_union_identity:
+                    for col in _REFERENCE_SOURCE_UNION_IDENTITY_COLUMNS:
+                        if col in ref.columns:
+                            part[col] = ref[col].to_numpy()
+                        else:
+                            part[col] = pd.NA
                 if include_provenance:
                     if method == _REFERENCE_SUMMARY_ALL_METHOD:
                         for col in _REFERENCE_PROVENANCE_COLUMNS:
@@ -2226,6 +2241,7 @@ def cancer_reference_expression(
                             include_provenance,
                             include_request_metadata,
                             include_gene_universe_flags,
+                            source_union_identity=source_union_identity,
                         )
                     ]
                 )
@@ -2241,6 +2257,7 @@ def cancer_reference_expression(
             include_provenance,
             include_request_metadata,
             include_gene_universe_flags,
+            source_union_identity=reference_source == "summary_rows_all",
         )
         if not long_parts:
             out = pd.DataFrame(columns=cols)
@@ -2317,7 +2334,13 @@ def cancer_reference_expression_availability(
             "supported with reference_source='summary_rows_all'"
         )
     requests = _reference_expression_requests(
-        cancer_types, modes, reference_source=reference_source, sample_qc=sample_qc
+        cancer_types,
+        modes,
+        reference_source=reference_source,
+        sample_qc=sample_qc,
+        source_kinds=source_kinds,
+        source_cohorts=source_cohorts,
+        exclude_microarray_proxy=exclude_microarray_proxy,
     )
     return _reference_expression_availability_for_requests(
         requests,
@@ -2379,6 +2402,13 @@ _REFERENCE_PROVENANCE_COLUMNS = [
     "source_matrix_version",
 ]
 
+_REFERENCE_SOURCE_UNION_IDENTITY_COLUMNS = [
+    "source_cohort",
+    "n_reference_samples",
+    "n_samples",
+    "n_detected",
+]
+
 _REFERENCE_SOURCES = {"artifact", "summary_rows", "summary_rows_all"}
 _REFERENCE_SUMMARY_DATASET = "cancer-reference-expression"
 _REFERENCE_SUMMARY_METHOD = "source_summary_rows"
@@ -2404,13 +2434,21 @@ def _reference_expression_requests(
     *,
     reference_source: str,
     sample_qc: str,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
 ) -> list[dict[str, str]]:
     """Resolved request rows while preserving aggregate-vs-direct intent."""
     if cancer_types is None:
         return [
             {"requested_code": code, "cancer_code": code, "request_kind": "default_available"}
             for code in _reference_available_codes_for_modes(
-                modes, reference_source=reference_source, sample_qc=sample_qc
+                modes,
+                reference_source=reference_source,
+                sample_qc=sample_qc,
+                source_kinds=source_kinds,
+                source_cohorts=source_cohorts,
+                exclude_microarray_proxy=exclude_microarray_proxy,
             )
         ]
     raw_values = [cancer_types] if isinstance(cancer_types, str) else list(cancer_types)
@@ -2434,11 +2472,21 @@ def _reference_expression_requests(
 
 
 def _reference_available_codes_for_modes(
-    modes: list[str], *, reference_source: str, sample_qc: str
+    modes: list[str],
+    *,
+    reference_source: str,
+    sample_qc: str,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
 ) -> list[str]:
     if reference_source in {"summary_rows", "summary_rows_all"}:
         if sample_qc == "all":
-            return _reference_summary_available_codes()
+            return _reference_summary_available_codes(
+                source_kinds=source_kinds,
+                source_cohorts=source_cohorts,
+                exclude_microarray_proxy=exclude_microarray_proxy,
+            )
         return sorted(source_matrices.available_cohorts())
     out: set[str] = set()
     if any(mode in {"tpm_clean", "tpm_clean_biological", "tpm_clean_log1p"} for mode in modes):
@@ -2663,12 +2711,16 @@ def _reference_long_columns(
     include_provenance: bool,
     include_request_metadata: bool,
     include_gene_universe_flags: bool,
+    *,
+    source_union_identity: bool = False,
 ) -> list[str]:
     cols = ["Ensembl_Gene_ID", "Symbol", "cancer_code", "normalization"]
     if include_request_metadata:
         cols += _REFERENCE_REQUEST_COLUMNS
     if include_provenance:
         cols += _REFERENCE_PROVENANCE_COLUMNS
+    elif source_union_identity:
+        cols += _REFERENCE_SOURCE_UNION_IDENTITY_COLUMNS
     if include_gene_universe_flags:
         cols += _ARTIFACT_GENE_UNIVERSE_FLAG_COLUMNS
     return [*cols, "expression", "q1", "q3"]

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1515,6 +1515,10 @@ def test_cancer_reference_expression_long_and_wide(monkeypatch):
         "metastasis_site",
         "n_reference_genes",
         "n_reference_samples",
+        "n_samples",
+        "n_detected",
+        "processing_pipeline",
+        "notes",
         "reference_method",
         "sample_qc",
         "data_version",
@@ -1647,6 +1651,10 @@ def test_cancer_reference_expression_availability_reports_missing(monkeypatch):
         "metastasis_site",
         "n_reference_genes",
         "n_reference_samples",
+        "n_samples",
+        "n_detected",
+        "processing_pipeline",
+        "notes",
         "reference_method",
         "sample_qc",
         "artifact_schema_version",
@@ -1685,6 +1693,10 @@ def test_cancer_reference_expression_missing_empty_and_raise(monkeypatch):
         "metastasis_site",
         "n_reference_genes",
         "n_reference_samples",
+        "n_samples",
+        "n_detected",
+        "processing_pipeline",
+        "notes",
         "reference_method",
         "sample_qc",
         "data_version",
@@ -1824,6 +1836,143 @@ def test_cancer_reference_expression_summary_rows_selects_richest_source(monkeyp
     ).set_index("normalization")
     assert raw_log.loc["tpm_raw", "expression"] == pytest.approx(10.0)
     assert raw_log.loc["tpm_clean_log1p", "expression"] == pytest.approx(np.log1p(1.0))
+    expression._reference_summary_source_table.cache_clear()
+
+
+def test_cancer_reference_expression_summary_rows_all_preserves_sources_and_filters(monkeypatch):
+    expression._reference_summary_source_table.cache_clear()
+    expression._source_cohort_kind_map.cache_clear()
+    summary = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1", "E1", "E2"],
+            "Symbol": ["A", "A", "B"],
+            "cancer_code": ["X", "X", "X"],
+            "source_cohort": ["GEO_X", "TREE_X", "TREE_X"],
+            "source_project": ["GEO", "Treehouse", "Treehouse"],
+            "source_version": ["v1", "v2", "v2"],
+            "TPM_median": [10.0, 20.0, 30.0],
+            "TPM_q1": [9.0, 19.0, 29.0],
+            "TPM_q3": [11.0, 21.0, 31.0],
+            "TPM_clean_median": [1.0, 2.0, 3.0],
+            "TPM_clean_q1": [0.9, 1.9, 2.9],
+            "TPM_clean_q3": [1.1, 2.1, 3.1],
+            "n_samples": [4, 8, 8],
+            "n_detected": [3, 8, 7],
+            "processing_pipeline": [
+                "geo_microarray_tpm_proxy_clean_tpm_16_9_75",
+                "treehouse_polya_tpm_clean_tpm_16_9_75",
+                "treehouse_polya_tpm_clean_tpm_16_9_75",
+            ],
+            "notes": ["geo notes", "tree notes", "tree notes"],
+            "tumor_origin": ["primary", "mixed", "mixed"],
+            "metastasis_site": [pd.NA, pd.NA, pd.NA],
+        }
+    )
+    registry = pd.DataFrame(
+        {
+            "cohort_id": ["GEO_X", "TREE_X"],
+            "kind": ["geo", "treehouse"],
+        }
+    )
+    monkeypatch.setattr(expression, "_reference_summary_frame", lambda: summary)
+    monkeypatch.setattr(expression, "cohort_registry_df", lambda: registry)
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code, **k: str(code).upper())
+    monkeypatch.setattr(expression.source_matrices, "available_cohorts", lambda: [])
+
+    out = expression.cancer_reference_expression(
+        "x",
+        genes="E1",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+    )
+
+    assert out.attrs["reference_source"] == "summary_rows_all"
+    assert out["source_cohort"].tolist() == ["GEO_X", "TREE_X"]
+    assert out["processing_pipeline"].tolist() == [
+        "geo_microarray_tpm_proxy_clean_tpm_16_9_75",
+        "treehouse_polya_tpm_clean_tpm_16_9_75",
+    ]
+    assert out["n_samples"].tolist() == [4, 8]
+    assert out["n_detected"].tolist() == [3, 8]
+    assert out["reference_method"].unique().tolist() == ["source_summary_rows_all"]
+
+    tree = expression.cancer_reference_expression(
+        "x",
+        genes="E1",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        source_kind="treehouse",
+    )
+    assert tree["source_cohort"].tolist() == ["TREE_X"]
+
+    non_proxy = expression.cancer_reference_expression(
+        "x",
+        genes="E1",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        exclude_microarray_proxy=True,
+    )
+    assert non_proxy["source_cohort"].tolist() == ["TREE_X"]
+
+    empty = expression.cancer_reference_expression_availability(
+        "x",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        source_kind="curated",
+    )
+    assert bool(empty.loc[0, "available"]) is False
+    assert empty.loc[0, "missing_reason"] == "no_reference_summary_rows"
+
+    expression._reference_summary_source_table.cache_clear()
+    expression._source_cohort_kind_map.cache_clear()
+
+
+def test_cancer_reference_expression_summary_rows_all_pool(monkeypatch):
+    expression._reference_summary_source_table.cache_clear()
+    summary = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1", "E1"],
+            "Symbol": ["A", "A"],
+            "cancer_code": ["X", "X"],
+            "source_cohort": ["SRC1", "SRC2"],
+            "source_project": ["P1", "P2"],
+            "source_version": ["v1", "v2"],
+            "TPM_median": [10.0, 20.0],
+            "TPM_q1": [9.0, 19.0],
+            "TPM_q3": [11.0, 21.0],
+            "TPM_clean_median": [1.0, 2.0],
+            "TPM_clean_q1": [0.9, 1.9],
+            "TPM_clean_q3": [1.1, 2.1],
+            "n_samples": [2, 6],
+            "n_detected": [2, 5],
+            "processing_pipeline": ["rna_seq", "rna_seq"],
+            "notes": ["a", "b"],
+            "tumor_origin": ["primary", "primary"],
+            "metastasis_site": [pd.NA, pd.NA],
+        }
+    )
+    monkeypatch.setattr(expression, "_reference_summary_frame", lambda: summary)
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code, **k: str(code).upper())
+
+    pooled = expression.cancer_reference_expression(
+        "x",
+        normalize="tpm",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        pool=True,
+    )
+
+    assert len(pooled) == 1
+    row = pooled.iloc[0]
+    assert row["source_cohort"] == "POOLED"
+    assert row["expression"] == pytest.approx((10.0 * 2 + 20.0 * 6) / 8)
+    assert pd.isna(row["q1"]) and pd.isna(row["q3"])
+    assert row["n_reference_samples"] == pytest.approx(8)
+    assert row["processing_pipeline"] == "pooled_n_weighted"
+
+    with pytest.raises(ValueError, match='requires sample_qc="all"'):
+        expression.cancer_reference_expression("x", reference_source="summary_rows_all")
+
     expression._reference_summary_source_table.cache_clear()
 
 

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1844,34 +1844,35 @@ def test_cancer_reference_expression_summary_rows_all_preserves_sources_and_filt
     expression._source_cohort_kind_map.cache_clear()
     summary = pd.DataFrame(
         {
-            "Ensembl_Gene_ID": ["E1", "E1", "E2"],
-            "Symbol": ["A", "A", "B"],
-            "cancer_code": ["X", "X", "X"],
-            "source_cohort": ["GEO_X", "TREE_X", "TREE_X"],
-            "source_project": ["GEO", "Treehouse", "Treehouse"],
-            "source_version": ["v1", "v2", "v2"],
-            "TPM_median": [10.0, 20.0, 30.0],
-            "TPM_q1": [9.0, 19.0, 29.0],
-            "TPM_q3": [11.0, 21.0, 31.0],
-            "TPM_clean_median": [1.0, 2.0, 3.0],
-            "TPM_clean_q1": [0.9, 1.9, 2.9],
-            "TPM_clean_q3": [1.1, 2.1, 3.1],
-            "n_samples": [4, 8, 8],
-            "n_detected": [3, 8, 7],
+            "Ensembl_Gene_ID": ["E1", "E1", "E2", "E1"],
+            "Symbol": ["A", "A", "B", "A"],
+            "cancer_code": ["X", "X", "X", "Y"],
+            "source_cohort": ["GEO_X", "TREE_X", "TREE_X", "GEO_Y"],
+            "source_project": ["GEO", "Treehouse", "Treehouse", "GEO"],
+            "source_version": ["v1", "v2", "v2", "v1"],
+            "TPM_median": [10.0, 20.0, 30.0, 40.0],
+            "TPM_q1": [9.0, 19.0, 29.0, 39.0],
+            "TPM_q3": [11.0, 21.0, 31.0, 41.0],
+            "TPM_clean_median": [1.0, 2.0, 3.0, 4.0],
+            "TPM_clean_q1": [0.9, 1.9, 2.9, 3.9],
+            "TPM_clean_q3": [1.1, 2.1, 3.1, 4.1],
+            "n_samples": [4, 8, 8, 3],
+            "n_detected": [3, 8, 7, 2],
             "processing_pipeline": [
                 "geo_microarray_tpm_proxy_clean_tpm_16_9_75",
                 "treehouse_polya_tpm_clean_tpm_16_9_75",
                 "treehouse_polya_tpm_clean_tpm_16_9_75",
+                "geo_microarray_tpm_proxy_clean_tpm_16_9_75",
             ],
-            "notes": ["geo notes", "tree notes", "tree notes"],
-            "tumor_origin": ["primary", "mixed", "mixed"],
-            "metastasis_site": [pd.NA, pd.NA, pd.NA],
+            "notes": ["geo notes", "tree notes", "tree notes", "geo y notes"],
+            "tumor_origin": ["primary", "mixed", "mixed", "primary"],
+            "metastasis_site": [pd.NA, pd.NA, pd.NA, pd.NA],
         }
     )
     registry = pd.DataFrame(
         {
-            "cohort_id": ["GEO_X", "TREE_X"],
-            "kind": ["geo", "treehouse"],
+            "cohort_id": ["GEO_X", "TREE_X", "GEO_Y"],
+            "kind": ["geo", "treehouse", "geo"],
         }
     )
     monkeypatch.setattr(expression, "_reference_summary_frame", lambda: summary)
@@ -1896,6 +1897,26 @@ def test_cancer_reference_expression_summary_rows_all_preserves_sources_and_filt
     assert out["n_detected"].tolist() == [3, 8]
     assert out["reference_method"].unique().tolist() == ["source_summary_rows_all"]
 
+    compact = expression.cancer_reference_expression(
+        "x",
+        genes="E1",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        include_provenance=False,
+    )
+    assert compact["source_cohort"].tolist() == ["GEO_X", "TREE_X"]
+    assert compact["n_reference_samples"].tolist() == [4, 8]
+    assert compact["n_samples"].tolist() == [4, 8]
+    assert "processing_pipeline" not in compact.columns
+
+    with pytest.raises(ValueError, match='requires format="long"'):
+        expression.cancer_reference_expression(
+            "x",
+            reference_source="summary_rows_all",
+            sample_qc="all",
+            format="wide",
+        )
+
     tree = expression.cancer_reference_expression(
         "x",
         genes="E1",
@@ -1913,6 +1934,23 @@ def test_cancer_reference_expression_summary_rows_all_preserves_sources_and_filt
         exclude_microarray_proxy=True,
     )
     assert non_proxy["source_cohort"].tolist() == ["TREE_X"]
+
+    all_tree = expression.cancer_reference_expression(
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        source_kind="treehouse",
+        on_missing="raise",
+    )
+    assert all_tree["cancer_code"].unique().tolist() == ["X"]
+    assert all_tree["source_cohort"].unique().tolist() == ["TREE_X"]
+
+    filtered_availability = expression.cancer_reference_expression_availability(
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        source_kind="treehouse",
+    )
+    assert filtered_availability["cancer_code"].tolist() == ["X"]
+    assert filtered_availability["available"].tolist() == [True]
 
     empty = expression.cancer_reference_expression_availability(
         "x",
@@ -1969,6 +2007,20 @@ def test_cancer_reference_expression_summary_rows_all_pool(monkeypatch):
     assert pd.isna(row["q1"]) and pd.isna(row["q3"])
     assert row["n_reference_samples"] == pytest.approx(8)
     assert row["processing_pipeline"] == "pooled_n_weighted"
+
+    compact = expression.cancer_reference_expression(
+        "x",
+        normalize="tpm",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        pool=True,
+        include_provenance=False,
+    )
+    assert len(compact) == 1
+    assert compact.loc[0, "source_cohort"] == "POOLED"
+    assert compact.loc[0, "expression"] == pytest.approx((10.0 * 2 + 20.0 * 6) / 8)
+    assert compact.loc[0, "n_reference_samples"] == pytest.approx(8)
+    assert "processing_pipeline" not in compact.columns
 
     with pytest.raises(ValueError, match='requires sample_qc="all"'):
         expression.cancer_reference_expression("x", reference_source="summary_rows_all")


### PR DESCRIPTION
## Summary

Progresses #207 by adding an explicit source-union mode to `cancer_reference_expression(...)`:

- adds `reference_source="summary_rows_all"` to return all shipped `cancer-reference-expression` sidecar rows instead of only the richest-source selected row;
- preserves per-source provenance fields including `n_samples`, `n_detected`, `processing_pipeline`, and `notes`;
- adds `source_kind`, `source_cohort`, and `exclude_microarray_proxy` filters for the source-union view;
- adds long-form `pool=True` for an explicit n-sample-weighted pooled source-union view;
- documents that `summary_rows_all` is intentionally all-sample only and rejects `sample_qc="pass"` / `"pass_or_warn"` until QC-filtered all-source artifacts are rebuilt.

## Issue Scope

This PR addresses the all-source reference-expression read-path part of #207. It does not close the broader expression migration by itself.

## Still Outstanding

- #329: emit classifier-ready pooled reference-expression columns for grouping/aggregate codes like NET, CRC, NSCLC, BTC, and SGC.
- #330 / #321 / #322: distinguish diagnosable classification targets from source-scope response cohorts in the ontology/registry.
- #209: finish the downstream-stable data-bundle/download contract.
- #296: continue hoisting expression ingestion builders end-to-end.
- #69: broader classifier-ready reference matrix products.
- #158/#159/#177 and related audit issues: source anchoring/provenance for clinical and burden facts.

## Validation

- `python -m pytest tests/test_expression.py -q` -> 98 passed.
- `./lint.sh` -> passed.
- `./test.sh` -> 707 passed, 1 existing matplotlib open-figures warning.
