### PR TITLE
Allow artifact QC for cancer reference accessors

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2590,6 +2590,11 @@ def cancer_reference_expression(
     this mode requires ``sample_qc="all"``; use ``summary_rows`` for the current
     QC-filtered richest-source recompute path.
 
+    ``sample_qc="artifact"`` reads each clean/log-clean percentile shard using
+    the QC policy recorded when that shard was built. It is intentionally valid
+    only with ``reference_source="artifact"`` and artifact-backed normalization
+    modes; raw TPM and summary-row modes require an explicit live-sample policy.
+
     Raw-TPM mode needs the per-sample source matrix available; pass
     ``auto_fetch=True`` to download it. Raw-TPM summaries default to
     ``sample_qc="pass"`` so sparse/source-QC-failed samples do not shape new
@@ -2619,8 +2624,15 @@ def cancer_reference_expression(
     ``on_missing="raise"`` to fail when any requested cohort/mode is unavailable.
     """
     modes = _reference_normalize_modes(normalize)
-    sample_qc = _validate_sample_qc(sample_qc)
+    sample_qc = _validate_artifact_sample_qc(sample_qc)
     reference_source = _validate_reference_source(reference_source)
+    if sample_qc == "artifact" and (
+        reference_source != "artifact" or "tpm_raw" in modes
+    ):
+        raise ValueError(
+            "sample_qc='artifact' requires reference_source='artifact' and "
+            "clean/log-clean artifact-backed normalization"
+        )
     _validate_gene_id_style(gene_id_style)
     gene_universe = _validate_artifact_gene_universe(gene_universe)
     source_kinds = _normalize_source_filter_values(source_kind)

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2626,9 +2626,7 @@ def cancer_reference_expression(
     modes = _reference_normalize_modes(normalize)
     sample_qc = _validate_artifact_sample_qc(sample_qc)
     reference_source = _validate_reference_source(reference_source)
-    if sample_qc == "artifact" and (
-        reference_source != "artifact" or "tpm_raw" in modes
-    ):
+    if sample_qc == "artifact" and (reference_source != "artifact" or "tpm_raw" in modes):
         raise ValueError(
             "sample_qc='artifact' requires reference_source='artifact' and "
             "clean/log-clean artifact-backed normalization"

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -2226,6 +2226,43 @@ def test_cancer_reference_expression_raw_tpm_uses_source_stats(monkeypatch):
     assert long["expression"].tolist() == [20.0]
 
 
+def test_cancer_reference_expression_accepts_artifact_qc_for_clean_shards(monkeypatch):
+    pct = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1"],
+            "Symbol": ["A"],
+            "p25": [1.0],
+            "p50": [2.0],
+            "p75": [3.0],
+        }
+    )
+    seen = {}
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+    monkeypatch.setattr(
+        expression,
+        "cohort_gene_percentiles",
+        lambda code, **kwargs: seen.update(kwargs) or pct.copy(),
+    )
+
+    out = expression.cancer_reference_expression("x", sample_qc="artifact")
+
+    assert seen["sample_qc"] == "artifact"
+    assert out["sample_qc"].tolist() == ["artifact"]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"normalize": "tpm", "sample_qc": "artifact"},
+        {"reference_source": "summary_rows", "sample_qc": "artifact"},
+    ],
+)
+def test_cancer_reference_expression_rejects_artifact_qc_for_live_views(kwargs):
+    with pytest.raises(ValueError, match="requires reference_source='artifact'"):
+        expression.cancer_reference_expression("PRAD", **kwargs)
+
+
 def test_cancer_reference_expression_summary_rows_selects_richest_source(monkeypatch):
     expression._reference_summary_source_table.cache_clear()
     summary = pd.DataFrame(


### PR DESCRIPTION
## Summary
- allow sample_qc="artifact" for artifact-backed clean/log-clean cancer reference shards
- reject artifact policy for raw TPM and live summary-row recomputation
- document and test the public accessor contract

## Motivation
Trufflepigs oncoref base-layer migration reads mixed reference artifacts whose recorded QC policies differ (for example, MTC uses pass_or_warn). The accessor already recommended sample_qc="artifact" for this case, but its validator rejected the value.

## Verification
- ./test.sh -q: 763 passed, 1 skipped
- python -m ruff check oncoref/expression.py tests/test_expression.py
- mkdocs build --strict
- git diff --check