### PR TITLE
Add Treehouse GDC project selector

### DIFF
--- a/oncoref/data/expression_sources.yaml
+++ b/oncoref/data/expression_sources.yaml
@@ -305,6 +305,41 @@ sources:
       GDC STAR-counts build can coexist without clobbering Treehouse-derived
       artifacts.
 
+  - id: treehouse-polya-25-01-tcga-glioma
+    category: expression
+    cancer_codes: [GBM, LGG]
+    source_type: treehouse-compendium
+    source_cohort: TREEHOUSE_POLYA_25_01_TCGA_SUBSET
+    source_project: Treehouse (TCGA samples)
+    url: https://public.gi.ucsc.edu/~ekephart/public-data/#tumor_25.01_polya
+    builder: scripts/build_treehouse_source.py
+    sibling_builders:
+      - scripts/sweep_treehouse_tcga_glioma_split.py  # superseded GDC-project split
+    unit: log2(TPM+1)
+    expected_size_gb: 6.2
+    citation: >
+      Treehouse Childhood Cancer Initiative, Tumor Compendium 25.01
+      PolyA, TCGA glioma subset split by GDC project assignment.
+      GSE294351.
+    files:
+      tpm: Tumor-25.01-Polya_hugo_log2tpm_58581genes_2025-02-27.tsv
+      clinical: clinical_Treehouse-Tumor-Compendium-25.01-PolyA_20250131v1.tsv
+      tpm_url: https://xena.treehouse.gi.ucsc.edu/download/Tumor-25.01-Polya_hugo_log2tpm_58581genes_2025-02-27.tsv
+      clinical_url: https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-Tumor-Compendium-25.01-PolyA_20250131v1.tsv
+    pipeline_stem: treehouse_polya_25_01_tcga_glioma_split
+    tumor_origin: mixed
+    treehouse_cohorts:
+      - {cancer_code: GBM, disease_label: glioma, group: tcga_glioma, selection: gdc_project:TCGA-GBM, cache_stem: tcga_gbm}
+      - {cancer_code: LGG, disease_label: glioma, group: tcga_glioma, selection: gdc_project:TCGA-LGG, cache_stem: tcga_lgg}
+    special_handling: >
+      Treehouse labels TCGA-GBM and TCGA-LGG samples with the shared
+      disease label `glioma`. This source splits that bucket by joining
+      each Treehouse TCGA sample barcode prefix to a cached GDC
+      case-to-project lookup, then routes TCGA-GBM and TCGA-LGG separately.
+      It uses the same source_cohort as the direct Treehouse TCGA subset
+      so downstream source comparisons can treat it as part of the same
+      Treehouse-reprocessed TCGA expression origin.
+
   - id: treehouse-ribod-25-01
     category: expression
     cancer_codes: [SARC_CHOR, RB]

--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -38,10 +38,12 @@ referenced and documented as the public build-time API.
 from __future__ import annotations
 
 import gzip
+import json
 import os
 import re
 import shutil
 import tempfile
+import urllib.parse
 import urllib.request
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, replace
@@ -967,12 +969,17 @@ def _treehouse_tcga_case_id(sample_id: str) -> str | None:
     return "-".join(text.split("-")[:3])
 
 
-def _treehouse_sample_matches_selection(row: Mapping, selection: str) -> bool:
+def _treehouse_sample_matches_selection(
+    row: Mapping,
+    selection: str,
+    *,
+    selection_case_sets: Mapping[str, set[str]] | None = None,
+) -> bool:
     """Return whether a Treehouse clinical row passes a declarative selector.
 
-    The initial oncoref-owned wrapper supports the selection grammar that can be
-    evaluated from the Treehouse clinical table alone. Molecular/histology
-    selectors that require cBioPortal/GDC side tables remain source-specific
+    Supports selectors that can be evaluated from the Treehouse clinical table
+    alone, plus GDC project membership via precomputed case sets. Molecular and
+    histology selectors that require cBioPortal/GDC labels remain source-specific
     follow-ups under #296.
     """
     selector = str(selection or "").strip()
@@ -980,15 +987,23 @@ def _treehouse_sample_matches_selection(row: Mapping, selection: str) -> bool:
         return True
     if selector == "tcga":
         return _treehouse_tcga_case_id(str(row.get("th_dataset_id", ""))) is not None
