### PR TITLE
Add Treehouse source-matrix builder

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -287,7 +287,14 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   `recount3_gene_sums_to_tpm`, `build_recount3_source_matrices`, and
   `scripts/build_recount3_source.py` do the same for `source_type: recount3`
   entries, including run-to-sample aggregation and metadata-based routing before
-  writing the standard source-matrix artifact set. `scripts/rebuild_expression_artifacts.py`
+  writing the standard source-matrix artifact set. `TreehouseSource`,
+  `treehouse_source_from_registry`, `treehouse_cohorts_for_group`, and
+  `scripts/build_treehouse_source.py` own the direct Treehouse-compendium path:
+  clinical disease-label routing, log2(TPM+1) inverse transform, symbol
+  canonicalization, sample QC, and summary-row sidecars. Treehouse selectors that
+  can be evaluated from the clinical table itself (`""` and `tcga`) are
+  registry-native; molecular/histology selectors that require cBioPortal/GDC side
+  tables remain separate #296 follow-ups. `scripts/rebuild_expression_artifacts.py`
   then applies the same sample-QC policy to derived shards by default
   (`--sample-qc pass`) and emits `source-matrix-sample-qc.csv` plus
   `expression-artifact-build-metadata.*` in the staging directory so bundle

--- a/oncoref/data/expression_sources.yaml
+++ b/oncoref/data/expression_sources.yaml
@@ -173,11 +173,16 @@ sources:
     cancer_codes:
       [ATRT, SARC_EWS, HEPB, MBL, NUTM, SARC_OS,
        SARC_RMS_ARMS, SARC_RMS_ERMS, SARC_RMS_PRMS, SARC_RMS_SSRMS,
-       SARC_LMS, SARC_LPS_UNSPEC, SARC_MYXFIB, SARC_SYN, SARC_UPS]
+       SARC_LMS, SARC_LPS_UNSPEC, SARC_MYXFIB, SARC_SYN, SARC_UPS,
+       SARC_ANGIO, SARC_ASPS, SARC_DSRCT, SARC_EPITH, SARC_IMT, SARC_IFS,
+       SARC_MPNST, SARC_EHE, SARC_LGFMS, NPC, SARC_GIST]
     source_type: treehouse-compendium
+    source_cohort: TREEHOUSE_POLYA_25_01
+    source_project: Treehouse
     url: https://public.gi.ucsc.edu/~ekephart/public-data/#tumor_25.01_polya
-    builder: scripts/sweep_treehouse_polya_cohorts.py
+    builder: scripts/build_treehouse_source.py
     sibling_builders:
+      - scripts/sweep_treehouse_polya_cohorts.py  # superseded direct-cohort sweep
       - scripts/sweep_treehouse_tcga_cohorts.py  # TCGA subset of this file
       - scripts/build_treehouse_reference_expression.py  # single-cohort CLI
     unit: log2(TPM+1)
@@ -191,6 +196,35 @@ sources:
       clinical: clinical_Treehouse-Tumor-Compendium-25.01-PolyA_20250131v1.tsv
       tpm_url: https://xena.treehouse.gi.ucsc.edu/download/Tumor-25.01-Polya_hugo_log2tpm_58581genes_2025-02-27.tsv
       clinical_url: https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-Tumor-Compendium-25.01-PolyA_20250131v1.tsv
+    pipeline_stem: treehouse_polya_25_01
+    tumor_origin: mixed
+    treehouse_cohorts:
+      - {cancer_code: ATRT, disease_label: atypical teratoid/rhabdoid tumor, group: polya_pediatric}
+      - {cancer_code: SARC_EWS, disease_label: Ewing sarcoma, group: polya_pediatric}
+      - {cancer_code: HEPB, disease_label: hepatoblastoma, group: polya_pediatric}
+      - {cancer_code: MBL, disease_label: medulloblastoma, group: polya_pediatric}
+      - {cancer_code: NUTM, disease_label: NUT midline carcinoma, group: polya_pediatric}
+      - {cancer_code: SARC_OS, disease_label: osteosarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_RMS_ARMS, disease_label: alveolar rhabdomyosarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_RMS_ERMS, disease_label: embryonal rhabdomyosarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_RMS_PRMS, disease_label: pleomorphic rhabdomyosarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_RMS_SSRMS, disease_label: spindle cell/sclerosing rhabdomyosarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_LMS, disease_label: leiomyosarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_LPS_UNSPEC, disease_label: liposarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_MYXFIB, disease_label: myxofibrosarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_SYN, disease_label: synovial sarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_UPS, disease_label: undifferentiated pleomorphic sarcoma, group: polya_pediatric}
+      - {cancer_code: SARC_ANGIO, disease_label: angiosarcoma, group: sarc_rare_direct}
+      - {cancer_code: SARC_ASPS, disease_label: alveolar soft part sarcoma, group: sarc_rare_direct}
+      - {cancer_code: SARC_DSRCT, disease_label: desmoplastic small round cell tumor, group: sarc_rare_direct}
+      - {cancer_code: SARC_EPITH, disease_label: epithelioid sarcoma, group: sarc_rare_direct}
+      - {cancer_code: SARC_IMT, disease_label: inflammatory myofibroblastic tumor, group: sarc_rare_direct}
+      - {cancer_code: SARC_IFS, disease_label: infantile fibrosarcoma, group: sarc_rare_direct}
+      - {cancer_code: SARC_MPNST, disease_label: malignant peripheral nerve sheath tumor, group: sarc_rare_direct}
+      - {cancer_code: SARC_EHE, disease_label: epithelioid hemangioendothelioma, group: sarc_rare_direct}
+      - {cancer_code: SARC_LGFMS, disease_label: low grade fibromyxoid sarcoma, group: sarc_rare_direct}
+      - {cancer_code: NPC, disease_label: nasopharyngeal carcinoma, group: sarc_rare_direct}
+      - {cancer_code: SARC_GIST, disease_label: gastrointestinal stromal tumor, group: sarc_subtypes}
     special_handling: >
       13,359 samples × 58,581 genes; matrix is RSEM log2(TPM+1) keyed
       by HUGO symbol. Builder inverse-transforms to TPM, subsets by
