### PR TITLE
Add burden provenance status schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,12 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
 - **Cohorts** — `oncoref.cohorts`: `cohort_registry`, `cohort_aggregates`,
   `cohort_source_version`, and mixture-cohort helpers.
 - **TMB** — `cancer_tmb`, `cancer_tmb_df` (parent-chain inheritance).
-- **Incidence / mortality** — `cancer_burden`, `burden_category` (ACS / GLOBOCAN).
+- **Incidence / mortality** — `cancer_burden`, `burden_category` (ACS /
+  GLOBOCAN). `cancer_burden_df()` is the auditable source table: percentage
+  columns are the current lookup surface, while raw-count, source-locator,
+  source-site, derivation, and rounding columns are explicit provenance fields.
+  Legacy rows mark source-local anchors as `not_extracted` until the row-level
+  ACS/GLOBOCAN audit fills them.
 - **Checkpoint response** — `oncoref.ici_response`: regimen-aware ORR anchors,
   anti-PD-1 shortcuts, endpoint estimates, and pooled response summaries. The
   long endpoint table exposes stable `estimate_id` values plus structured

--- a/docs/api.md
+++ b/docs/api.md
@@ -635,6 +635,11 @@ but it is not the clean-TPM biological denominator.
   audited gaps use `inheritance_kind="direct_missing"` so callers can distinguish
   “known no supported site-specific estimate” from an unmapped cancer code.
 - `oncoref.incidence` — incidence/mortality burden and burden categories.
+  `incidence.cancer_burden_df()` is the auditable burden table: percentages are
+  the public lookup values, and raw-count, source-locator, source-site,
+  derivation, and rounding columns are preserved as provenance fields. Existing
+  legacy rows keep locator status values such as `not_extracted` until exact
+  ACS/GLOBOCAN table/export anchors are filled in.
 - `oncoref.fusions` — defining fusions and partner-family lookups.
 - `oncoref.response_signatures` — legacy/compatibility response-signature
   surface used by oncoref plots. Treat it as transitional: new or extended

