### PR TITLE
Qualify representative source provenance

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -313,13 +313,18 @@ _REPRESENTATIVE_PROVENANCE_COLUMNS = [
     "source_version",
     "source_project",
     "source_sample",
+    "source_group_id",
     "n_cohort_samples",
     "sample_qc",
+    "sample_qc_requested",
+    "source_sample_qc",
     "sample_qc_effective",
     "sample_qc_policy_version",
     "n_qc_pass",
     "n_qc_warn",
     "n_qc_fail",
+    "representative_role",
+    "benchmark_eligible",
     "selection_rank",
     "selection_method",
     "selection_basis",
@@ -523,7 +528,14 @@ def _attach_representative_provenance(long: pd.DataFrame, root: Path) -> pd.Data
             on="representative_id",
             how="left",
         )
-    for col in ("source_cohort", "source_version", "source_project", "source_sample"):
+    for col in (
+        "source_cohort",
+        "source_version",
+        "source_project",
+        "source_sample",
+        "source_group_id",
+        "representative_role",
+    ):
         if col not in long.columns:
             long[col] = pd.NA
     for col in (
@@ -535,7 +547,14 @@ def _attach_representative_provenance(long: pd.DataFrame, root: Path) -> pd.Data
     ):
         if col not in long.columns:
             long[col] = pd.NA
-    for col in ("sample_qc", "sample_qc_effective", "sample_qc_policy_version"):
+    for col in (
+        "sample_qc",
+        "sample_qc_requested",
+        "source_sample_qc",
+        "sample_qc_effective",
+        "sample_qc_policy_version",
+        "benchmark_eligible",
+    ):
         if col not in long.columns:
             long[col] = pd.NA
     if "selection_rank" in long.columns:
@@ -3863,8 +3882,14 @@ def representative_cohort_samples(
     IDs default to pirlygenes-compatible ``CODE_rep01`` columns/values; pass
     ``representative_id_style="internal"`` for the shard/provenance IDs
     (``CODE__rep1``). Long output can attach representative-level provenance:
-    source cohort/project/sample, selection rank, selection method/basis, and
-    package/data schema versions.
+    source cohort/project/sample, a stable source-group ID shared by aliases of
+    the same physical vector, selection rank/method/basis, and package/data
+    schema versions. Row-level ``sample_qc`` and ``source_sample_qc`` are the
+    selected sample's actual status; ``sample_qc_requested`` and
+    ``sample_qc_effective`` preserve the artifact policies separately.
+    ``benchmark_eligible=False`` with a QC-fallback ``representative_role``
+    keeps an all-fail representative inspectable without presenting it as
+    ordinary validation truth.
 
     ``gene_id_style="oncoref"`` returns canonical oncoref ENSG IDs. Opt into
     ``"pirlygenes"`` only for migration wrappers that need known legacy ENSG IDs

--- a/scripts/generate_representatives.py
+++ b/scripts/generate_representatives.py
@@ -63,7 +63,14 @@ _DATA_DIR = Path(__file__).resolve().parents[1] / "oncoref" / "data"
 OUT_DIR = _DATA_DIR / "cancer-reference-expression-representatives"
 _BASE = ["Ensembl_Gene_ID", "Symbol"]
 #: Columns representative_cohort_samples(include_provenance=True) merges back in.
-_PROVENANCE_COLUMNS = ["representative_id", "source_cohort", "source_project", "n_cohort_samples"]
+_PROVENANCE_COLUMNS = [
+    "representative_id",
+    "source_cohort",
+    "source_project",
+    "source_sample",
+    "source_group_id",
+    "n_cohort_samples",
+]
 
 
 def _drop_technical(df: pd.DataFrame) -> pd.DataFrame:
@@ -128,13 +135,13 @@ def build(input_dir: Path, *, k: int = 5, out_dir: Path = OUT_DIR) -> None:
                     "source_cohort": source_cohort,
                     "source_project": source_project,
                     "source_sample": src,
+                    "source_group_id": f"{source_cohort}:{src}",
                     "n_cohort_samples": n_cohort,
                 }
             )
         n += 1
         print(f"  {code}: {len(rep_ids)} reps of {n_cohort} samples", flush=True)