@@ -208,8 +242,12 @@ sources:
     category: expression
     cancer_codes: [SARC_CHOR, RB]
     source_type: treehouse-compendium
+    source_cohort: TREEHOUSE_RIBOD_25_01
+    source_project: Treehouse
     url: https://public.gi.ucsc.edu/~ekephart/public-data/#tumor_25.01_ribodeplete
-    builder: scripts/sweep_treehouse_ribod_cohorts.py
+    builder: scripts/build_treehouse_source.py
+    sibling_builders:
+      - scripts/sweep_treehouse_ribod_cohorts.py  # superseded direct-cohort sweep
     unit: log2(TPM+1)
     expected_size_gb: 1
     citation: >
@@ -221,6 +259,11 @@ sources:
       clinical: clinical_Treehouse-Tumor-Compendium-25.01-RiboD_20250306v1.tsv
       tpm_url: https://xena.treehouse.gi.ucsc.edu/download/Tumor-25.01-Ribodeplete_hugo_log2tpm_58581genes_2025-03-19.tsv
       clinical_url: https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-Tumor-Compendium-25.01-RiboD_20250306v1.tsv
+    pipeline_stem: treehouse_ribod_25_01
+    tumor_origin: mixed
+    treehouse_cohorts:
+      - {cancer_code: SARC_CHOR, disease_label: chordoma, group: ribod}
+      - {cancer_code: RB, disease_label: retinoblastoma, group: ribod}
     special_handling: >
       RiboD (ribo-depleted) sibling of treehouse-polya-25-01; 2,079
       samples. Same builder works after pointing `--cache-dir` /

--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -44,7 +44,7 @@ import shutil
 import tempfile
 import urllib.request
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import lru_cache
 from pathlib import Path
 from typing import Callable, Literal
@@ -65,6 +65,7 @@ from .normalization import clean_tpm
 SourceExpressionUnit = Literal["TPM", "FPKM", "RPKM", "log2(TPM+1)", "raw_counts"]
 GEO_MATRIX_SOURCE_TYPE = "geo-matrix"
 RECOUNT3_SOURCE_TYPE = "recount3"
