### PR TITLE
[codex] Stabilize reference-expression proteoform bridge

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -368,13 +368,15 @@ artifacts, this source-union mode intentionally rejects `format="wide"`,
 reference artifacts remain part of the expression-artifact rebuild work.
 
 For compatibility with pirlygenes reference-expression consumers, the accessor
-can also fold identical loci at read time. Use
+also exposes the gene-to-proteoform bridge columns on every long-form row:
+`Proteoform_ID` is the cDNA/read-recovery identity that the row maps to, and
+`Member_Ensembl_Gene_IDs` is the row's member ENSG list. Without a collapse flag
+this is only an annotation; it does not fold rows. Use
 `collapse_cdna_identical=True` for the read-recovery space: byte-identical CDS
 groups plus the curated proteoform-collapse overrides. Use
 `collapse_protein_identical=True` for the genome-wide identical-protein space.
 Set at most one. These modes sum `expression`, `q1`, and `q3` in linear TPM
-space inside each source context, add `Proteoform_ID` and
-`Member_Ensembl_Gene_IDs` in long output, and leave wide output in the historical
+space inside each source context and leave wide output in the historical
 `Ensembl_Gene_ID`, `Symbol`, value-column shape.
 
 Use `expression.cancer_reference_expression_availability()` before delegating a

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2108,12 +2108,14 @@ def cancer_reference_expression(
     extras without a pirlygenes counterpart while keeping documented remap targets;
     ``include_gene_universe_flags=True`` appends row-level audit columns in long output.
     Neither option synthesizes missing biological rows.
-    ``collapse_cdna_identical=True`` or ``collapse_protein_identical=True`` sums
+    Long output always carries ``Proteoform_ID`` and ``Member_Ensembl_Gene_IDs`` so
+    gene-level and folded views share one schema. By default this is a bridge over
+    the cDNA/read-recovery identity space without folding rows. Set
+    ``collapse_cdna_identical=True`` or ``collapse_protein_identical=True`` to sum
     identical-locus rows in linear expression space before output. cDNA collapse is
     the read-recovery view (byte-identical CDS plus curated overrides); protein
-    collapse is the genome-wide identical-protein view. Set at most one. Long output
-    gains ``Proteoform_ID`` and ``Member_Ensembl_Gene_IDs`` columns; wide output keeps
-    the historical ``Ensembl_Gene_ID``/``Symbol`` plus value columns shape.
+    collapse is the genome-wide identical-protein view. Set at most one. Wide output
+    keeps the historical ``Ensembl_Gene_ID``/``Symbol`` plus value columns shape.
     Missing requested cohorts are omitted by default to preserve the historical
     behavior; pass ``on_missing="empty"`` to preserve a schema-stable empty result
     with missing-request metadata in ``df.attrs["missing_requests"]`` or
@@ -2230,11 +2232,19 @@ def cancer_reference_expression(
                 gene_id_style=gene_id_style,
                 alias_expand_remaps=gene_universe == "pirlygenes",
             )
+            if collapse_kind is None:
+                ref = _annotate_reference_proteoform_bridge(ref, kind="cdna")
             label = _REFERENCE_NORMALIZE_LABELS[mode]
             if format == "long":
-                value_cols = ["Ensembl_Gene_ID", "Symbol", "p25", "p50", "p75"]
-                if collapse_kind is not None:
-                    value_cols.extend(["Proteoform_ID", "Member_Ensembl_Gene_IDs"])
+                value_cols = [
+                    "Ensembl_Gene_ID",
+                    "Symbol",
+                    "p25",
+                    "p50",
+                    "p75",
+                    "Proteoform_ID",
+                    "Member_Ensembl_Gene_IDs",
+                ]
                 if include_gene_universe_flags:
                     value_cols.extend(_ARTIFACT_GENE_UNIVERSE_FLAG_COLUMNS)
                 part = ref[value_cols].copy()
@@ -2279,7 +2289,7 @@ def cancer_reference_expression(
                             include_request_metadata,
                             include_gene_universe_flags,
                             source_union_identity=source_union_identity,
-                            include_proteoform_columns=collapse_kind is not None,
+                            include_proteoform_columns=True,
                         )
                     ]
                 )
@@ -2296,7 +2306,7 @@ def cancer_reference_expression(
             include_request_metadata,
             include_gene_universe_flags,
             source_union_identity=reference_source == "summary_rows_all",
-            include_proteoform_columns=collapse_cdna_identical or collapse_protein_identical,
+            include_proteoform_columns=True,
         )
         if not long_parts:
             out = pd.DataFrame(columns=cols)
