### PR TITLE
Close batch plot figures

### DIFF
--- a/scripts/regenerate_plots.py
+++ b/scripts/regenerate_plots.py
@@ -303,14 +303,18 @@ def main() -> int:
         fam_dir = run_dir / family
         fam_dir.mkdir(parents=True, exist_ok=True)
         out = fam_dir / f"{name}.png"
+        figure = None
         try:
-            getattr(plots, fn_attr)(save=out, **kwargs)
+            figure = getattr(plots, fn_attr)(save=out, **kwargs)
             done.append(f"{family}/{name}.png")
             print(f"  ok    {family}/{name}.png")
         except Exception as e:
             skipped.append((f"{family}/{name}", f"{type(e).__name__}: {e}"))
             print(f"  SKIP  {family}/{name}  ({type(e).__name__}: {e})", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)
+        finally:
+            if figure is not None:
+                plt.close(figure)
 
     curation_dir = run_dir / "cta_curation"
     try:

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -14,6 +14,14 @@ pytest.importorskip("matplotlib")
 from oncoref import cli, plots
 
 
+@pytest.fixture(autouse=True)
+def _close_figures_after_test():
+    yield
+    import matplotlib.pyplot as plt
+
+    plt.close("all")
+
+
 def test_apd1_vs_tmb_renders(tmp_path):
     out = tmp_path / "apd1_vs_tmb.png"
     fig = plots.apd1_vs_tmb(save=str(out))
@@ -754,3 +762,48 @@ def test_regenerate_plots_runner_writes_all_figures_pdf(tmp_path):
     assert pdf == tmp_path / "all-figures.pdf"
     assert pdf.exists()
     assert pdf.stat().st_size > 0
+
+
+def test_regenerate_plots_runner_closes_each_returned_figure(tmp_path, monkeypatch):
+    import importlib.util
+    import sys
+
+    import matplotlib.pyplot as plt
+
+    runner = Path(__file__).resolve().parent.parent / "scripts" / "regenerate_plots.py"
+    spec = importlib.util.spec_from_file_location("_regen_plots_memory", runner)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    def stub_plot(*, save, label):
+        fig, ax = plt.subplots()
+        ax.set_title(label)
+        fig.savefig(save)
+        return fig
+
+    monkeypatch.setattr(mod.plots, "_memory_test_plot", stub_plot, raising=False)
+    monkeypatch.setattr(
+        mod,
+        "_jobs",
+        lambda: [
+            ("memory", "first", "_memory_test_plot", {"label": "first"}),
+            ("memory", "second", "_memory_test_plot", {"label": "second"}),
+        ],
+    )
+    monkeypatch.setattr(
+        mod.cta_curation_plots,
+        "render",
+        lambda **kwargs: {"n_genes": 0, "paths": {}},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["regenerate_plots.py", "--out-dir", str(tmp_path), "--no-timestamp"],
+    )
+
+    existing_figures = set(plt.get_fignums())
+    assert mod.main() == 0
+    assert set(plt.get_fignums()) == existing_figures
+    assert (tmp_path / "memory" / "first.png").exists()
+    assert (tmp_path / "memory" / "second.png").exists()
+    assert (tmp_path / "all-figures.pdf").exists()


### PR DESCRIPTION
Closes #363.

## Summary
- close each `Figure` returned to the batch regeneration loop in a `finally` block
- preserve the public plotting API and its caller-owned figure lifecycle
- close figures between plot tests so full-suite state cannot accumulate
- add a batch-runner regression covering multiple saved figures and combined-PDF output

## Validation
- `./lint.sh`
- `python -m pytest tests/test_plots.py -q` (55 passed)
- `./test.sh` (769 passed, 1 skipped; no open-figure warning)