--- a/oncoref/data/cancer-incidence-mortality.csv
+++ b/oncoref/data/cancer-incidence-mortality.csv
@@ -1,38 +1,38 @@
-burden_category,us_incidence_pct,us_mortality_pct,world_incidence_pct,world_mortality_pct,confidence,source,notes
-lung,11.0,20.0,12.4,18.7,high,ACS-CFF2024;GLOBOCAN2022,highest mortality:incidence of common sites
-breast,15.0,7.0,11.6,6.9,high,ACS-CFF2024;GLOBOCAN2022,female breast
-prostate,16.0,6.0,7.3,4.1,high,ACS-CFF2024;GLOBOCAN2022,low mortality:incidence (indolent fraction)
-colorectal,8.0,9.0,9.6,9.3,high,ACS-CFF2024;GLOBOCAN2022,COAD+READ
-pancreas,3.0,8.0,4.1,4.8,high,ACS-CFF2024;GLOBOCAN2022,high mortality:incidence
-liver,2.0,5.0,4.3,7.8,high,ACS-CFF2024;GLOBOCAN2022,liver+intrahepatic bile duct; world>>US (GLOBOCAN2022 866k=4.3%)
-stomach,1.5,1.8,4.9,6.8,high,ACS-CFF2024;GLOBOCAN2022,world>>US
-esophagus,1.0,2.7,4.6,4.6,medium,ACS-CFF2024;GLOBOCAN2022,adeno(West)/squamous(Asia)
-bladder,4.0,3.0,3.0,2.0,medium,ACS-CFF2024;GLOBOCAN2022,
-kidney,4.0,2.0,2.5,1.8,medium,ACS-CFF2024;GLOBOCAN2022,kidney+renal pelvis
-melanoma,5.0,1.3,1.7,0.6,high,ACS-CFF2024;GLOBOCAN2022,cutaneous; low mortality share
-ovary,1.6,2.6,1.6,2.1,medium,ACS-CFF2024;GLOBOCAN2022,HGSOC-dominant
-uterus_endometrium,3.0,2.0,2.2,1.0,medium,ACS-CFF2024;GLOBOCAN2022,corpus uteri
-cervix,0.8,0.7,3.3,3.6,high,ACS-CFF2024;GLOBOCAN2022,world>>US (screening/HPV gap)
-head_and_neck,3.5,2.6,5.0,4.5,medium,ACS-CFF2024;GLOBOCAN2022,oral+pharynx+larynx aggregate (incl larynx); world adds nasopharynx
-thyroid,2.0,0.4,4.1,0.5,high,ACS-CFF2024;GLOBOCAN2022,lowest mortality:incidence; overdiagnosis (GLOBOCAN2022 821k=4.1%)
-brain_cns,1.4,2.7,1.6,2.5,medium,ACS-CFF2024;GLOBOCAN2022,brain+CNS incl glioma (GBM/LGG)
-non_hodgkin_lymphoma,4.0,3.0,2.8,2.5,medium,ACS-CFF2024;GLOBOCAN2022,incl DLBCL/FL/MCL/BL
-hodgkin_lymphoma,0.4,0.1,0.4,0.2,medium,ACS-CFF2024;GLOBOCAN2022,highly curable
-multiple_myeloma,1.8,2.0,1.0,1.1,medium,ACS-CFF2024;GLOBOCAN2022,plasma-cell
-leukemia_AML,1.0,1.9,0.9,1.5,low,ACS-CFF2024,deadliest leukemia; world approx
-leukemia_all_other,2.1,2.0,1.5,1.6,medium,ACS-CFF2024;GLOBOCAN2022,leukemia excl AML (CLL+CML+ALL+other)
-mesothelioma,0.15,0.4,0.1,0.2,low,ACS-CFF2024,asbestos-linked; very low survival
-testicular_germ_cell,0.5,0.05,0.5,0.1,medium,ACS-CFF2024;GLOBOCAN2022,young men; chemo-curable
-adrenal,0.04,0.04,0.05,0.05,low,literature,adrenocortical+pheo/paraganglioma; very rare
-bone_and_joint,0.2,0.34,0.2,0.2,low,ACS-CFF2024;GLOBOCAN2022,primary bone (OS/EWS/CHON/CHOR)
-soft_tissue_sarcoma,0.65,0.4,0.4,0.3,low,ACS-CFF2024;literature,STS excl bone
-gallbladder_biliary,0.62,0.77,0.9,1.0,medium,ACS-CFF2024;GLOBOCAN2022,extrahepatic biliary+gallbladder (intrahepatic=liver)
-small_intestine,0.62,0.36,0.3,0.2,medium,ACS-CFF2024;GLOBOCAN2022,carcinoid+adeno
-anus,0.53,0.36,0.3,0.2,medium,ACS-CFF2024;GLOBOCAN2022,HPV-driven SCC
-vulva,0.34,0.27,0.2,0.1,medium,ACS-CFF2024;GLOBOCAN2022,HPV+lichen sclerosus
-vagina,0.07,0.07,0.1,0.1,low,ACS-CFF2024;GLOBOCAN2022,rare HPV-driven
-penis,0.05,0.01,0.2,0.1,low,ACS-CFF2024;GLOBOCAN2022,world higher
-eye_ocular,0.17,0.06,0.05,0.04,low,ACS-CFF2024;GLOBOCAN2022,uveal melanoma + retinoblastoma
-kaposi_sarcoma,0.02,0.02,0.2,0.2,low,GLOBOCAN2022;literature,HIV/HHV8; world>>US
-other_and_unknown_primary,3.94,12.15,6.0,8.71,medium,ACS-CFF2024;GLOBOCAN2022,ill-defined/unknown primary + minor untabulated sites (residual to 100%)
-non_melanoma_skin,0.0,0.3,0.0,0.2,low,ACS-CFF2024,keratinocyte BCC/cSCC; excluded from standard incidence registries (not reportable); small mortality share
+burden_category,us_incidence_pct,us_incidence_count,us_incidence_total,us_mortality_pct,us_mortality_count,us_mortality_total,world_incidence_pct,world_incidence_count,world_incidence_total,world_mortality_pct,world_mortality_count,world_mortality_total,confidence,source,us_source_locator,us_source_locator_status,world_source_locator,world_source_locator_status,source_site_labels,source_site_codes,included_source_sites,excluded_source_sites,derivation_basis,rounding_rule,provenance_notes,notes
+lung,11.0,,,20.0,,,12.4,,,18.7,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,highest mortality:incidence of common sites
+breast,15.0,,,7.0,,,11.6,,,6.9,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,female breast
+prostate,16.0,,,6.0,,,7.3,,,4.1,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,low mortality:incidence (indolent fraction)
+colorectal,8.0,,,9.0,,,9.6,,,9.3,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,COAD+READ
+pancreas,3.0,,,8.0,,,4.1,,,4.8,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,high mortality:incidence
+liver,2.0,,,5.0,,,4.3,,,7.8,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,liver+intrahepatic bile duct; world>>US (GLOBOCAN2022 866k=4.3%)
+stomach,1.5,,,1.8,,,4.9,,,6.8,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,world>>US
+esophagus,1.0,,,2.7,,,4.6,,,4.6,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,adeno(West)/squamous(Asia)
+bladder,4.0,,,3.0,,,3.0,,,2.0,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,
+kidney,4.0,,,2.0,,,2.5,,,1.8,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,kidney+renal pelvis
+melanoma,5.0,,,1.3,,,1.7,,,0.6,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,cutaneous; low mortality share
+ovary,1.6,,,2.6,,,1.6,,,2.1,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,HGSOC-dominant
+uterus_endometrium,3.0,,,2.0,,,2.2,,,1.0,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,corpus uteri
+cervix,0.8,,,0.7,,,3.3,,,3.6,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,world>>US (screening/HPV gap)
+head_and_neck,3.5,,,2.6,,,5.0,,,4.5,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,oral+pharynx+larynx aggregate (incl larynx); world adds nasopharynx
+thyroid,2.0,,,0.4,,,4.1,,,0.5,,,high,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,lowest mortality:incidence; overdiagnosis (GLOBOCAN2022 821k=4.1%)
+brain_cns,1.4,,,2.7,,,1.6,,,2.5,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,brain+CNS incl glioma (GBM/LGG)
+non_hodgkin_lymphoma,4.0,,,3.0,,,2.8,,,2.5,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,incl DLBCL/FL/MCL/BL
+hodgkin_lymphoma,0.4,,,0.1,,,0.4,,,0.2,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,highly curable
+multiple_myeloma,1.8,,,2.0,,,1.0,,,1.1,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,plasma-cell
+leukemia_AML,1.0,,,1.9,,,0.9,,,1.5,,,low,ACS-CFF2024,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,deadliest leukemia; world approx
+leukemia_all_other,2.1,,,2.0,,,1.5,,,1.6,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,leukemia excl AML (CLL+CML+ALL+other)
+mesothelioma,0.15,,,0.4,,,0.1,,,0.2,,,low,ACS-CFF2024,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,asbestos-linked; very low survival
+testicular_germ_cell,0.5,,,0.05,,,0.5,,,0.1,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,young men; chemo-curable
+adrenal,0.04,,,0.04,,,0.05,,,0.05,,,low,literature,,not_extracted,,not_extracted,,,,,literature_approximation,not_extracted,,adrenocortical+pheo/paraganglioma; very rare
+bone_and_joint,0.2,,,0.34,,,0.2,,,0.2,,,low,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,primary bone (OS/EWS/CHON/CHOR)
+soft_tissue_sarcoma,0.65,,,0.4,,,0.4,,,0.3,,,low,ACS-CFF2024;literature,,not_extracted,,not_extracted,,,,,literature_approximation,not_extracted,,STS excl bone
+gallbladder_biliary,0.62,,,0.77,,,0.9,,,1.0,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,extrahepatic biliary+gallbladder (intrahepatic=liver)
+small_intestine,0.62,,,0.36,,,0.3,,,0.2,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,carcinoid+adeno
+anus,0.53,,,0.36,,,0.3,,,0.2,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,HPV-driven SCC
+vulva,0.34,,,0.27,,,0.2,,,0.1,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,HPV+lichen sclerosus
+vagina,0.07,,,0.07,,,0.1,,,0.1,,,low,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,rare HPV-driven
+penis,0.05,,,0.01,,,0.2,,,0.1,,,low,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,world higher
+eye_ocular,0.17,,,0.06,,,0.05,,,0.04,,,low,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,sum_of_sites,not_extracted,,uveal melanoma + retinoblastoma
+kaposi_sarcoma,0.02,,,0.02,,,0.2,,,0.2,,,low,GLOBOCAN2022;literature,,not_extracted,,not_extracted,,,,,literature_approximation,not_extracted,,HIV/HHV8; world>>US
+other_and_unknown_primary,3.94,,,12.15,,,6.0,,,8.71,,,medium,ACS-CFF2024;GLOBOCAN2022,,not_extracted,,not_extracted,,,,,residual,not_extracted,,ill-defined/unknown primary + minor untabulated sites (residual to 100%)
+non_melanoma_skin,0.0,,,0.3,,,0.0,,,0.2,,,low,ACS-CFF2024,,not_extracted,,not_extracted,,,,,not_extracted,not_extracted,,keratinocyte BCC/cSCC; excluded from standard incidence registries (not reportable); small mortality share

