### PR TITLE
Preserve unmeasured values through clean TPM

### DIFF
--- a/oncoref/normalization.py
+++ b/oncoref/normalization.py
@@ -165,6 +165,8 @@ def clean_tpm(
     compartments themselves comparable and the budget empirically interpretable.)
 
     An empty/zero compartment simply contributes 0 (the others still fill their share).
+    Missing source values remain ``NaN``: an unmeasured gene is not evidence of
+    measured zero expression.
     The public clean-TPM contract is deliberately singular: 16% ribosomal proteins,
     9% other technical RNA, and 75% biological genes. Use separately named helpers
     such as :func:`drop_technical_rna` / :func:`filter_technical_rna` for biology-only
@@ -218,7 +220,7 @@ def clean_tpm(
         scale = pd.Series(0.0, index=values.columns, dtype=float)
         scale.loc[comp_sum > 0] = fraction * 1_000_000.0 / comp_sum.loc[comp_sum > 0]
         clean.loc[mask] = values.loc[mask].mul(scale, axis=1)
-    return clean.fillna(0.0)
+    return clean
 
 
 def drop_technical_rna(

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from oncoref import expression
+from oncoref import expression, normalization
 
 _BREAKPOINTS = [0, 1, 5, 10, 50, 90, 95, 99, 100]
 
@@ -2836,6 +2836,18 @@ def test_pan_cancer_expression_converts_fpkm_to_tpm(monkeypatch):
     # Each TCGA column is rescaled to sum 1e6: FPKM_LUAD [2,8] -> [200000, 800000].
     assert out["LUAD_TPM_raw"].tolist() == pytest.approx([200000.0, 800000.0])
     assert out["BLCA_TPM_raw"].sum() == pytest.approx(1e6)
+
+
+def test_pan_cancer_expression_preserves_unmeasured_source_values(monkeypatch):
+    fixture = _pan_cancer_fixture()
+    fixture.loc[0, "FPKM_LUAD"] = np.nan
+    monkeypatch.setattr(expression, "get_data", lambda name: fixture.copy())
+
+    out = expression.pan_cancer_expression()
+
+    assert pd.isna(out.loc[0, "LUAD_TPM_raw"])
+    assert pd.isna(out.loc[0, "LUAD_TPM_clean"])
+    assert out.loc[1, "LUAD_TPM_clean"] == pytest.approx(normalization.BIOLOGICAL_FRACTION * 1e6)
 
 
 def test_pan_cancer_expression_raw_only(monkeypatch):

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -93,6 +93,29 @@ def test_clean_tpm_three_compartments():
     assert clean.loc[[2, 3], "s1"].sum() == pytest.approx(norm.BIOLOGICAL_FRACTION * 1e6)  # 750k
 
 
+def test_clean_tpm_preserves_missing_source_values():
+    rpl = sorted(gf.clean_tpm_ribosomal_gene_ids())[0]
+    mito = sorted(gf.clean_tpm_other_technical_gene_ids())[0]
+    gt = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": [rpl, mito, "ENSG00000111111"],
+            "Symbol": ["RP", "MT", "BIO"],
+        }
+    )
+    values = pd.DataFrame(
+        {
+            "missing_ribosomal": [np.nan, 10.0, 20.0],
+            "missing_technical": [10.0, np.nan, 20.0],
+            "missing_biological": [10.0, 20.0, np.nan],
+        },
+        index=gt.index,
+    )
+
+    clean = norm.clean_tpm(values, gt)
+
+    assert clean.isna().equals(values.isna())
+
+
 def test_clean_tpm_uses_censored_table_categories_for_ribosomal_budget():
     rpl10ap1 = "ENSG00000244691"
     rpl10l = "ENSG00000165496"


### PR DESCRIPTION
## Summary
- preserve source `NaN` cells during clean-TPM compartment rescaling
- document that missing expression is not measured zero
- cover both the normalization primitive and public pan-cancer accessor

## Why
Direct trufflepig consumption exposed 24 SARC genes whose raw source values were unmeasured but whose clean values became zero. That converted missingness into negative biological evidence and changed broad-SARC classification to DDLPS.

## Validation
- `./lint.sh`
- `./test.sh` (764 passed, 1 skipped)
- focused public accessor and normalization regressions (2 passed)