### PR TITLE
[codex] Add computed aggregate reference-expression columns

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -78,8 +78,8 @@ msi_crc[["code", "evidence_source_code", "normal_tissue_code", "hpa_tissues"]]
 # Join scalar references for the returned codes.
 cancer_ontology.cancer_type_reference_data(msi_crc)
 
-# Ask whether each ontology node has a direct expression reference or only
-# molecular/no expression evidence.
+# Ask whether each ontology node has a direct expression reference, a computed
+# member-union reference, or only molecular/no expression evidence.
 cancer_ontology.expression_reference_coverage(subtype_group="MSI", under="CRC")
 cancer_ontology.coverage_for_cancer_type("ASTB")
 
@@ -95,12 +95,16 @@ cohorts.cohort_registry_df()
 
 `expression_reference_coverage()` is the ontology-wide readiness table for
 classifier consumers. It reports direct observed-bulk source-matrix coverage,
-matched normal tissue availability, molecular/fusion-only definitions, canonical
-gene/proteoform space, data/source-matrix versions, and a conservative
-`consumer_recommendation`: `direct_reference`, `molecular_only`, or
-`unsupported`. It intentionally does not synthesize marker-program or
-discriminator fallbacks; those remain consumer-layer choices in packages such as
-trufflepig.
+computed member-union references for curated grouping/source-scope codes such as
+`NET`, `CRC`, `NSCLC`, `BTC`, and `SGC`, matched normal tissue availability,
+molecular/fusion-only definitions, canonical gene/proteoform space, data/source
+matrix versions, and a conservative `consumer_recommendation`:
+`direct_reference`, `computed_reference`, `molecular_only`, or `unsupported`.
+`has_direct_expression_reference` remains literal; computed groupings use
+`expression_reference_kind="computed_union"` and expose their pooled member codes
+in `computed_expression_member_codes`. The table intentionally does not
+synthesize marker-program or discriminator fallbacks; those remain consumer-layer
+choices in packages such as trufflepig.
 
 ## Gene Identity
 
@@ -291,6 +295,11 @@ columns are `<CODE>_FPKM_raw`, deterministic TCGA TPM companions are
 `_log1p`. For migration code that needs pirlygenes' unsuffixed column names, use
 `column_style="pirlygenes"`; the legacy `to_tpm=True` keyword is accepted as a
 compatibility alias for that view and maps the default call to `normalize="tpm"`.
+The pan-cancer view also emits raw-TPM companion columns for member-backed
+grouping/source-scope references (`NET`, `CRC`, `NSCLC`, `BTC`, `SGC`) by pooling
+the selected `cancer-reference-expression` summary rows with n-sample weights.
+Existing directly sourced columns, including `SARC` and `OV`, keep their current
+source-table behavior.
 
 `expression.cancer_reference_expression()` returns cohort-level tumor reference
 expression with stable long or wide output. It accepts canonical cancer codes,