-    # Stable column order; source_sample is kept as extra provenance the reader ignores.
-    prov_df = pd.DataFrame(provenance, columns=[*_PROVENANCE_COLUMNS, "source_sample"])
+    prov_df = pd.DataFrame(provenance, columns=_PROVENANCE_COLUMNS)
     prov_df.to_csv(out_dir / "_provenance.csv", index=False)
     total_mb = sum(f.stat().st_size for f in out_dir.glob("*.parquet")) / 1e6
     print(f"\ndone: {n} cohorts, {total_mb:.1f} MB -> {out_dir}", flush=True)

--- a/scripts/rebuild_expression_artifacts.py
+++ b/scripts/rebuild_expression_artifacts.py
@@ -345,9 +345,16 @@ def rebuild(
         reps.to_parquet(rep_dir / f"{code}.parquet", index=False, compression="zstd")
         source_version = cohort_source_version(code)
         qc_counts = _qc_counts(qc)
+        source_cohort = code_to_source.get(code, code)
+        sample_qc_by_id = dict(
+            zip(
+                qc.get("sample_id", pd.Series(dtype=str)).astype(str),
+                qc.get("sample_qc_status", pd.Series(dtype=str)).astype(str),
+            )
+        )
         build_row = {
             "cancer_code": code,
-            "source_cohort": code_to_source.get(code, code),
+            "source_cohort": source_cohort,
             "source_version": source_version,
             "source_matrix_path": str(source_path),
             "sample_qc": sample_qc,
@@ -360,20 +367,38 @@ def rebuild(
             **qc_counts,
         }
         build_rows.append(build_row)
-        for rep_id in rep_ids:
+        for rep_id, source_sample in zip(rep_ids, rep_cols):
+            source_sample_qc = sample_qc_by_id.get(str(source_sample), effective_sample_qc)
+            benchmark_eligible = bool(
+                effective_sample_qc in {"pass", "pass_or_warn"}
+                and source_sample_qc in {"pass", "warn"}
+            )
             provenance.append(
                 {
                     "representative_id": rep_id,
-                    "source_cohort": code_to_source.get(code, code),
+                    "source_cohort": source_cohort,
                     "source_version": source_version,  # harmonized Ensembl release
                     "source_matrix_path": str(source_path),
-                    "sample_qc": sample_qc,
+                    "source_sample": source_sample,
+                    "source_group_id": f"{source_cohort}:{source_sample}",
+                    # Row-level sample_qc is the selected source sample's actual
+                    # status. Preserve the requested and effective artifact policies
+                    # separately so an all-fail fallback can never look like a pass.
+                    "sample_qc": source_sample_qc,
+                    "sample_qc_requested": sample_qc,
+                    "source_sample_qc": source_sample_qc,
                     "sample_qc_effective": effective_sample_qc,
                     "sample_qc_fallback_reason": sample_qc_fallback_reason,
                     "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
                     "n_source_samples": len(source_samples),
                     "n_cohort_samples": len(samples),
                     "n_negative_values_clipped": n_negative_values_clipped,
+                    "representative_role": (
+                        "standard"
+                        if benchmark_eligible
+                        else "source_qc_fallback_audit_only"
+                    ),
+                    "benchmark_eligible": benchmark_eligible,
                     **qc_counts,
                 }
             )

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -2094,10 +2094,19 @@ def test_representatives_generator_writes_shards_and_provenance(tmp_path):
     # The reader merges on these exact columns — all must be present (source_project
     # is best-effort and empty for an unregistered synthetic code, but the column
     # must exist so consumers don't KeyError).
-    for col in ("representative_id", "source_cohort", "source_project", "n_cohort_samples"):
+    for col in (
+        "representative_id",
+        "source_cohort",
+        "source_project",
+        "source_sample",
+        "source_group_id",
+        "n_cohort_samples",
+    ):
         assert col in prov.columns
     # Unregistered code -> source_cohort falls back to the code itself.
     assert (prov["source_cohort"] == "COHORT_A").all()
+    assert set(prov["source_sample"]) <= {f"s{i}" for i in range(6)}
+    assert (prov["source_group_id"] == prov["source_cohort"] + ":" + prov["source_sample"]).all()
 
 
 def test_representatives_generator_selects_on_biological_view(tmp_path, monkeypatch):
@@ -2195,6 +2204,12 @@ def test_rebuild_expression_artifacts_defaults_to_qc_passing_samples(tmp_path, m
     assert prov.loc[0, "n_source_samples"] == 3
     assert prov.loc[0, "n_cohort_samples"] == 1
     assert prov.loc[0, "sample_qc"] == "pass"
+    assert prov.loc[0, "sample_qc_requested"] == "pass"
+    assert prov.loc[0, "source_sample_qc"] == "pass"
+    assert prov.loc[0, "source_sample"] == "pass_sample"
+    assert prov.loc[0, "source_group_id"] == "TEST_SOURCE:pass_sample"
+    assert prov.loc[0, "representative_role"] == "standard"
+    assert bool(prov.loc[0, "benchmark_eligible"]) is True
     assert prov.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v2"
     assert prov.loc[0, "n_qc_pass"] == 1
     assert prov.loc[0, "n_qc_warn"] == 1
@@ -2309,6 +2324,14 @@ def test_rebuild_expression_artifacts_keeps_concentration_only_source_when_pass_
         build_meta.loc[0, "sample_qc_fallback_reason"]
         == "no_pass_samples_high_concentration_source"
     )
+    prov = pd.read_csv(out / "cancer-reference-expression-representatives" / "_provenance.csv")
+    assert set(prov["sample_qc"]) == {"fail"}
+    assert set(prov["sample_qc_requested"]) == {"pass"}
+    assert set(prov["source_sample_qc"]) == {"fail"}
+    assert set(prov["representative_role"]) == {"source_qc_fallback_audit_only"}
+    assert not prov["benchmark_eligible"].any()
+    assert prov["source_sample"].notna().all()
+    assert prov["source_group_id"].str.startswith("TEST_SOURCE:").all()
 
 
 def test_rebuild_expression_artifacts_clips_negative_source_values():

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -686,6 +686,12 @@ def test_representative_provenance_includes_source_sample_and_selection_metadata
             "source_cohort": ["PRAD"],
             "source_project": ["TCGA"],
             "source_sample": ["TCGA-XX-0001"],
+            "source_group_id": ["TCGA:TCGA-XX-0001"],
+            "sample_qc": ["pass"],
+            "sample_qc_requested": ["pass"],
+            "source_sample_qc": ["pass"],
+            "representative_role": ["standard"],
+            "benchmark_eligible": [True],
             "n_cohort_samples": [10],
         }
     ).to_csv(d / "_provenance.csv", index=False)
