### PR TITLE
Add Treehouse cBioPortal clinical selector

### DIFF
--- a/oncoref/data/expression_sources.yaml
+++ b/oncoref/data/expression_sources.yaml
@@ -305,6 +305,42 @@ sources:
       GDC STAR-counts build can coexist without clobbering Treehouse-derived
       artifacts.
 
+  - id: treehouse-polya-25-01-tcga-brca-pam50
+    category: expression
+    cancer_codes: [BRCA_Basal, BRCA_HER2, BRCA_LumA, BRCA_LumB, BRCA_Normal]
+    source_type: treehouse-compendium
+    source_cohort: TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50
+    source_project: Treehouse (TCGA-BRCA) x cBioPortal PAM50
+    url: https://public.gi.ucsc.edu/~ekephart/public-data/#tumor_25.01_polya
+    builder: scripts/build_treehouse_source.py
+    sibling_builders:
+      - scripts/sweep_treehouse_tcga_brca_pam50.py  # superseded cBioPortal subtype split
+    unit: log2(TPM+1)
+    expected_size_gb: 6.2
+    citation: >
+      Treehouse Childhood Cancer Initiative, Tumor Compendium 25.01
+      PolyA, TCGA-BRCA subset split by cBioPortal PAM50 subtype calls
+      from brca_tcga_pan_can_atlas_2018. PMID 29625050.
+    files:
+      tpm: Tumor-25.01-Polya_hugo_log2tpm_58581genes_2025-02-27.tsv
+      clinical: clinical_Treehouse-Tumor-Compendium-25.01-PolyA_20250131v1.tsv
+      tpm_url: https://xena.treehouse.gi.ucsc.edu/download/Tumor-25.01-Polya_hugo_log2tpm_58581genes_2025-02-27.tsv
+      clinical_url: https://xena.treehouse.gi.ucsc.edu/download/clinical_Treehouse-Tumor-Compendium-25.01-PolyA_20250131v1.tsv
+    pipeline_stem: treehouse_polya_25_01_tcga_brca_pam50
+    tumor_origin: primary
+    treehouse_cohorts:
+      - {cancer_code: BRCA_Basal, disease_label: breast invasive carcinoma, group: tcga_brca_pam50, selection: "cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_Basal", cache_stem: tcga_brca_basal}
+      - {cancer_code: BRCA_HER2, disease_label: breast invasive carcinoma, group: tcga_brca_pam50, selection: "cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_Her2", cache_stem: tcga_brca_her2}
+      - {cancer_code: BRCA_LumA, disease_label: breast invasive carcinoma, group: tcga_brca_pam50, selection: "cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_LumA", cache_stem: tcga_brca_luma}
+      - {cancer_code: BRCA_LumB, disease_label: breast invasive carcinoma, group: tcga_brca_pam50, selection: "cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_LumB", cache_stem: tcga_brca_lumb}
+      - {cancer_code: BRCA_Normal, disease_label: breast invasive carcinoma, group: tcga_brca_pam50, selection: "cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_Normal", cache_stem: tcga_brca_normal}
+    special_handling: >
+      Treehouse carries TCGA-BRCA samples in the parent breast invasive
+      carcinoma disease bucket. This source joins each TCGA sample barcode
+      prefix to cBioPortal PanCancer Atlas patient SUBTYPE calls and routes
+      the five PAM50 cohorts separately. It uses a distinct source_cohort from
+      the unsplit BRCA cohort so subtype-derived references remain auditable.
+
   - id: treehouse-polya-25-01-tcga-glioma
     category: expression
     cancer_codes: [GBM, LGG]

--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -969,6 +969,19 @@ def _treehouse_tcga_case_id(sample_id: str) -> str | None:
     return "-".join(text.split("-")[:3])
 
 