--- a/oncoref/cancer_types.py
+++ b/oncoref/cancer_types.py
@@ -1171,7 +1171,10 @@ _EXPRESSION_REFERENCE_COVERAGE_COLUMNS = [
     "normal_tissue_code",
     "hpa_tissues",
     "has_matched_normal_expression",
+    "has_expression_reference",
     "has_direct_expression_reference",
+    "has_computed_expression_reference",
+    "computed_expression_member_codes",
     "observed_bulk_reference",
     "deconvolved_tumor_reference",
     "subtype_deconvolved_reference",
@@ -1194,6 +1197,8 @@ _EXPRESSION_REFERENCE_COVERAGE_COLUMNS = [
     "missing_reason",
 ]
 
+_COMPUTED_EXPRESSION_REFERENCE_CODES = frozenset({"NET", "CRC", "NSCLC", "BTC", "SGC"})
+
 
 def _definition_kind(record, raw_record) -> tuple[str, ...]:
     kinds = []
@@ -1211,9 +1216,36 @@ def _definition_kind(record, raw_record) -> tuple[str, ...]:
     return tuple(kinds)
 
 
-def _coverage_recommendation(*, has_direct: bool, molecular_kinds: tuple[str, ...]) -> str:
+def _computed_expression_reference_members(code: str) -> tuple[str, ...]:
+    """Direct-expression members that define a computed reference for a grouping code."""
+    code = str(code)
+    if code not in _COMPUTED_EXPRESSION_REFERENCE_CODES:
+        return ()
+    members = cohort_aggregate_members(code)
+    if members is None:
+        members = _children_map().get(code, ())
+    if not members:
+        return ()
+    source_codes = set(_source_matrix_frame()["cancer_code"].dropna().astype(str))
+    return tuple(member for member in members if member in source_codes)
+
+
+def _computed_expression_reference_sample_count(member_codes: tuple[str, ...]) -> int | None:
+    if not member_codes:
+        return None
+    sm = _source_matrix_frame()
+    hits = sm.loc[sm["cancer_code"].astype(str).isin(member_codes), "source_matrix_n_samples"]
+    counts = pd.to_numeric(hits, errors="coerce").dropna()
+    return int(counts.sum()) if not counts.empty else None
+
+
+def _coverage_recommendation(
+    *, has_direct: bool, has_computed: bool, molecular_kinds: tuple[str, ...]
+) -> str:
     if has_direct:
         return "direct_reference"
+    if has_computed:
+        return "computed_reference"
     if molecular_kinds:
         return "molecular_only"
     return "unsupported"
@@ -1245,9 +1277,32 @@ def expression_reference_coverage(cancer_types=None, **query_kwargs) -> pd.DataF
         code = record["code"]
         raw_record = raw.loc[code] if code in raw.index else {}
         has_direct = bool(record["has_expression_matrix"])
+        computed_members = _computed_expression_reference_members(code)
+        has_computed = bool(computed_members)
+        has_reference = has_direct or has_computed
         molecular_kinds = _definition_kind(record, raw_record)
         has_normal = not _row_is_missing(record["normal_tissue_code"]) and bool(
             record["hpa_tissues"]
+        )
+        reference_kind = (
+            "observed_bulk" if has_direct else "computed_union" if has_computed else "none"
+        )
+        source_matrix_n_samples = (
+            _none_if_missing(record["source_matrix_n_samples"])
+            if has_direct
+            else _computed_expression_reference_sample_count(computed_members)
+        )
+        source_matrix_cohort = (
+            _none_if_missing(record["source_matrix_cohort"])
+            if has_direct
+            else (
+                _none_if_missing(record["source_cohort"])
+                if str(record["expression_source"]) == "computed"
+                and not _row_is_missing(record["source_cohort"])
+                else f"COMPUTED_{code}"
+            )
+            if has_computed
+            else None
         )
         rows.append(
             {
@@ -1267,31 +1322,36 @@ def expression_reference_coverage(cancer_types=None, **query_kwargs) -> pd.DataF
                 "normal_tissue_code": _none_if_missing(record["normal_tissue_code"]),
                 "hpa_tissues": record["hpa_tissues"],
                 "has_matched_normal_expression": has_normal,
+                "has_expression_reference": has_reference,
                 "has_direct_expression_reference": has_direct,
+                "has_computed_expression_reference": has_computed,
+                "computed_expression_member_codes": computed_members,
                 "observed_bulk_reference": has_direct,
                 "deconvolved_tumor_reference": False,
                 "subtype_deconvolved_reference": False,
                 "cell_line_reference": False,
                 "single_cell_pseudobulk_reference": False,
-                "expression_reference_kind": "observed_bulk" if has_direct else "none",
-                "expression_reference_source_code": code if has_direct else None,
-                "source_matrix_cohort": _none_if_missing(record["source_matrix_cohort"]),
-                "source_matrix_n_samples": _none_if_missing(record["source_matrix_n_samples"]),
+                "expression_reference_kind": reference_kind,
+                "expression_reference_source_code": code if has_reference else None,
+                "source_matrix_cohort": source_matrix_cohort,
+                "source_matrix_n_samples": source_matrix_n_samples,
                 "source_cohort": _none_if_missing(record["source_cohort"]),
                 "source_pmid": _none_if_missing(record["source_pmid"]),
-                "normalization_method": "clean_tpm_16_9_75" if has_direct else None,
-                "gene_id_space": "oncoref_canonical_ensg" if has_direct else None,
-                "proteoform_space": "oncoref_proteoform_groups" if has_direct else None,
-                "data_version": DATA_VERSION if has_direct else None,
-                "source_matrix_version": SOURCE_MATRIX_VERSION if has_direct else None,
+                "normalization_method": "clean_tpm_16_9_75" if has_reference else None,
+                "gene_id_space": "oncoref_canonical_ensg" if has_reference else None,
+                "proteoform_space": "oncoref_proteoform_groups" if has_reference else None,
+                "data_version": DATA_VERSION if has_reference else None,
+                "source_matrix_version": SOURCE_MATRIX_VERSION if has_reference else None,
                 "has_molecular_definition": bool(molecular_kinds),
                 "molecular_definition_kind": molecular_kinds,
                 "consumer_recommendation": _coverage_recommendation(
-                    has_direct=has_direct, molecular_kinds=molecular_kinds
+                    has_direct=has_direct,
+                    has_computed=has_computed,
+                    molecular_kinds=molecular_kinds,
                 ),
                 "missing_reason": (
                     None
-                    if has_direct
+                    if has_reference
                     else (
                         "molecular_definition_without_expression_matrix"
                         if molecular_kinds

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -70,7 +70,12 @@ import numpy as np
 import pandas as pd
 
 from . import data_bundle, source_matrices
-from .cancer_types import cohort_aggregates, cohort_registry_df, resolve_cancer_type
+from .cancer_types import (
+    _computed_expression_reference_members,
+    cohort_aggregates,
+    cohort_registry_df,
+    resolve_cancer_type,
+)
 from .expression_builders import (
     PERCENTILE_BREAKPOINTS as _PERCENTILE_BREAKPOINTS,
 )
@@ -4237,6 +4242,8 @@ def pan_cancer_expression(
     if raw_parts:
         out = pd.concat([out, *raw_parts], axis=1)
 
+    out, raw_cols, computed_aggregate_cols = _add_computed_pan_cancer_raw_columns(out, raw_cols)
+
     modes = _pan_cancer_normalize_modes(normalize)
     clean_cols: list[str] = []
     if modes & {"tpm_clean", "housekeeping", "hk", "percentile", "tpm_clean_log1p"}:
@@ -4307,8 +4314,89 @@ def pan_cancer_expression(
         "data_version": DATA_VERSION,
         "source_matrix_version": SOURCE_MATRIX_VERSION,
         "column_style": column_style,
+        "computed_aggregate_columns": tuple(computed_aggregate_cols),
     }
     return out
+
+
+_PAN_CANCER_COMPUTED_AGGREGATES = ("NET", "CRC", "NSCLC", "BTC", "SGC")
+
+
+def _add_computed_pan_cancer_raw_columns(
+    out: pd.DataFrame, raw_cols: list[str]
+) -> tuple[pd.DataFrame, list[str], list[str]]:
+    """Append TPM columns for grouping codes whose references are computed from members."""
+    if out.empty:
+        return out, raw_cols, []
+    added: list[str] = []
+    raw_cols = list(raw_cols)
+    gene_key = out["Ensembl_Gene_ID"].astype(str).map(unversioned)
+    frames: list[pd.DataFrame] = []
+    for aggregate_code in _PAN_CANCER_COMPUTED_AGGREGATES:
+        target = f"{aggregate_code}_TPM_raw"
+        if target in out.columns:
+            continue
+        members = _computed_expression_reference_members(aggregate_code)
+        if not members:
+            continue
+        values = _pooled_reference_expression_series_for_pan_cancer(members)
+        if values.empty:
+            continue
+        frames.append(pd.DataFrame({target: gene_key.map(values)}, index=out.index))
+        raw_cols.append(target)
+        added.append(target)
+    if frames:
+        out = pd.concat([out, *frames], axis=1)
+    return out, raw_cols, added
+
+
+def _pooled_reference_expression_series_for_pan_cancer(member_codes: tuple[str, ...]) -> pd.Series:
+    """n-sample-weighted raw TPM medians for a computed pan-cancer aggregate."""
+    try:
+        rows = _selected_reference_summary_rows_for_pan_cancer(member_codes)
+    except (FileNotFoundError, KeyError, TypeError):
+        return pd.Series(dtype=float)
+    if rows.empty:
+        return pd.Series(dtype=float)
+    work = rows.copy()
+    work["_gene_key"] = work["Ensembl_Gene_ID"].astype(str).map(unversioned)
+    work["_expression"] = pd.to_numeric(work["TPM_median"], errors="coerce")
+    weights = pd.to_numeric(work.get("n_samples"), errors="coerce")
+    if not isinstance(weights, pd.Series):
+        weights = pd.Series(1.0, index=work.index)
+    work["_weight"] = weights.reindex(work.index).fillna(0.0)
+    rows: dict[str, float] = {}
+    for gene_id, group in work.groupby("_gene_key", sort=False):
+        valid = group["_expression"].notna() & (group["_weight"] > 0)
+        if not valid.any():
+            continue
+        rows[str(gene_id)] = float(
+            np.average(group.loc[valid, "_expression"], weights=group.loc[valid, "_weight"])
+        )
+    return pd.Series(rows, dtype=float)
+
+
+def _selected_reference_summary_rows_for_pan_cancer(member_codes: tuple[str, ...]) -> pd.DataFrame:
+    source_table = _reference_summary_source_table()
+    if source_table.empty:
+        return pd.DataFrame()
+    wanted = {str(code) for code in member_codes}
+    selected = source_table.loc[
+        source_table["cancer_code"].astype(str).isin(wanted) & source_table["selected"]
+    ].copy()
+    if selected.empty:
+        return pd.DataFrame()
+    selected["_source_key"] = selected["source_cohort"].fillna("").astype(str)
+    summary = _reference_summary_frame().copy()
+    if summary.empty:
+        return pd.DataFrame()
+    summary["_source_key"] = summary["source_cohort"].fillna("").astype(str)
+    rows = summary.merge(
+        selected[["cancer_code", "_source_key"]],
+        how="inner",
+        on=["cancer_code", "_source_key"],
+    )
+    return rows.drop(columns=["_source_key"])
 
 
 def _pan_cancer_column_style(column_style: str | None) -> str:

--- a/tests/test_cancer_types.py
+++ b/tests/test_cancer_types.py
@@ -4,6 +4,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import pandas as pd
 import pytest
 
 import oncoref as cd
@@ -448,7 +449,10 @@ def test_expression_reference_coverage_contract():
         "ontology_level",
         "ontology_kind",
         "ontology_depth",
+        "has_expression_reference",
         "has_direct_expression_reference",
+        "has_computed_expression_reference",
+        "computed_expression_member_codes",
         "observed_bulk_reference",
         "expression_reference_kind",
         "source_matrix_cohort",
@@ -465,7 +469,9 @@ def test_expression_reference_coverage_contract():
     assert expected <= set(coverage.columns)
 
     keyed = coverage.set_index("code")
+    assert bool(keyed.loc["COAD_MSI", "has_expression_reference"]) is True
     assert bool(keyed.loc["COAD_MSI", "has_direct_expression_reference"]) is True
+    assert bool(keyed.loc["COAD_MSI", "has_computed_expression_reference"]) is False
     assert keyed.loc["COAD_MSI", "expression_reference_kind"] == "observed_bulk"
     assert keyed.loc["COAD_MSI", "consumer_recommendation"] == "direct_reference"
     assert keyed.loc["COAD_MSI", "normalization_method"] == "clean_tpm_16_9_75"
@@ -481,6 +487,31 @@ def test_expression_reference_coverage_contract():
     assert bool(keyed.loc["ASTB", "has_direct_expression_reference"]) is False
     assert keyed.loc["ASTB", "consumer_recommendation"] == "molecular_only"
     assert keyed.loc["ASTB", "molecular_definition_kind"] == ("fusion",)
+
+
+def test_expression_reference_coverage_computed_groupings():
+    coverage = cancer_types.expression_reference_coverage(
+        ["NET", "CRC", "NSCLC", "BTC", "SGC", "SARC", "OV"]
+    ).set_index("code")
+
+    for code in ["NET", "CRC", "NSCLC", "BTC", "SGC"]:
+        row = coverage.loc[code]
+        assert bool(row["has_expression_reference"]) is True
+        assert bool(row["has_direct_expression_reference"]) is False
+        assert bool(row["has_computed_expression_reference"]) is True
+        assert row["expression_reference_kind"] == "computed_union"
+        assert row["expression_reference_source_code"] == code
+        assert row["consumer_recommendation"] == "computed_reference"
+        assert pd.isna(row["missing_reason"])
+        assert row["computed_expression_member_codes"]
+
+    # Existing SARC/OV behavior is deliberately unchanged by the source-scope fix:
+    # SARC still has no direct reference row here, while OV remains a direct matrix.
+    assert bool(coverage.loc["SARC", "has_expression_reference"]) is False
+    assert coverage.loc["SARC", "expression_reference_kind"] == "none"
+    assert bool(coverage.loc["OV", "has_direct_expression_reference"]) is True
+    assert bool(coverage.loc["OV", "has_computed_expression_reference"]) is False
+    assert coverage.loc["OV", "expression_reference_kind"] == "observed_bulk"
 
 
 def test_expression_reference_coverage_filters_and_empty_results():

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -2344,6 +2344,87 @@ def test_pan_cancer_expression_pirlygenes_column_style(monkeypatch):
     assert out.attrs["oncoref"]["column_style"] == "pirlygenes"
 
 
+def test_pan_cancer_expression_adds_computed_aggregate_tpm_columns(monkeypatch):
+    source_table = pd.DataFrame(
+        {
+            "cancer_code": [
+                "NET_PANCREAS",
+                "COAD",
+                "READ",
+                "LUAD",
+                "LUSC",
+                "CHOL",
+                "ADCC",
+            ],
+            "source_cohort": [
+                "NET_SRC",
+                "COAD_SRC",
+                "READ_SRC",
+                "LUAD_SRC",
+                "LUSC_SRC",
+                "CHOL_SRC",
+                "ADCC_SRC",
+            ],
+            "selected": [True, True, True, True, True, True, True],
+        }
+    )
+    summary_rows = []
+    values = {
+        "NET_PANCREAS": ([7.0, 9.0], 5, "NET_SRC"),
+        "COAD": ([10.0, 20.0], 2, "COAD_SRC"),
+        "READ": ([30.0, 40.0], 6, "READ_SRC"),
+        "LUAD": ([100.0, 200.0], 1, "LUAD_SRC"),
+        "LUSC": ([300.0, 400.0], 3, "LUSC_SRC"),
+        "CHOL": ([11.0, 12.0], 4, "CHOL_SRC"),
+        "ADCC": ([21.0, 22.0], 8, "ADCC_SRC"),
+    }
+    for code, (exprs, n_samples, source) in values.items():
+        for gene_id, symbol, expr in zip(
+            ["ENSG00000001", "ENSG00000002"], ["GENE1", "GENE2"], exprs
+        ):
+            summary_rows.append(
+                {
+                    "Ensembl_Gene_ID": gene_id,
+                    "Symbol": symbol,
+                    "cancer_code": code,
+                    "source_cohort": source,
+                    "TPM_median": expr,
+                    "n_samples": n_samples,
+                }
+            )
+    summary = pd.DataFrame(summary_rows)
+    members = {
+        "NET": ("NET_PANCREAS",),
+        "CRC": ("COAD", "READ"),
+        "NSCLC": ("LUAD", "LUSC"),
+        "BTC": ("CHOL",),
+        "SGC": ("ADCC",),
+    }
+
+    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    monkeypatch.setattr(
+        expression, "_computed_expression_reference_members", lambda code: members.get(code, ())
+    )
+    monkeypatch.setattr(expression, "_reference_summary_source_table", lambda: source_table)
+    monkeypatch.setattr(expression, "_reference_summary_frame", lambda: summary)
+
+    out = expression.pan_cancer_expression(normalize="tpm", column_style="pirlygenes")
+
+    assert {"NET_TPM", "CRC_TPM", "NSCLC_TPM", "BTC_TPM", "SGC_TPM"} <= set(out.columns)
+    assert out["NET_TPM"].tolist() == pytest.approx([7.0, 9.0])
+    assert out["CRC_TPM"].tolist() == pytest.approx([25.0, 35.0])
+    assert out["NSCLC_TPM"].tolist() == pytest.approx([250.0, 350.0])
+    assert out["BTC_TPM"].tolist() == pytest.approx([11.0, 12.0])
+    assert out["SGC_TPM"].tolist() == pytest.approx([21.0, 22.0])
+    assert out.attrs["oncoref"]["computed_aggregate_columns"] == (
+        "NET_TPM_raw",
+        "CRC_TPM_raw",
+        "NSCLC_TPM_raw",
+        "BTC_TPM_raw",
+        "SGC_TPM_raw",
+    )
+
+
 def test_pan_cancer_expression_to_tpm_legacy_keyword(monkeypatch):
     monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
     out = expression.pan_cancer_expression(genes=["ENSG00000001"], to_tpm=True)


### PR DESCRIPTION
## Summary

Fixes #329.

- adds explicit computed expression-reference coverage for NET, CRC, NSCLC, BTC, and SGC
- keeps has_direct_expression_reference literal while adding has_expression_reference, has_computed_expression_reference, and computed_expression_member_codes
- adds NET_TPM, CRC_TPM, NSCLC_TPM, BTC_TPM, and SGC_TPM via n-sample-weighted selected cancer-reference-expression summary rows in pan_cancer_expression(..., column_style="pirlygenes")
- documents the direct-vs-computed reference distinction and preserves existing SARC/OV behavior

## Validation

- ./lint.sh
- pytest tests/test_cancer_types.py tests/test_expression.py
- ./test.sh -> 709 passed, 1 existing matplotlib open-figure warning

## Remaining related work

This does not close the larger pure-consumer path: #296 (builder hoist), #207 follow-up/parity signoff for broader reference-expression access, and #209 (bundle/download contract) remain separate.