### PR TITLE
[codex] Clarify SARC TMB source scope

### DIFF
--- a/oncoref/tmb.py
+++ b/oncoref/tmb.py
@@ -52,6 +52,9 @@ _TMB_EVIDENCE_OVERRIDES = {
     "CRANIO": {"estimate_type": "small_n"},
     "HCL": {"estimate_type": "small_n"},
     "UCEC_POLE": {"estimate_type": "order_of_magnitude"},
+    # TCGA-SARC is a soft-tissue sarcoma cohort. It does not span the full oncoref
+    # SARC member-union scope, which also includes bone sarcomas and RMS.
+    "SARC": {"source_scope": "soft_tissue_sarcoma_subset"},
     "SARC_CIC": {"source_scope": "renal_cic_rearranged_sarcoma_proxy"},
 }
 

--- a/tests/test_tmb.py
+++ b/tests/test_tmb.py
@@ -101,6 +101,23 @@ def test_crc_msi_tmb_record_preserves_source_scope_metadata():
     assert direct["missing_reason"] is None
 
 
+def test_sarc_tmb_row_is_soft_tissue_subset_not_grand_union_direct():
+    row = tmb.cancer_tmb_df().set_index("cancer_code").loc["SARC"]
+
+    assert row["median_tmb_mut_mb"] == 1.8
+    assert row["source_scope"] == "soft_tissue_sarcoma_subset"
+    assert row["source_scope"] != "cancer_code_direct"
+    assert "soft-tissue" in row["notes"]
+
+    record = tmb.cancer_tmb_record("SARC")
+    assert record["resolved_cancer_code"] == "SARC"
+    assert record["inheritance_kind"] == "direct"
+    assert record["source_scope"] == "soft_tissue_sarcoma_subset"
+
+    registry_row = cancer_types.cancer_type_records(["SARC"]).iloc[0]
+    assert registry_row["reference_source"] == "member_union"
+
+
 def test_tmb_record_missing_and_bulk_direct_rows():
     assert tmb.cancer_tmb_record("COAD_MSI", inherit=False) is None
 


### PR DESCRIPTION
## Summary

Fixes #351 by keeping the useful TCGA-SARC median row while no longer labeling it as direct whole-code SARC evidence.

- overrides `SARC` TMB `source_scope` to `soft_tissue_sarcoma_subset`
- keeps the published 1.8 mut/Mb TCGA-SARC value available for callers that explicitly want that subset
- adds a regression test tying the TMB source scope to the registry member-union semantics

This avoids conflating soft-tissue-only TCGA-SARC TMB with the oncoref `SARC` member-union expression scope, which also includes bone sarcomas and RMS.

## Validation

- `python -m pytest tests/test_tmb.py tests/test_data_parity.py tests/test_cancer_types.py::test_cancer_type_reference_data_joins_scalar_oncoref_metrics -q`
- `./lint.sh`
- `./test.sh` (`731 passed, 1 skipped, 1 warning`)

## Remaining new queue

- #349: audit/add a direct UCEC_POLE aPD-1 row rather than inheriting bulk UCEC
- #352: build representative/percentile artifacts for the 8 UCEC/STAD subtype cohorts