+TREEHOUSE_SOURCE_TYPE = "treehouse-compendium"
 TUMOR_ORIGIN_VALUES: frozenset[str] = frozenset(
     {
         "primary",
@@ -241,10 +242,49 @@ class Recount3Source:
 
 
 @dataclass(frozen=True)
+class TreehouseCohort:
+    """One cohort routed from a Treehouse compendium clinical table."""
+
+    cancer_code: str
+    disease_label: str
+    group: str = "direct"
+    selection: str = ""
+    cache_stem: str | None = None
+    source_cohort: str | None = None
+    extra_notes: str = ""
+
+    @property
+    def effective_cache_stem(self) -> str:
+        return self.cache_stem or self.cancer_code
+
+
+@dataclass(frozen=True)
+class TreehouseSource:
+    """One Treehouse compendium release plus its declarative cohort routing."""
+
+    source_id: str
+    source_cohort: str
+    cancer_code: str | list[str]
+    tpm_file: str
+    clinical_file: str
+    tpm_url: str | None = None
+    clinical_url: str | None = None
+    source_project: str | None = "Treehouse"
+    citation: str | None = None
+    release_label: str = ""
+    unit: SourceExpressionUnit = "log2(TPM+1)"
+    cohorts: tuple[TreehouseCohort, ...] = ()
+    notes: str = ""
+    pipeline_stem: str = ""
+    tumor_origin: str = "mixed"
+    metastasis_site: str | None = None
+
+
+@dataclass(frozen=True)
 class SourceMatrixBuildResult:
     """Artifacts produced by :func:`build_source_matrices`."""
 
-    source: GeoMatrixSource | Recount3Source
+    source: GeoMatrixSource | Recount3Source | TreehouseSource
     matrices: dict[str, pd.DataFrame]
     matrix_paths: dict[str, Path]
     summary_rows: pd.DataFrame
@@ -260,7 +300,7 @@ def _unit_slug(unit: str) -> str:
 
 
 def _summary_processing_pipeline(
-    source: GeoMatrixSource | Recount3Source,
+    source: GeoMatrixSource | Recount3Source | TreehouseSource,
     *,
     native_unit: str,
 ) -> str:
@@ -269,7 +309,7 @@ def _summary_processing_pipeline(
 
 
 def _summary_source_version(
-    source: GeoMatrixSource | Recount3Source,
+    source: GeoMatrixSource | Recount3Source | TreehouseSource,
     *,
     native_unit: str,
 ) -> str:
@@ -287,7 +327,7 @@ def _summary_source_version(
 
 
 def _summary_notes(
-    source: GeoMatrixSource | Recount3Source,
+    source: GeoMatrixSource | Recount3Source | TreehouseSource,
     *,
     n_samples: int,
 ) -> str:
@@ -619,6 +659,106 @@ def recount3_source_from_registry(
     raise KeyError(f"source id {source_id!r} not found in expression source registry")
 
 
+def treehouse_source_entries(registry_path: str | Path | None = None) -> list[dict]:
+    """Raw ``source_type: treehouse-compendium`` entries from the source registry."""
+    return [
+        entry
+        for entry in _source_entries_from_registry(registry_path)
+        if entry.get("source_type") == TREEHOUSE_SOURCE_TYPE
+    ]
+
+
+def _treehouse_cohort_from_entry(entry: Mapping) -> TreehouseCohort:
+    code = str(entry.get("cancer_code") or entry.get("code") or "").strip()
+    label = str(entry.get("disease_label") or "").strip()
+    if not code:
+        raise ValueError("treehouse cohort entry lacks cancer_code")
+    if not label:
+        raise ValueError(f"treehouse cohort {code!r} lacks disease_label")
+    return TreehouseCohort(
+        cancer_code=code,
+        disease_label=label,
+        group=str(entry.get("group") or "direct"),
+        selection=str(entry.get("selection") or ""),
+        cache_stem=_coerce_optional_text(entry.get("cache_stem")),
+        source_cohort=_coerce_optional_text(entry.get("source_cohort")),
+        extra_notes=str(entry.get("extra_notes") or ""),
+    )
+
+
+def treehouse_source_from_entry(entry: Mapping) -> TreehouseSource:
+    """Convert one registry YAML entry into an executable :class:`TreehouseSource`."""
+    if entry.get("source_type") != TREEHOUSE_SOURCE_TYPE:
+        raise ValueError(
+            f"source {entry.get('id')!r} has source_type={entry.get('source_type')!r}, "
+            f"not {TREEHOUSE_SOURCE_TYPE!r}"
+        )
+    cancer_codes = [str(code) for code in entry.get("cancer_codes", [])]
+    cohorts = tuple(
+        _treehouse_cohort_from_entry(cohort) for cohort in entry.get("treehouse_cohorts", [])
+    )
+    if not cancer_codes and cohorts:
+        cancer_codes = [cohort.cancer_code for cohort in cohorts]
+    if not cancer_codes:
+        raise ValueError(f"source {entry.get('id')!r} has no cancer_codes")
+    if not cohorts:
+        raise ValueError(f"source {entry.get('id')!r} has no treehouse_cohorts")
+    files = dict(entry.get("files") or {})
+    tpm_file = str(files.get("tpm") or entry.get("tpm_file") or "").strip()
+    clinical_file = str(files.get("clinical") or entry.get("clinical_file") or "").strip()
+    if not tpm_file or not clinical_file:
+        raise ValueError(f"source {entry.get('id')!r} lacks Treehouse TPM/clinical files")
+    cancer_code: str | list[str] = cancer_codes[0] if len(cancer_codes) == 1 else cancer_codes
+    source_cohort = str(entry.get("source_cohort") or "").strip()
+    if not source_cohort:
+        raise ValueError(f"source {entry.get('id')!r} lacks source_cohort")
+    return TreehouseSource(
+        source_id=str(entry["id"]),
+        source_cohort=source_cohort,
+        cancer_code=cancer_code,
+        tpm_file=tpm_file,
+        clinical_file=clinical_file,
+        tpm_url=files.get("tpm_url") or entry.get("tpm_url"),
+        clinical_url=files.get("clinical_url") or entry.get("clinical_url"),
+        source_project=entry.get("source_project") or "Treehouse",
+        citation=entry.get("citation"),
+        release_label=str(entry.get("release_label") or entry.get("citation") or source_cohort),
+        unit=_coerce_source_expression_unit(str(entry.get("unit") or "log2(TPM+1)")),
+        cohorts=cohorts,
+        notes=str(entry.get("notes") or entry.get("special_handling") or ""),
+        pipeline_stem=str(entry.get("pipeline_stem") or ""),
+        tumor_origin=_coerce_tumor_origin(entry.get("tumor_origin") or "mixed"),
+        metastasis_site=_coerce_optional_text(entry.get("metastasis_site")),
+    )
+
+
+def treehouse_source_from_registry(
+    source_id: str,
+    registry_path: str | Path | None = None,
+) -> TreehouseSource:
+    """Load one ``source_type: treehouse-compendium`` source from the registry."""
+    for entry in _source_entries_from_registry(registry_path):
+        if entry.get("id") == source_id:
+            return treehouse_source_from_entry(entry)
+    raise KeyError(f"source id {source_id!r} not found in expression source registry")
+
+
+def treehouse_cohorts_for_group(
+    group: str,
+    *,
+    source_id: str | None = None,
+    registry_path: str | Path | None = None,
+) -> list[TreehouseCohort]:
+    """Treehouse cohort definitions in a build group, preserving registry order."""
+    out: list[TreehouseCohort] = []
+    for entry in treehouse_source_entries(registry_path):
+        if source_id is not None and entry.get("id") != source_id:
+            continue
+        source = treehouse_source_from_entry(entry)
+        out.extend(cohort for cohort in source.cohorts if cohort.group == group)
+    return out
+
+
 def _csv_engine(sep: str) -> str:
     return "python" if len(sep) > 1 or "\\" in sep else "c"
 
@@ -818,6 +958,89 @@ def source_metadata(
         "linear_tpm_comparable": bool(linear_tpm_comparable),
         "tpm_proxy": bool(tpm_proxy),
     }
+
+
+def _treehouse_tcga_case_id(sample_id: str) -> str | None:
+    text = str(sample_id)
+    if not text.startswith("TCGA"):
+        return None
+    return "-".join(text.split("-")[:3])
+
+
+def _treehouse_sample_matches_selection(row: Mapping, selection: str) -> bool:
+    """Return whether a Treehouse clinical row passes a declarative selector.
+
+    The initial oncoref-owned wrapper supports the selection grammar that can be
+    evaluated from the Treehouse clinical table alone. Molecular/histology
+    selectors that require cBioPortal/GDC side tables remain source-specific
+    follow-ups under #296.
+    """
+    selector = str(selection or "").strip()
+    if not selector:
+        return True
+    if selector == "tcga":
+        return _treehouse_tcga_case_id(str(row.get("th_dataset_id", ""))) is not None
+    raise ValueError(
+        f"unsupported Treehouse cohort selection {selector!r}; "
+        "only '' and 'tcga' are registry-native so far"
+    )
+
+
+def treehouse_sample_ids(
+    clinical: pd.DataFrame,
+    cohort: TreehouseCohort,
+) -> list[str]:
+    """Sample IDs in ``clinical`` matching one Treehouse cohort definition."""
+    required = {"th_dataset_id", "disease"}
+    missing = required - set(clinical.columns)
+    if missing:
+        raise ValueError(f"Treehouse clinical table lacks required columns: {sorted(missing)}")
+    disease = clinical["disease"].astype(str).str.strip().str.lower()
+    subset = clinical.loc[disease.eq(cohort.disease_label.strip().lower())].copy()
+    if cohort.selection:
+        keep = subset.apply(
+            lambda row: _treehouse_sample_matches_selection(row.to_dict(), cohort.selection),
+            axis=1,
+        )
+        subset = subset.loc[keep]
+    ids = subset["th_dataset_id"].astype(str).tolist()
+    if not ids:
+        raise ValueError(
+            f"no Treehouse samples matched {cohort.cancer_code!r} "
+            f"(disease_label={cohort.disease_label!r}, selection={cohort.selection!r})"
+        )
+    return ids
+
+
+def read_treehouse_tpm_columns(path: str | Path, sample_cols: Iterable[str]) -> pd.DataFrame:
+    """Read selected sample columns from a Treehouse HUGO log2(TPM+1) matrix."""
+    samples = [str(col) for col in sample_cols]
+    header = pd.read_csv(Path(path), sep="\t", nrows=0).columns.astype(str).tolist()
+    if not header:
+        raise ValueError(f"Treehouse TPM matrix is empty: {path}")
+    gene_col = header[0]
+    available = set(header)
+    missing = [col for col in samples if col not in available]
+    if missing:
+        raise ValueError(
+            f"{len(missing)} Treehouse samples are missing from TPM matrix; "
+            f"first few: {missing[:5]}"
+        )
+    keep = [gene_col, *samples]
+    df = pd.read_csv(Path(path), sep="\t", usecols=keep, low_memory=False)
+    return df.set_index(gene_col)
+
+
+def _treehouse_cohort_source(
+    source: TreehouseSource,
+    cohort: TreehouseCohort,
+) -> TreehouseSource:
+    notes = " ".join(part for part in (source.notes, cohort.extra_notes) if part).strip()
+    return replace(
+        source,
+        source_cohort=cohort.source_cohort or source.source_cohort,
+        notes=notes,
+    )
 
 
 def _download(url: str, dest: Path, *, force: bool = False) -> Path:
@@ -1353,6 +1576,162 @@ def build_recount3_source_matrices(
     summary_path = out_dir / f"{stem}_summary_rows.csv"
     _write_csv_atomic(summary_rows, summary_path)
     _reconcile_per_code_artifacts(out_dir, matrices)
+    sidecar_paths["summary_rows"] = summary_path
+    return SourceMatrixBuildResult(
+        source=source,
+        matrices=matrices,
+        matrix_paths=matrix_paths,
+        summary_rows=summary_rows,
+        mapping_audit=audit,
+        parse_diagnostics=parse_diagnostics,
+        sample_qc=sample_qc,
+        sidecar_paths=sidecar_paths,
+    )
+
+
+def build_treehouse_source_matrices(
+    source: TreehouseSource,
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    tpm_path: str | Path | None = None,
+    clinical_path: str | Path | None = None,
+    force_download: bool = False,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build source-matrix artifacts for one Treehouse compendium release.
+
+    Treehouse matrices are HUGO-symbol rows and sample columns stored as
+    ``log2(TPM+1)``. This wrapper filters samples via the declarative cohort
+    definitions in ``expression_sources.yaml``, inverse-transforms to linear TPM,
+    canonicalizes symbols through oncoref's gene-ID resolver, then writes the same
+    per-code parquet, parse/mapping audit, sample-QC, and summary-row sidecars as
+    the generic GEO/recount3 builders.
+    """
+    cache = Path(cache_dir)
+    out_dir = Path(output_dir) if output_dir is not None else cache / "derived"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    tpm_file = Path(tpm_path) if tpm_path is not None else cache / source.tpm_file
+    if not tpm_file.exists() or force_download:
+        if not source.tpm_url:
+            raise ValueError("tpm_path is absent and TreehouseSource.tpm_url is not set")
+        tpm_file = _download(source.tpm_url, tpm_file, force=force_download)
+    clinical_file = (
+        Path(clinical_path) if clinical_path is not None else cache / source.clinical_file
+    )
+    if not clinical_file.exists() or force_download:
+        if not source.clinical_url:
+            raise ValueError("clinical_path is absent and TreehouseSource.clinical_url is not set")
+        clinical_file = _download(source.clinical_url, clinical_file, force=force_download)
+
+    clinical = pd.read_csv(clinical_file, sep="\t")
+    buckets = {
+        cohort.cancer_code: treehouse_sample_ids(clinical, cohort) for cohort in source.cohorts
+    }
+    all_samples = sorted({sample for samples in buckets.values() for sample in samples})
+    if not all_samples:
+        raise ValueError(f"no Treehouse samples routed for source {source.source_id!r}")
+
+    log_values = read_treehouse_tpm_columns(tpm_file, all_samples)
+    raw = log_values.reset_index()
+    source_symbol_col = "source_symbol"
+    raw = raw.rename(columns={raw.columns[0]: source_symbol_col})
+    raw.attrs["row_id_col"] = source_symbol_col
+    raw.attrs["symbol_col"] = None
+    _, parse_diagnostics = coerce_source_expression_values(
+        raw,
+        value_cols=all_samples,
+        row_id_col=source_symbol_col,
+        symbol_col=None,
+    )
+    tpm = normalize_source_matrix_to_tpm(
+        raw,
+        unit=source.unit,
+        row_id_col=source_symbol_col,
+        symbol_col=None,
+        value_cols=all_samples,
+    )
+    matrix, audit = canonicalize_source_gene_matrix(
+        tpm,
+        row_id_col=source_symbol_col,
+        symbol_col=None,
+        value_cols=all_samples,
+        high_expression_threshold=high_expression_threshold,
+    )
+    matrix.attrs["source_value_parse_diagnostics"] = parse_diagnostics
+
+    stem = _artifact_stem(source.source_cohort)
+    sidecar_paths: dict[str, Path] = {}
+    audit_path = out_dir / f"{stem}_mapping_audit.csv"
+    parse_path = out_dir / f"{stem}_parse_diagnostics.csv"
+    _write_csv_atomic(audit, audit_path)
+    _write_csv_atomic(parse_diagnostics, parse_path)
+    sidecar_paths["mapping_audit"] = audit_path
+    sidecar_paths["parse_diagnostics"] = parse_path
+
+    from .expression import sample_expression_qc_from_matrix
+
+    matrices: dict[str, pd.DataFrame] = {}
+    matrix_paths: dict[str, Path] = {}
+    qc_frames: list[pd.DataFrame] = []
+    summary_frames: list[pd.DataFrame] = []
+    source_by_code = {
+        cohort.cancer_code: _treehouse_cohort_source(source, cohort) for cohort in source.cohorts
+    }
+    written_stems: list[str] = []
+    for code, cols in buckets.items():
+        if not cols:
+            continue
+        missing = [col for col in cols if col not in matrix.columns]
+        if missing:
+            raise ValueError(
+                f"{len(missing)} routed Treehouse samples are absent after read: {missing[:5]}"
+            )
+        cohort_source = source_by_code[code]
+        sub = matrix[[*id_columns(matrix), *cols]].copy()
+        sub.attrs = {}
+        cache_stem = next(
+            cohort.effective_cache_stem for cohort in source.cohorts if cohort.cancer_code == code
+        )
+        path = out_dir / f"{_artifact_stem(cache_stem)}_per_sample_tpm.parquet"
+        _write_parquet_atomic(sub, path)
+        meta = source_metadata(
+            source_cohort=cohort_source.source_cohort,
+            source_type=TREEHOUSE_SOURCE_TYPE,
+            unit=source.unit,
+            source_scale_class="linear_rnaseq_tpm",
+            linear_tpm_comparable=True,
+            tpm_proxy=False,
+        )
+        qc = sample_expression_qc_from_matrix(sub, cancer_type=code, source_metadata=meta)
+        qc_path = out_dir / f"{_artifact_stem(cache_stem)}_sample_qc.csv"
+        _write_csv_atomic(qc, qc_path)
+        matrices[code] = sub
+        matrix_paths[code] = path
+        written_stems.append(cache_stem)
+        sidecar_paths[f"{code}_sample_qc"] = qc_path
+        qc_frames.append(qc)
+        summary_frames.append(
+            summarize_source_matrix(
+                sub,
+                cancer_code=code,
+                source=cohort_source,
+                native_unit=source.unit,
+            )
+        )
+
+    if not matrices:
+        raise ValueError("no Treehouse samples were routed to a cancer code")
+    sample_qc = pd.concat(qc_frames, ignore_index=True) if qc_frames else pd.DataFrame()
+    summary_rows = (
+        pd.concat(summary_frames, ignore_index=True)
+        if summary_frames
+        else pd.DataFrame(columns=list(REFERENCE_EXPRESSION_COLUMNS))
+    )
+    summary_path = out_dir / f"{stem}_summary_rows.csv"
+    _write_csv_atomic(summary_rows, summary_path)
+    _reconcile_per_code_artifacts(out_dir, written_stems)
     sidecar_paths["summary_rows"] = summary_path
     return SourceMatrixBuildResult(
         source=source,

--- a/scripts/build_treehouse_source.py
+++ b/scripts/build_treehouse_source.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+"""Build a registry-backed Treehouse compendium source matrix.
+
+This script is intentionally thin: Treehouse clinical routing, log2(TPM+1)
+inverse transform, symbol canonicalization, parse diagnostics, sample QC, and
+summary-row production live in :mod:`oncoref.expression_builders`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from oncoref.expression_builders import (
+    build_treehouse_source_matrices,
+    treehouse_source_from_registry,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source_id_arg", nargs="?", help="Source id from expression_sources.yaml")
+    parser.add_argument("--source-id", help="Source id from expression_sources.yaml")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Optional expression_sources.yaml path; defaults to the packaged registry.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Treehouse cache directory. Defaults to ~/.cache/oncoref/expression/<source-id>/.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for per-code parquet matrices and sidecars. Defaults to cache_dir/derived.",
+    )
+    parser.add_argument(
+        "--tpm-path",
+        type=Path,
+        default=None,
+        help="Use an already-downloaded Treehouse TPM matrix instead of registry/cache lookup.",
+    )
+    parser.add_argument(
+        "--clinical-path",
+        type=Path,
+        default=None,
+        help="Use an already-downloaded Treehouse clinical table instead of registry/cache lookup.",
+    )
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    source_id = args.source_id or args.source_id_arg
+    if source_id is None:
+        raise SystemExit("provide --source-id <id>")
+
+    source = treehouse_source_from_registry(source_id, registry_path=args.registry)
+    cache_dir = args.cache_dir or Path.home() / ".cache" / "oncoref" / "expression" / source_id
+    result = build_treehouse_source_matrices(
+        source,
+        cache_dir=cache_dir,
+        output_dir=args.output_dir,
+        tpm_path=args.tpm_path,
+        clinical_path=args.clinical_path,
+        force_download=args.force_download,
+        high_expression_threshold=args.high_expression_threshold,
+    )
+    summary = {
+        "source_id": source_id,
+        "source_cohort": source.source_cohort,
+        "matrix_paths": {code: str(path) for code, path in result.matrix_paths.items()},
+        "sidecar_paths": {name: str(path) for name, path in result.sidecar_paths.items()},
+        "sample_counts": {
+            code: len([c for c in matrix.columns if c not in {"Ensembl_Gene_ID", "Symbol"}])
+            for code, matrix in result.matrices.items()
+        },
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -468,6 +468,116 @@ def test_recount3_source_from_registry_loads_packaged_routes():
     assert source.sample_to_cancer_code({"origin": "lung"}, "") is None
 
 
+def test_treehouse_source_from_registry_loads_direct_cohort_routes():
+    source = expression_builders.treehouse_source_from_registry("treehouse-polya-25-01")
+
+    assert source.source_id == "treehouse-polya-25-01"
+    assert source.source_cohort == "TREEHOUSE_POLYA_25_01"
+    assert source.tpm_file.startswith("Tumor-25.01-Polya")
+    assert source.clinical_file.startswith("clinical_Treehouse")
+    assert len(source.cohorts) == 26
+    by_code = {cohort.cancer_code: cohort for cohort in source.cohorts}
+    assert by_code["SARC_EWS"].disease_label == "Ewing sarcoma"
+    assert by_code["SARC_MPNST"].group == "sarc_rare_direct"
+    assert by_code["SARC_GIST"].group == "sarc_subtypes"
+
+    rare = expression_builders.treehouse_cohorts_for_group("sarc_rare_direct")
+    assert "SARC_MPNST" in {cohort.cancer_code for cohort in rare}
+
+    ribod = expression_builders.treehouse_source_from_registry("treehouse-ribod-25-01")
+    assert [cohort.cancer_code for cohort in ribod.cohorts] == ["SARC_CHOR", "RB"]
+
+
+def test_treehouse_sample_ids_filter_disease_and_tcga_selection():
+    clinical = pd.DataFrame(
+        [
+            {"th_dataset_id": "TREEHOUSE-1", "disease": "Ewing sarcoma"},
+            {"th_dataset_id": "TREEHOUSE-2", "disease": "ewing sarcoma"},
+            {"th_dataset_id": "TCGA-AB-1234-01A", "disease": "Ewing sarcoma"},
+            {"th_dataset_id": "TCGA-XY-9999-01A", "disease": "osteosarcoma"},
+        ]
+    )
+    cohort = expression_builders.TreehouseCohort("SARC_EWS", "Ewing sarcoma")
+    assert expression_builders.treehouse_sample_ids(clinical, cohort) == [
+        "TREEHOUSE-1",
+        "TREEHOUSE-2",
+        "TCGA-AB-1234-01A",
+    ]
+
+    tcga = expression_builders.TreehouseCohort(
+        "SARC_EWS",
+        "Ewing sarcoma",
+        selection="tcga",
+    )
+    assert expression_builders.treehouse_sample_ids(clinical, tcga) == ["TCGA-AB-1234-01A"]
+
+    unsupported = expression_builders.TreehouseCohort(
+        "SARC_EWS",
+        "Ewing sarcoma",
+        selection="pam50:BRCA_Basal",
+    )
+    with pytest.raises(ValueError, match="unsupported Treehouse cohort selection"):
+        expression_builders.treehouse_sample_ids(clinical, unsupported)
+
+
+def test_build_treehouse_source_matrices_writes_canonical_artifacts(tmp_path):
+    clinical_path = tmp_path / "clinical.tsv"
+    pd.DataFrame(
+        [
+            {"th_dataset_id": "SAMPLE_A", "disease": "synthetic tumor"},
+            {"th_dataset_id": "SAMPLE_B", "disease": "Synthetic Tumor"},
+            {"th_dataset_id": "CONTROL", "disease": "other"},
+        ]
+    ).to_csv(clinical_path, sep="\t", index=False)
+    tpm_path = tmp_path / "treehouse.tsv"
+    pd.DataFrame(
+        {
+            "Gene": ["TP53", "EGFR"],
+            "SAMPLE_A": np.log2(np.array([2.0, 1.0]) + 1.0),
+            "SAMPLE_B": np.log2(np.array([4.0, 0.0]) + 1.0),
+            "CONTROL": np.log2(np.array([100.0, 100.0]) + 1.0),
+        }
+    ).to_csv(tpm_path, sep="\t", index=False)
+    source = expression_builders.TreehouseSource(
+        source_id="synthetic-treehouse",
+        source_cohort="SYNTHETIC_TREEHOUSE",
+        cancer_code="CODE_A",
+        tpm_file=tpm_path.name,
+        clinical_file=clinical_path.name,
+        source_project="Treehouse",
+        cohorts=(
+            expression_builders.TreehouseCohort(
+                "CODE_A",
+                "synthetic tumor",
+                extra_notes="Synthetic cohort note.",
+            ),
+        ),
+        notes="Synthetic source note.",
+        pipeline_stem="synthetic_treehouse",
+    )
+
+    result = expression_builders.build_treehouse_source_matrices(source, cache_dir=tmp_path)
+
+    assert set(result.matrix_paths) == {"CODE_A"}
+    out = pd.read_parquet(result.matrix_paths["CODE_A"]).set_index("Symbol")
+    assert list(out.columns) == ["Ensembl_Gene_ID", "SAMPLE_A", "SAMPLE_B"]
+    np.testing.assert_allclose(
+        out.loc["TP53", ["SAMPLE_A", "SAMPLE_B"]].astype(float).to_numpy(),
+        [2.0, 4.0],
+    )
+    np.testing.assert_allclose(
+        out.loc["EGFR", ["SAMPLE_A", "SAMPLE_B"]].astype(float).to_numpy(),
+        [1.0, 0.0],
+    )
+    assert result.sidecar_paths["mapping_audit"].exists()
+    assert result.sidecar_paths["parse_diagnostics"].exists()
+    assert result.sidecar_paths["summary_rows"].exists()
+    assert result.summary_rows["notes"].str.contains("Synthetic cohort note").all()
+    summary = result.summary_rows.set_index("Symbol")
+    assert summary.loc["TP53", "TPM_median"] == 3.0
+    assert set(result.sample_qc["sample_id"]) == {"SAMPLE_A", "SAMPLE_B"}
+
+
 def test_recount3_gene_sums_to_tpm_length_normalizes_and_collapses_versions():
     gene_sums = pd.DataFrame(
         {"S1": [1000.0, 1000.0], "S2": [0.0, 500.0]},
@@ -699,6 +809,54 @@ def test_build_recount3_script_uses_registry_config(tmp_path, monkeypatch, capsy
     assert mod.main(["synthetic-recount3", "--cache-dir", str(tmp_path / "cache")]) == 0
     stdout = capsys.readouterr().out
     assert '"source_id": "synthetic-recount3"' in stdout
+    assert '"CODE_A": 1' in stdout
+
+
+def test_build_treehouse_script_uses_registry_config(tmp_path, monkeypatch, capsys):
+    mod = _load_script("build_treehouse_source")
+    source = expression_builders.TreehouseSource(
+        source_id="synthetic-treehouse",
+        source_cohort="SYNTHETIC_TREEHOUSE",
+        cancer_code="CODE_A",
+        tpm_file="treehouse.tsv",
+        clinical_file="clinical.tsv",
+        cohorts=(expression_builders.TreehouseCohort("CODE_A", "synthetic tumor"),),
+    )
+
+    def _fake_build(source_obj, *, cache_dir, output_dir=None, **_kwargs):
+        assert source_obj is source
+        assert Path(cache_dir) == tmp_path / "cache"
+        assert output_dir is None
+        matrix = pd.DataFrame(
+            {
+                "Ensembl_Gene_ID": ["ENSG00000141510"],
+                "Symbol": ["TP53"],
+                "S1": [10.0],
+            }
+        )
+        return expression_builders.SourceMatrixBuildResult(
+            source=source,
+            matrices={"CODE_A": matrix},
+            matrix_paths={"CODE_A": tmp_path / "CODE_A_per_sample_tpm.parquet"},
+            summary_rows=pd.DataFrame(
+                columns=list(expression_builders.REFERENCE_EXPRESSION_COLUMNS)
+            ),
+            mapping_audit=pd.DataFrame(),
+            parse_diagnostics=pd.DataFrame(),
+            sample_qc=pd.DataFrame(),
+            sidecar_paths={"mapping_audit": tmp_path / "mapping_audit.csv"},
+        )
+
+    monkeypatch.setattr(
+        mod,
+        "treehouse_source_from_registry",
+        lambda source_id, registry_path=None: source,
+    )
+    monkeypatch.setattr(mod, "build_treehouse_source_matrices", _fake_build)
+
+    assert mod.main(["synthetic-treehouse", "--cache-dir", str(tmp_path / "cache")]) == 0
+    stdout = capsys.readouterr().out
+    assert '"source_id": "synthetic-treehouse"' in stdout
     assert '"CODE_A": 1' in stdout
 
 


### PR DESCRIPTION
## Summary

- Add `TreehouseSource` / `TreehouseCohort` registry-backed build primitives to `oncoref.expression_builders`.
- Add `scripts/build_treehouse_source.py`, matching the thin CLI shape used by the GEO and recount3 builders.
- Move direct Treehouse PolyA/RiboD cohort disease-label routing into `expression_sources.yaml`, including the rare direct Treehouse cohorts already represented by the shipped cohort registry.
- Document the Treehouse builder API and explicitly leave cBioPortal/GDC side-table selectors as follow-up #296 work.

## Scope

This is a concrete slice of #296. It covers direct Treehouse compendium routing from clinical disease labels plus the registry-native `tcga` selector. It does not yet port the molecular/histology Treehouse subtype sweeps that require external cBioPortal/GDC side tables.

## Validation

- `python -m pytest tests/test_build_generators.py -q`
- `python -m pytest tests/test_expression_sources.py tests/test_catalog.py tests/test_data_manifest.py -q`
- `./lint.sh`

Refs #296.