@@ -2885,6 +2895,24 @@ def _collapse_reference_identical_loci(
         if col not in keep:
             keep.append(col)
     return out.sort_values("_ord").reset_index(drop=True)[keep]
+
+
+def _annotate_reference_proteoform_bridge(df: pd.DataFrame, *, kind: str) -> pd.DataFrame:
+    """Add pirlygenes-compatible gene/proteoform bridge columns without folding rows."""
+    out = df.copy()
+    if "Proteoform_ID" not in out.columns:
+        if out.empty:
+            out["Proteoform_ID"] = pd.Series(dtype="object")
+        else:
+            member_to_identity, _ = _identical_locus_identity_maps(kind)
+            gene_ids = out["Ensembl_Gene_ID"].astype(str).map(unversioned)
+            out["Proteoform_ID"] = gene_ids.map(member_to_identity).fillna(gene_ids).to_numpy()
+    if "Member_Ensembl_Gene_IDs" not in out.columns:
+        if out.empty:
+            out["Member_Ensembl_Gene_IDs"] = pd.Series(dtype="object")
+        else:
+            out["Member_Ensembl_Gene_IDs"] = out["Ensembl_Gene_ID"].astype(str).to_numpy()
+    return out
 
 
 def _reference_long_columns(

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1502,6 +1502,8 @@ def test_cancer_reference_expression_long_and_wide(monkeypatch):
     assert list(long.columns) == [
         "Ensembl_Gene_ID",
         "Symbol",
+        "Proteoform_ID",
+        "Member_Ensembl_Gene_IDs",
         "cancer_code",
         "normalization",
         "source_cohort",
@@ -1584,6 +1586,46 @@ def test_cancer_reference_expression_can_return_pirlygenes_legacy_gene_ids(monke
 def test_cancer_reference_expression_bad_gene_id_style():
     with pytest.raises(ValueError, match="gene_id_style"):
         expression.cancer_reference_expression("PRAD", gene_id_style="legacy")
+
+
+def test_cancer_reference_expression_adds_proteoform_bridge_without_collapse(monkeypatch):
+    pct = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": [
+                "ENSG00000154545",  # MAGED4 cDNA-identical group member
+                "ENSG00000187243",  # MAGED4B cDNA-identical group member
+                "ENSG00000141510",
+            ],
+            "Symbol": ["MAGED4", "MAGED4B", "TP53"],
+            "p25": [1.0, 10.0, 100.0],
+            "p50": [2.0, 20.0, 200.0],
+            "p75": [3.0, 30.0, 300.0],
+        }
+    )
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+    monkeypatch.setattr(expression, "cohort_gene_percentiles", lambda *a, **k: pct.copy())
+
+    out = expression.cancer_reference_expression("x", include_provenance=False)
+
+    assert list(out.columns) == [
+        "Ensembl_Gene_ID",
+        "Symbol",
+        "Proteoform_ID",
+        "Member_Ensembl_Gene_IDs",
+        "cancer_code",
+        "normalization",
+        "expression",
+        "q1",
+        "q3",
+    ]
+    assert len(out) == 3
+    by_id = out.set_index("Ensembl_Gene_ID")
+    assert by_id.loc["ENSG00000154545", "Proteoform_ID"] == "MAGED4"
+    assert by_id.loc["ENSG00000187243", "Proteoform_ID"] == "MAGED4"
+    assert by_id.loc["ENSG00000154545", "Member_Ensembl_Gene_IDs"] == "ENSG00000154545"
+    assert by_id.loc["ENSG00000187243", "Member_Ensembl_Gene_IDs"] == "ENSG00000187243"
+    assert by_id.loc["ENSG00000141510", "Proteoform_ID"] == "ENSG00000141510"
 
 
 def test_cancer_reference_expression_cdna_identical_collapse(monkeypatch):
@@ -1768,6 +1810,8 @@ def test_cancer_reference_expression_missing_empty_and_raise(monkeypatch):
     assert list(empty.columns) == [
         "Ensembl_Gene_ID",
         "Symbol",
+        "Proteoform_ID",
+        "Member_Ensembl_Gene_IDs",
         "cancer_code",
         "normalization",
         "source_cohort",


### PR DESCRIPTION
## Summary

Addresses a focused compatibility slice of #207.

- make `cancer_reference_expression(..., format="long")` always include `Proteoform_ID` and `Member_Ensembl_Gene_IDs`
- annotate the default non-collapsed gene view with the cDNA/read-recovery identity bridge, matching pirlygenes stable schema without folding rows
- keep wide output unchanged and keep explicit `collapse_cdna_identical` / `collapse_protein_identical` behavior unchanged
- document the bridge/collapse boundary in the API guide

## Why

Pirlygenes reference-expression accessor exposes the gene/proteoform bridge columns regardless of collapse mode. Downstream wrappers can then consume one long-form schema whether they are looking at gene-level rows or folded rows. Oncoref only exposed those columns when a collapse flag was active, which left one more schema incompatibility in #207.

## Validation

- `python -m pytest tests/test_expression.py -q` -> 103 passed
- `./lint.sh` -> passed
- `./test.sh` -> 715 passed, 1 existing matplotlib warning

## Still Out Of Scope

This does not close #207. Remaining migration work still includes final row/value parity for `cancer_reference_expression`, plus the adjacent #296 ingestion-builder ownership and #209 data-bundle/download contract.