--- a/oncoref/incidence.py
+++ b/oncoref/incidence.py
@@ -32,8 +32,15 @@ def cancer_burden_df():
     """Return the curated ``cancer-incidence-mortality.csv`` reference: each
     cancer **burden category**'s share (%) of annual cancer incidence and
     mortality, for the US and worldwide, cited per row (ACS Cancer Facts &
-    Figures 2024 / GLOBOCAN 2022). Rows flagged in ``notes`` as subsets/rollups
-    overlap others — don't sum them blindly."""
+    Figures 2024 / GLOBOCAN 2022).
+
+    The percentage columns are the current public lookup surface. The companion
+    ``*_count`` / ``*_total`` columns, ``*_source_locator`` fields, source-site
+    fields, ``derivation_basis``, and ``rounding_rule`` are the audit/provenance
+    contract. Legacy rows keep ``*_source_locator_status="not_extracted"`` until
+    exact ACS/GLOBOCAN table/export anchors and raw counts are filled in. Rows
+    flagged in ``notes`` as subsets/rollups overlap others — don't sum them
+    blindly."""
     return get_data("cancer-incidence-mortality")
 
 

--- a/tests/test_incidence.py
+++ b/tests/test_incidence.py
@@ -50,6 +50,44 @@ def test_burden_all_metrics_resolve():
         assert mapping
 
 
+def test_burden_table_exposes_source_provenance_schema():
+    df = incidence.cancer_burden_df()
+    expected = {
+        "us_incidence_count",
+        "us_incidence_total",
+        "us_mortality_count",
+        "us_mortality_total",
+        "world_incidence_count",
+        "world_incidence_total",
+        "world_mortality_count",
+        "world_mortality_total",
+        "us_source_locator",
+        "us_source_locator_status",
+        "world_source_locator",
+        "world_source_locator_status",
+        "source_site_labels",
+        "source_site_codes",
+        "included_source_sites",
+        "excluded_source_sites",
+        "derivation_basis",
+        "rounding_rule",
+        "provenance_notes",
+    }
+    assert expected <= set(df.columns)
+    assert set(df["us_source_locator_status"]) == {"not_extracted"}
+    assert set(df["world_source_locator_status"]) == {"not_extracted"}
+    assert set(df["rounding_rule"]) == {"not_extracted"}
+    assert set(df["derivation_basis"]) <= {
+        "not_extracted",
+        "sum_of_sites",
+        "residual",
+        "literature_approximation",
+    }
+    by_category = df.set_index("burden_category")
+    assert by_category.loc["colorectal", "derivation_basis"] == "sum_of_sites"
+    assert by_category.loc["other_and_unknown_primary", "derivation_basis"] == "residual"
+
+
 def test_burden_category_from_primary_tissue():
     assert incidence.burden_category("PRAD") == "prostate"
     assert incidence.burden_category("LUAD") == "lung"


### PR DESCRIPTION
## Summary
- add explicit source-locator status fields for US and global burden rows
- distinguish row-level values that still need extraction from values with complete locators
- validate and document the provenance-status contract

## Validation
- `./test.sh`
- 755 passed, 1 skipped
- lint and formatting passed

Closes #159 only for the structural schema; row-by-row locator extraction remains tracked by the issue.