+    if selector.startswith("gdc_project:"):
+        case_sets = selection_case_sets or {}
+        if selector not in case_sets:
+            raise ValueError(f"Treehouse selector {selector!r} requires a precomputed GDC case set")
+        case_id = _treehouse_tcga_case_id(str(row.get("th_dataset_id", "")))
+        return case_id in case_sets[selector] if case_id is not None else False
     raise ValueError(
         f"unsupported Treehouse cohort selection {selector!r}; "
-        "only '' and 'tcga' are registry-native so far"
+        "only '', 'tcga', and 'gdc_project:<TCGA-project>' are registry-native so far"
     )
 
 
 def treehouse_sample_ids(
     clinical: pd.DataFrame,
     cohort: TreehouseCohort,
+    *,
+    selection_case_sets: Mapping[str, set[str]] | None = None,
 ) -> list[str]:
     """Sample IDs in ``clinical`` matching one Treehouse cohort definition."""
     required = {"th_dataset_id", "disease"}
@@ -999,7 +1014,11 @@ def treehouse_sample_ids(
     subset = clinical.loc[disease.eq(cohort.disease_label.strip().lower())].copy()
     if cohort.selection:
         keep = subset.apply(
-            lambda row: _treehouse_sample_matches_selection(row.to_dict(), cohort.selection),
+            lambda row: _treehouse_sample_matches_selection(
+                row.to_dict(),
+                cohort.selection,
+                selection_case_sets=selection_case_sets,
+            ),
             axis=1,
         )
         subset = subset.loc[keep]
@@ -1010,6 +1029,77 @@ def treehouse_sample_ids(
             f"(disease_label={cohort.disease_label!r}, selection={cohort.selection!r})"
         )
     return ids
+
+
+def treehouse_gdc_case_project_map(
+    project_ids: Iterable[str],
+    *,
+    cache_path: str | Path | None = None,
+    force_download: bool = False,
+) -> pd.DataFrame:
+    """TCGA case submitter IDs and GDC project IDs for Treehouse splits."""
+    projects = sorted({str(project).strip() for project in project_ids if str(project).strip()})
+    if not projects:
+        return pd.DataFrame(columns=["submitter_id", "project_id"])
+    cache = Path(cache_path) if cache_path is not None else None
+    if cache is not None and cache.exists() and not force_download:
+        return pd.read_csv(cache)
+
+    filters = {
+        "op": "in",
+        "content": {
+            "field": "project.project_id",
+            "value": projects,
+        },
+    }
+    params = {
+        "filters": json.dumps(filters),
+        "fields": "submitter_id,project.project_id",
+        "format": "JSON",
+        "size": "5000",
+    }
+    url = "https://api.gdc.cancer.gov/cases?" + urllib.parse.urlencode(params)
+    with urllib.request.urlopen(url, timeout=60) as response:
+        hits = json.load(response)["data"]["hits"]
+    rows = [
+        {
+            "submitter_id": str(hit["submitter_id"]),
+            "project_id": str(hit["project"]["project_id"]),
+        }
+        for hit in hits
+    ]
+    out = pd.DataFrame(rows, columns=["submitter_id", "project_id"])
+    if cache is not None:
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        out.to_csv(cache, index=False)
+    return out
+
+
+def _treehouse_selection_case_sets(
+    source: TreehouseSource,
+    *,
+    cache_dir: str | Path,
+    force_download: bool = False,
+) -> dict[str, set[str]]:
+    gdc_projects = {
+        cohort.selection.split(":", 1)[1]
+        for cohort in source.cohorts
+        if cohort.selection.startswith("gdc_project:")
+    }
+    if not gdc_projects:
+        return {}
+    cache_path = Path(cache_dir) / "derived" / f"{_artifact_stem(source.source_id)}_gdc_cases.csv"
+    case_map = treehouse_gdc_case_project_map(
+        gdc_projects,
+        cache_path=cache_path,
+        force_download=force_download,
+    )
+    case_sets: dict[str, set[str]] = {
+        f"gdc_project:{project_id}": set() for project_id in gdc_projects
+    }
+    for project_id, sub in case_map.groupby("project_id"):
+        case_sets[f"gdc_project:{project_id}"] = set(sub["submitter_id"].astype(str))
+    return case_sets
 
 
 def read_treehouse_tpm_columns(path: str | Path, sample_cols: Iterable[str]) -> pd.DataFrame:
@@ -1626,8 +1716,18 @@ def build_treehouse_source_matrices(
         clinical_file = _download(source.clinical_url, clinical_file, force=force_download)
 
     clinical = pd.read_csv(clinical_file, sep="\t")
+    selection_case_sets = _treehouse_selection_case_sets(
+        source,
+        cache_dir=cache,
+        force_download=force_download,
+    )
     buckets = {
-        cohort.cancer_code: treehouse_sample_ids(clinical, cohort) for cohort in source.cohorts
+        cohort.cancer_code: treehouse_sample_ids(
+            clinical,
+            cohort,
+            selection_case_sets=selection_case_sets,
+        )
+        for cohort in source.cohorts
     }
     all_samples = sorted({sample for samples in buckets.values() for sample in samples})
     if not all_samples:

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -514,6 +514,25 @@ def test_treehouse_source_from_registry_loads_tcga_subset_routes():
     assert {cohort.selection for cohort in tcga_direct} == {"tcga"}
 
 
+def test_treehouse_source_from_registry_loads_glioma_gdc_project_routes():
+    source = expression_builders.treehouse_source_from_registry("treehouse-polya-25-01-tcga-glioma")
+
+    assert source.source_cohort == "TREEHOUSE_POLYA_25_01_TCGA_SUBSET"
+    assert source.pipeline_stem == "treehouse_polya_25_01_tcga_glioma_split"
+    assert source.cancer_code == ["GBM", "LGG"]
+    by_code = {cohort.cancer_code: cohort for cohort in source.cohorts}
+    assert by_code["GBM"].disease_label == "glioma"
+    assert by_code["GBM"].selection == "gdc_project:TCGA-GBM"
+    assert by_code["GBM"].effective_cache_stem == "tcga_gbm"
+    assert by_code["LGG"].selection == "gdc_project:TCGA-LGG"
+
+    glioma = expression_builders.treehouse_cohorts_for_group(
+        "tcga_glioma",
+        source_id="treehouse-polya-25-01-tcga-glioma",
+    )
+    assert [cohort.cancer_code for cohort in glioma] == ["GBM", "LGG"]
+
+
 def test_treehouse_sample_ids_filter_disease_and_tcga_selection():
     clinical = pd.DataFrame(
         [
@@ -544,6 +563,31 @@ def test_treehouse_sample_ids_filter_disease_and_tcga_selection():
     )
     with pytest.raises(ValueError, match="unsupported Treehouse cohort selection"):
         expression_builders.treehouse_sample_ids(clinical, unsupported)
+
+
+def test_treehouse_sample_ids_filter_gdc_project_selection():
+    clinical = pd.DataFrame(
+        [
+            {"th_dataset_id": "TCGA-GB-0001-01A", "disease": "glioma"},
+            {"th_dataset_id": "TCGA-LG-0002-01A", "disease": "glioma"},
+            {"th_dataset_id": "TREEHOUSE-3", "disease": "glioma"},
+        ]
+    )
+    cohort = expression_builders.TreehouseCohort(
+        "GBM",
+        "glioma",
+        selection="gdc_project:TCGA-GBM",
+    )
+    case_sets = {"gdc_project:TCGA-GBM": {"TCGA-GB-0001"}}
+
+    assert expression_builders.treehouse_sample_ids(
+        clinical,
+        cohort,
+        selection_case_sets=case_sets,
+    ) == ["TCGA-GB-0001-01A"]
+
+    with pytest.raises(ValueError, match="requires a precomputed GDC case set"):
+        expression_builders.treehouse_sample_ids(clinical, cohort)
 
 
 def test_build_treehouse_source_matrices_writes_canonical_artifacts(tmp_path):
@@ -602,6 +646,76 @@ def test_build_treehouse_source_matrices_writes_canonical_artifacts(tmp_path):
     summary = result.summary_rows.set_index("Symbol")
     assert summary.loc["TP53", "TPM_median"] == 3.0
     assert set(result.sample_qc["sample_id"]) == {"SAMPLE_A", "SAMPLE_B"}
+
+
+def test_build_treehouse_source_matrices_splits_gdc_project_cohorts(
+    tmp_path,
+    monkeypatch,
+):
+    clinical_path = tmp_path / "clinical.tsv"
+    pd.DataFrame(
+        [
+            {"th_dataset_id": "TCGA-GB-0001-01A", "disease": "glioma"},
+            {"th_dataset_id": "TCGA-LG-0002-01A", "disease": "glioma"},
+            {"th_dataset_id": "TREEHOUSE-3", "disease": "glioma"},
+        ]
+    ).to_csv(clinical_path, sep="\t", index=False)
+    tpm_path = tmp_path / "treehouse.tsv"
+    pd.DataFrame(
+        {
+            "Gene": ["TP53", "EGFR"],
+            "TCGA-GB-0001-01A": np.log2(np.array([2.0, 1.0]) + 1.0),
+            "TCGA-LG-0002-01A": np.log2(np.array([4.0, 0.0]) + 1.0),
+            "TREEHOUSE-3": np.log2(np.array([100.0, 100.0]) + 1.0),
+        }
+    ).to_csv(tpm_path, sep="\t", index=False)
+    source = expression_builders.TreehouseSource(
+        source_id="synthetic-treehouse-glioma",
+        source_cohort="SYNTHETIC_TREEHOUSE_TCGA",
+        cancer_code=["GBM", "LGG"],
+        tpm_file=tpm_path.name,
+        clinical_file=clinical_path.name,
+        source_project="Treehouse (TCGA samples)",
+        cohorts=(
+            expression_builders.TreehouseCohort(
+                "GBM",
+                "glioma",
+                selection="gdc_project:TCGA-GBM",
+                cache_stem="tcga_gbm",
+            ),
+            expression_builders.TreehouseCohort(
+                "LGG",
+                "glioma",
+                selection="gdc_project:TCGA-LGG",
+                cache_stem="tcga_lgg",
+            ),
+        ),
+    )
+
+    def fake_case_map(project_ids, *, cache_path=None, force_download=False):
+        assert set(project_ids) == {"TCGA-GBM", "TCGA-LGG"}
+        assert cache_path is not None
+        return pd.DataFrame(
+            {
+                "submitter_id": ["TCGA-GB-0001", "TCGA-LG-0002"],
+                "project_id": ["TCGA-GBM", "TCGA-LGG"],
+            }
+        )
+
+    monkeypatch.setattr(
+        expression_builders,
+        "treehouse_gdc_case_project_map",
+        fake_case_map,
+    )
+    result = expression_builders.build_treehouse_source_matrices(source, cache_dir=tmp_path)
+
+    assert set(result.matrix_paths) == {"GBM", "LGG"}
+    gbm = pd.read_parquet(result.matrix_paths["GBM"]).set_index("Symbol")
+    lgg = pd.read_parquet(result.matrix_paths["LGG"]).set_index("Symbol")
+    assert list(gbm.columns) == ["Ensembl_Gene_ID", "TCGA-GB-0001-01A"]
+    assert list(lgg.columns) == ["Ensembl_Gene_ID", "TCGA-LG-0002-01A"]
+    np.testing.assert_allclose(gbm.loc["TP53", "TCGA-GB-0001-01A"], 2.0)
+    np.testing.assert_allclose(lgg.loc["TP53", "TCGA-LG-0002-01A"], 4.0)
 
 
 def test_recount3_gene_sums_to_tpm_length_normalizes_and_collapses_versions():


### PR DESCRIPTION
## Summary

- add a registry-native `gdc_project:<TCGA-project>` selector for Treehouse source routing
- fetch/cache TCGA case-to-GDC-project mappings for Treehouse split builders
- add the `treehouse-polya-25-01-tcga-glioma` source so GBM and LGG can be built from the shared Treehouse `glioma` bucket without a pirlygenes-only split script
- cover the registry route, selector behavior, and mocked split build with tests

## Issue scope

Addresses another slice of #296, using the old `sweep_treehouse_tcga_glioma_split.py` route as the template. This does not close #296.

Still outstanding under #296: cBioPortal subtype label selectors for molecular splits, SARC/histology side-table overlays, and remaining non-Treehouse source-specific builders.

## Validation

- `python -m pytest tests/test_build_generators.py -q`
- `./lint.sh`
- `./test.sh` before the final empty-set guard tweak: 724 passed, 1 skipped, 1 warning
