### PR TITLE
Index reference summary rows by cohort

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -3236,6 +3236,47 @@ def _reference_summary_frame() -> pd.DataFrame:
     return get_data(_REFERENCE_SUMMARY_DATASET, copy=False)
 
 
+_REFERENCE_SUMMARY_ROW_INDEX: (
+    tuple[
+        pd.DataFrame,
+        dict[tuple[str, str], np.ndarray],
+    ]
+    | None
+) = None
+
+
+def _reference_summary_row_index() -> dict[tuple[str, str], np.ndarray]:
+    """Map ``(cancer_code, source_cohort)`` to summary row positions.
+
+    The source-summary artifact currently has roughly five million rows.  A
+    boolean scan for each accessor call made small gene queries take tens of
+    seconds and multiplied that cost by every requested normalization.  The
+    frame is process-global and read-only, so build the positional index once;
+    keying the cache on object identity keeps monkeypatched/test frames safe.
+    """
+    global _REFERENCE_SUMMARY_ROW_INDEX
+    df = _reference_summary_frame()
+    cached = _REFERENCE_SUMMARY_ROW_INDEX
+    if cached is not None and cached[0] is df:
+        return cached[1]
+    code = df["cancer_code"].astype(str)
+    source = df["source_cohort"].fillna("").astype(str)
+    index = {
+        (str(key[0]), str(key[1])): positions
+        for key, positions in df.groupby([code, source], sort=False).indices.items()
+    }
+    _REFERENCE_SUMMARY_ROW_INDEX = (df, index)
+    return index
+
+
+def _clear_reference_summary_row_index() -> None:
+    global _REFERENCE_SUMMARY_ROW_INDEX
+    _REFERENCE_SUMMARY_ROW_INDEX = None
+
+
+_register_derived_cache(_clear_reference_summary_row_index)
+
+
 def _reference_summary_available_codes(
     *,
     source_kinds: set[str] | None = None,
@@ -3326,13 +3367,15 @@ def _reference_summary_selected_source(code: str) -> dict | None:
 
 def _reference_summary_selected_rows(code: str) -> pd.DataFrame:
     selected = _reference_summary_selected_source(code)
-    if selected is None:
-        return pd.DataFrame(columns=_reference_summary_frame().columns)
     df = _reference_summary_frame()
-    mask = (df["cancer_code"].astype(str) == code) & (
-        df["source_cohort"].fillna("").astype(str) == str(selected["source_cohort"])
+    if selected is None:
+        return pd.DataFrame(columns=df.columns)
+    positions = _reference_summary_row_index().get(
+        (str(code), str(selected["source_cohort"])),
     )
-    return df.loc[mask].copy()
+    if positions is None:
+        return pd.DataFrame(columns=df.columns)
+    return df.iloc[positions].copy()
 
 
 def _normalize_source_filter_values(values: str | Iterable[str] | None) -> set[str] | None:
@@ -3389,14 +3432,20 @@ def _reference_summary_all_rows(
         exclude_microarray_proxy=exclude_microarray_proxy,
     )
     sources = sources.loc[sources["cancer_code"].astype(str) == str(code)]
-    if sources.empty:
-        return pd.DataFrame(columns=_reference_summary_frame().columns)
-    allowed = set(sources["source_cohort"].astype(str))
     df = _reference_summary_frame()
-    mask = (df["cancer_code"].astype(str) == str(code)) & (
-        df["source_cohort"].fillna("").astype(str).isin(allowed)
-    )
-    return df.loc[mask].copy()
+    if sources.empty:
+        return pd.DataFrame(columns=df.columns)
+    row_index = _reference_summary_row_index()
+    parts = [
+        row_index[(str(code), source)]
+        for source in sources["source_cohort"].astype(str)
+        if (str(code), source) in row_index
+    ]
+    if not parts:
+        return pd.DataFrame(columns=df.columns)
+    # Preserve authoritative artifact order across multiple source cohorts.
+    positions = np.sort(np.concatenate(parts))
+    return df.iloc[positions].copy()
 
 
 def _reference_summary_expression_frame(

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -2211,6 +2211,34 @@ def test_cancer_reference_expression_summary_rows_all_preserves_sources_and_filt
     expression._source_cohort_kind_map.cache_clear()
 
 
+def test_reference_summary_row_index_reuses_positions_and_tracks_frame_identity(
+    monkeypatch,
+):
+    first = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1", "E2", "E3", "E4"],
+            "cancer_code": ["X", "Y", "X", "X"],
+            "source_cohort": ["SRC1", "SRC2", "SRC2", "SRC1"],
+        }
+    )
+    current = [first]
+    monkeypatch.setattr(expression, "_reference_summary_frame", lambda: current[0])
+    expression._clear_reference_summary_row_index()
+
+    index = expression._reference_summary_row_index()
+    assert index[("X", "SRC1")].tolist() == [0, 3]
+    assert index[("X", "SRC2")].tolist() == [2]
+    assert expression._reference_summary_row_index() is index
+
+    second = first.iloc[[2, 0]].reset_index(drop=True)
+    current[0] = second
+    rebuilt = expression._reference_summary_row_index()
+    assert rebuilt is not index
+    assert rebuilt[("X", "SRC2")].tolist() == [0]
+    assert rebuilt[("X", "SRC1")].tolist() == [1]
+    expression._clear_reference_summary_row_index()
+
+
 def test_cancer_reference_expression_summary_rows_all_pool(monkeypatch):
     expression._reference_summary_source_table.cache_clear()
     summary = pd.DataFrame(


### PR DESCRIPTION
## Summary
- build one identity-keyed positional index over the 5-million-row reference summary
- use it for selected-source and all-source cohort slices
- preserve authoritative artifact order across multi-source results
- rebuild automatically when tests or callers replace the backing frame

This removes the repeated full-frame scans exposed while implementing pirl-unc/pirlygenes#557. Seven delegated compatibility checks dropped from roughly six minutes to six seconds locally.

## Validation
- `./test.sh`
- 756 passed, 1 skipped
- lint and formatting passed