+def _parse_cbio_clinical_selector(selection: str) -> tuple[str, str, str] | None:
+    selector = str(selection or "").strip()
+    if not selector.startswith("cbio_clinical:"):
+        return None
+    parts = selector.split(":", 3)
+    if len(parts) != 4 or not all(part.strip() for part in parts[1:]):
+        raise ValueError(
+            "Treehouse cbio_clinical selectors must have the form "
+            "'cbio_clinical:<study_id>:<attribute_id>:<value>'"
+        )
+    return parts[1].strip(), parts[2].strip(), parts[3].strip()
+
+
 def _treehouse_sample_matches_selection(
     row: Mapping,
     selection: str,
@@ -993,9 +1006,19 @@ def _treehouse_sample_matches_selection(
             raise ValueError(f"Treehouse selector {selector!r} requires a precomputed GDC case set")
         case_id = _treehouse_tcga_case_id(str(row.get("th_dataset_id", "")))
         return case_id in case_sets[selector] if case_id is not None else False
+    if selector.startswith("cbio_clinical:"):
+        _parse_cbio_clinical_selector(selector)
+        case_sets = selection_case_sets or {}
+        if selector not in case_sets:
+            raise ValueError(
+                f"Treehouse selector {selector!r} requires a precomputed cBioPortal case set"
+            )
+        case_id = _treehouse_tcga_case_id(str(row.get("th_dataset_id", "")))
+        return case_id in case_sets[selector] if case_id is not None else False
     raise ValueError(
         f"unsupported Treehouse cohort selection {selector!r}; "
-        "only '', 'tcga', and 'gdc_project:<TCGA-project>' are registry-native so far"
+        "only '', 'tcga', 'gdc_project:<TCGA-project>', and "
+        "'cbio_clinical:<study_id>:<attribute_id>:<value>' are registry-native so far"
     )
 
 
@@ -1075,6 +1098,51 @@ def treehouse_gdc_case_project_map(
     return out
 
 
+def treehouse_cbioportal_clinical_attribute_map(
+    study_id: str,
+    attribute_id: str,
+    *,
+    clinical_data_type: str = "PATIENT",
+    cache_path: str | Path | None = None,
+    force_download: bool = False,
+) -> pd.DataFrame:
+    """cBioPortal clinical attribute values keyed by TCGA case submitter ID."""
+    study = str(study_id).strip()
+    attribute = str(attribute_id).strip()
+    data_type = str(clinical_data_type or "PATIENT").strip().upper()
+    if not study or not attribute:
+        return pd.DataFrame(columns=["case_id", "value"])
+    cache = Path(cache_path) if cache_path is not None else None
+    if cache is not None and cache.exists() and not force_download:
+        return pd.read_csv(cache)
+
+    params = {
+        "clinicalDataType": data_type,
+        "attributeId": attribute,
+    }
+    url = (
+        f"https://www.cbioportal.org/api/studies/{urllib.parse.quote(study)}/clinical-data?"
+        + urllib.parse.urlencode(params)
+    )
+    with urllib.request.urlopen(url, timeout=60) as response:
+        data = json.load(response)
+    rows = []
+    for item in data:
+        raw_id = item.get("patientId") or item.get("sampleId")
+        value = item.get("value")
+        if raw_id is None or value is None:
+            continue
+        case_id = _treehouse_tcga_case_id(str(raw_id))
+        if case_id is None:
+            continue
+        rows.append({"case_id": case_id, "value": str(value)})
+    out = pd.DataFrame(rows, columns=["case_id", "value"]).drop_duplicates()
+    if cache is not None:
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        out.to_csv(cache, index=False)
+    return out
+
+
 def _treehouse_selection_case_sets(
     source: TreehouseSource,
     *,
@@ -1086,19 +1154,49 @@ def _treehouse_selection_case_sets(
         for cohort in source.cohorts
         if cohort.selection.startswith("gdc_project:")
     }
-    if not gdc_projects:
-        return {}
-    cache_path = Path(cache_dir) / "derived" / f"{_artifact_stem(source.source_id)}_gdc_cases.csv"
-    case_map = treehouse_gdc_case_project_map(
-        gdc_projects,
-        cache_path=cache_path,
-        force_download=force_download,
-    )
-    case_sets: dict[str, set[str]] = {
-        f"gdc_project:{project_id}": set() for project_id in gdc_projects
+    cbio_selectors = {
+        cohort.selection
+        for cohort in source.cohorts
+        if cohort.selection.startswith("cbio_clinical:")
     }
-    for project_id, sub in case_map.groupby("project_id"):
-        case_sets[f"gdc_project:{project_id}"] = set(sub["submitter_id"].astype(str))
+    if not gdc_projects and not cbio_selectors:
+        return {}
+    derived = Path(cache_dir) / "derived"
+    case_sets: dict[str, set[str]] = {}
+    if gdc_projects:
+        cache_path = derived / f"{_artifact_stem(source.source_id)}_gdc_cases.csv"
+        case_map = treehouse_gdc_case_project_map(
+            gdc_projects,
+            cache_path=cache_path,
+            force_download=force_download,
+        )
+        case_sets.update({f"gdc_project:{project_id}": set() for project_id in gdc_projects})
+        for project_id, sub in case_map.groupby("project_id"):
+            case_sets[f"gdc_project:{project_id}"] = set(sub["submitter_id"].astype(str))
+
+    cbio_requests: dict[tuple[str, str], list[tuple[str, str]]] = {}
+    for selector in cbio_selectors:
+        parsed = _parse_cbio_clinical_selector(selector)
+        if parsed is None:
+            continue
+        study_id, attribute_id, value = parsed
+        cbio_requests.setdefault((study_id, attribute_id), []).append((selector, value))
+    for (study_id, attribute_id), selectors in cbio_requests.items():
+        cache_stem = "_".join(
+            part.lower().replace("-", "_")
+            for part in (_artifact_stem(source.source_id), study_id, attribute_id)
+        )
+        cache_path = derived / f"{cache_stem}_cbio_clinical.csv"
+        clinical = treehouse_cbioportal_clinical_attribute_map(
+            study_id,
+            attribute_id,
+            cache_path=cache_path,
+            force_download=force_download,
+        )
+        for selector, value in selectors:
+            case_sets[selector] = set(
+                clinical.loc[clinical["value"].astype(str).eq(value), "case_id"].astype(str)
+            )
     return case_sets
 
 

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -514,6 +514,39 @@ def test_treehouse_source_from_registry_loads_tcga_subset_routes():
     assert {cohort.selection for cohort in tcga_direct} == {"tcga"}
 
 
+def test_treehouse_source_from_registry_loads_brca_pam50_routes():
+    source = expression_builders.treehouse_source_from_registry(
+        "treehouse-polya-25-01-tcga-brca-pam50"
+    )
+
+    assert source.source_cohort == "TREEHOUSE_POLYA_25_01_TCGA_BRCA_PAM50"
+    assert source.pipeline_stem == "treehouse_polya_25_01_tcga_brca_pam50"
+    assert source.cancer_code == [
+        "BRCA_Basal",
+        "BRCA_HER2",
+        "BRCA_LumA",
+        "BRCA_LumB",
+        "BRCA_Normal",
+    ]
+    by_code = {cohort.cancer_code: cohort for cohort in source.cohorts}
+    assert by_code["BRCA_Basal"].disease_label == "breast invasive carcinoma"
+    assert (
+        by_code["BRCA_Basal"].selection
+        == "cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_Basal"
+    )
+    assert (
+        by_code["BRCA_HER2"].selection
+        == "cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_Her2"
+    )
+    assert by_code["BRCA_HER2"].effective_cache_stem == "tcga_brca_her2"
+
+    pam50 = expression_builders.treehouse_cohorts_for_group(
+        "tcga_brca_pam50",
+        source_id="treehouse-polya-25-01-tcga-brca-pam50",
+    )
+    assert [cohort.cancer_code for cohort in pam50] == source.cancer_code
+
+
 def test_treehouse_source_from_registry_loads_glioma_gdc_project_routes():
     source = expression_builders.treehouse_source_from_registry("treehouse-polya-25-01-tcga-glioma")
 
@@ -559,7 +592,7 @@ def test_treehouse_sample_ids_filter_disease_and_tcga_selection():
     unsupported = expression_builders.TreehouseCohort(
         "SARC_EWS",
         "Ewing sarcoma",
-        selection="pam50:BRCA_Basal",
+        selection="legacy_pam50:BRCA_Basal",
     )
     with pytest.raises(ValueError, match="unsupported Treehouse cohort selection"):
         expression_builders.treehouse_sample_ids(clinical, unsupported)
@@ -587,6 +620,32 @@ def test_treehouse_sample_ids_filter_gdc_project_selection():
     ) == ["TCGA-GB-0001-01A"]
 
     with pytest.raises(ValueError, match="requires a precomputed GDC case set"):
+        expression_builders.treehouse_sample_ids(clinical, cohort)
+
+
+def test_treehouse_sample_ids_filter_cbio_clinical_selection():
+    clinical = pd.DataFrame(
+        [
+            {"th_dataset_id": "TCGA-BR-0001-01A", "disease": "breast invasive carcinoma"},
+            {"th_dataset_id": "TCGA-BR-0002-01A", "disease": "breast invasive carcinoma"},
+            {"th_dataset_id": "TREEHOUSE-3", "disease": "breast invasive carcinoma"},
+        ]
+    )
+    selector = "cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_Basal"
+    cohort = expression_builders.TreehouseCohort(
+        "BRCA_Basal",
+        "breast invasive carcinoma",
+        selection=selector,
+    )
+    case_sets = {selector: {"TCGA-BR-0001"}}
+
+    assert expression_builders.treehouse_sample_ids(
+        clinical,
+        cohort,
+        selection_case_sets=case_sets,
+    ) == ["TCGA-BR-0001-01A"]
+
+    with pytest.raises(ValueError, match="requires a precomputed cBioPortal case set"):
         expression_builders.treehouse_sample_ids(clinical, cohort)
 
 
@@ -716,6 +775,85 @@ def test_build_treehouse_source_matrices_splits_gdc_project_cohorts(
     assert list(lgg.columns) == ["Ensembl_Gene_ID", "TCGA-LG-0002-01A"]
     np.testing.assert_allclose(gbm.loc["TP53", "TCGA-GB-0001-01A"], 2.0)
     np.testing.assert_allclose(lgg.loc["TP53", "TCGA-LG-0002-01A"], 4.0)
+
+
+def test_build_treehouse_source_matrices_splits_cbio_clinical_cohorts(
+    tmp_path,
+    monkeypatch,
+):
+    clinical_path = tmp_path / "clinical.tsv"
+    pd.DataFrame(
+        [
+            {"th_dataset_id": "TCGA-BR-0001-01A", "disease": "breast invasive carcinoma"},
+            {"th_dataset_id": "TCGA-BR-0002-01A", "disease": "breast invasive carcinoma"},
+            {"th_dataset_id": "TREEHOUSE-3", "disease": "breast invasive carcinoma"},
+        ]
+    ).to_csv(clinical_path, sep="\t", index=False)
+    tpm_path = tmp_path / "treehouse.tsv"
+    pd.DataFrame(
+        {
+            "Gene": ["TP53", "ERBB2"],
+            "TCGA-BR-0001-01A": np.log2(np.array([2.0, 1.0]) + 1.0),
+            "TCGA-BR-0002-01A": np.log2(np.array([4.0, 8.0]) + 1.0),
+            "TREEHOUSE-3": np.log2(np.array([100.0, 100.0]) + 1.0),
+        }
+    ).to_csv(tpm_path, sep="\t", index=False)
+    source = expression_builders.TreehouseSource(
+        source_id="synthetic-treehouse-brca-pam50",
+        source_cohort="SYNTHETIC_TREEHOUSE_BRCA_PAM50",
+        cancer_code=["BRCA_Basal", "BRCA_HER2"],
+        tpm_file=tpm_path.name,
+        clinical_file=clinical_path.name,
+        source_project="Treehouse (TCGA-BRCA) x cBioPortal PAM50",
+        cohorts=(
+            expression_builders.TreehouseCohort(
+                "BRCA_Basal",
+                "breast invasive carcinoma",
+                selection="cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_Basal",
+                cache_stem="tcga_brca_basal",
+            ),
+            expression_builders.TreehouseCohort(
+                "BRCA_HER2",
+                "breast invasive carcinoma",
+                selection="cbio_clinical:brca_tcga_pan_can_atlas_2018:SUBTYPE:BRCA_Her2",
+                cache_stem="tcga_brca_her2",
+            ),
+        ),
+    )
+
+    def fake_clinical_map(
+        study_id,
+        attribute_id,
+        *,
+        clinical_data_type="PATIENT",
+        cache_path=None,
+        force_download=False,
+    ):
+        assert study_id == "brca_tcga_pan_can_atlas_2018"
+        assert attribute_id == "SUBTYPE"
+        assert clinical_data_type == "PATIENT"
+        assert cache_path is not None
+        return pd.DataFrame(
+            {
+                "case_id": ["TCGA-BR-0001", "TCGA-BR-0002"],
+                "value": ["BRCA_Basal", "BRCA_Her2"],
+            }
+        )
+
+    monkeypatch.setattr(
+        expression_builders,
+        "treehouse_cbioportal_clinical_attribute_map",
+        fake_clinical_map,
+    )
+    result = expression_builders.build_treehouse_source_matrices(source, cache_dir=tmp_path)
+
+    assert set(result.matrix_paths) == {"BRCA_Basal", "BRCA_HER2"}
+    basal = pd.read_parquet(result.matrix_paths["BRCA_Basal"]).set_index("Symbol")
+    her2 = pd.read_parquet(result.matrix_paths["BRCA_HER2"]).set_index("Symbol")
+    assert list(basal.columns) == ["Ensembl_Gene_ID", "TCGA-BR-0001-01A"]
+    assert list(her2.columns) == ["Ensembl_Gene_ID", "TCGA-BR-0002-01A"]
+    np.testing.assert_allclose(basal.loc["TP53", "TCGA-BR-0001-01A"], 2.0)
+    np.testing.assert_allclose(her2.loc["ERBB2", "TCGA-BR-0002-01A"], 8.0)
 
 
 def test_recount3_gene_sums_to_tpm_length_normalizes_and_collapses_versions():


### PR DESCRIPTION
## Summary

- add a registry-native `cbio_clinical:<study_id>:<attribute_id>:<value>` selector for Treehouse cohort routing
- add cached cBioPortal clinical-attribute case maps keyed by TCGA case submitter ID
- add `treehouse-polya-25-01-tcga-brca-pam50` so BRCA PAM50 subtype cohorts can be built directly from Treehouse TCGA-BRCA plus cBioPortal SUBTYPE calls
- cover registry loading, selector behavior, and mocked BRCA PAM50 split builds with tests

## Issue scope

Addresses another focused slice of #296, replacing the old `scripts/sweep_treehouse_tcga_brca_pam50.py` path with a declarative oncoref Treehouse source.

This does not close #296. Remaining source-specific builder work includes HNSC HPV, UCEC/STAD molecular subtype routes, COAD/READ MSI score splits, LUAD mutation-positive cohorts, SARC histology overlays, and the remaining non-Treehouse source-specific builders.

## Validation

- `python -m pytest tests/test_build_generators.py tests/test_expression_sources.py tests/test_catalog.py tests/test_data_manifest.py -q`
- `./lint.sh`
- `./test.sh` -> 727 passed, 1 skipped, 1 existing matplotlib warning