@@ -694,6 +700,10 @@ def test_representative_provenance_includes_source_sample_and_selection_metadata
 
     assert df.loc[0, "representative_id"] == "PRAD_rep01"
     assert df.loc[0, "source_sample"] == "TCGA-XX-0001"
+    assert df.loc[0, "source_group_id"] == "TCGA:TCGA-XX-0001"
+    assert df.loc[0, "source_sample_qc"] == "pass"
+    assert df.loc[0, "representative_role"] == "standard"
+    assert bool(df.loc[0, "benchmark_eligible"]) is True
     assert df.loc[0, "selection_rank"] == 1
     assert df.loc[0, "selection_method"] == expression.REPRESENTATIVE_SELECTION_METHOD
     assert df.loc[0, "selection_basis"] == expression.REPRESENTATIVE_SELECTION_BASIS
@@ -749,13 +759,18 @@ def test_representative_empty_long_schema_includes_requested_provenance(monkeypa
         "source_version",
         "source_project",
         "source_sample",
+        "source_group_id",
         "n_cohort_samples",
         "sample_qc",
+        "sample_qc_requested",
+        "source_sample_qc",
         "sample_qc_effective",
         "sample_qc_policy_version",
         "n_qc_pass",
         "n_qc_warn",
         "n_qc_fail",
+        "representative_role",
+        "benchmark_eligible",
         "selection_rank",
         "selection_method",
         "selection_basis",


### PR DESCRIPTION
## Summary

- preserve the physical source sample and a stable source-group ID for every representative
- separate the selected sample's actual QC status from requested/effective artifact policy
- mark all-fail QC fallbacks audit-only and benchmark-ineligible instead of presenting them as ordinary validation truth
- expose the new provenance fields through the public representative reader while keeping legacy bundles schema-compatible

This addresses the source-accounting gap uncovered by the trufflepig 598-sample accuracy audit. In particular, RB_rep03 came from an all-fail cohort fallback, while BRCA_rep02 and BRCA_Basal_rep02 are aliases of the same physical metaplastic breast tumor and must not count as independent observations.

No source expression values or cancer labels are changed by this PR. A data-bundle rebuild after merge will populate the new fields in released artifacts.

Tracks #367, #368, and #369.

## Validation

- ./test.sh
- 756 passed, 1 skipped
- lint and formatting clean
