### PR TITLE
Filter summary availability provenance

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -3113,6 +3113,9 @@ def _reference_expression_availability_for_requests(
                     method,
                     sample_qc=sample_qc,
                     reference_source=reference_source,
+                    source_kinds=source_kinds,
+                    source_cohorts=source_cohorts,
+                    exclude_microarray_proxy=exclude_microarray_proxy,
                 )
             )
             rows.append(row)
@@ -3580,8 +3583,37 @@ def _reference_expression_frame(
     raise AssertionError(f"unhandled reference normalize mode: {mode}")
 
 
+_SARC_HISTOLOGY_SUMMARY_CODES = frozenset({"SARC_DDLPS", "SARC_WDLPS"})
+_STALE_SARC_HISTOLOGY_COHORT = "TREEHOUSE_POLYA_25_01_TCGA_SUBSET"
+_SARC_HISTOLOGY_COHORT = "TREEHOUSE_POLYA_25_01_TCGA_SARC_HISTOLOGY"
+
+
+def _canonical_reference_summary_source_labels(df: pd.DataFrame) -> pd.DataFrame:
+    """Expose canonical registry labels for two legacy SARC summary shards."""
+
+    if df.empty:
+        return df
+    codes = df["cancer_code"]
+    sources = df["source_cohort"].fillna("")
+    stale = codes.isin(_SARC_HISTOLOGY_SUMMARY_CODES) & sources.eq(_STALE_SARC_HISTOLOGY_COHORT)
+    if not stale.any():
+        return df
+    out = df.copy(deep=False)
+    canonical_sources = df["source_cohort"].copy()
+    canonical_sources.loc[stale] = _SARC_HISTOLOGY_COHORT
+    out["source_cohort"] = canonical_sources
+    return out
+
+
+@lru_cache(maxsize=1)
 def _reference_summary_frame() -> pd.DataFrame:
-    return get_data(_REFERENCE_SUMMARY_DATASET, copy=False)
+    """Shared read-only summary frame with canonical source labels."""
+
+    frame = get_data(_REFERENCE_SUMMARY_DATASET, copy=False)
+    return _canonical_reference_summary_source_labels(frame)
+
+
+_register_derived_cache(_reference_summary_frame.cache_clear)
 
 
 _REFERENCE_SUMMARY_ROW_INDEX: (
@@ -3607,12 +3639,24 @@ def _reference_summary_row_index() -> dict[tuple[str, str], np.ndarray]:
     cached = _REFERENCE_SUMMARY_ROW_INDEX
     if cached is not None and cached[0] is df:
         return cached[1]
-    code = df["cancer_code"].astype(str)
-    source = df["source_cohort"].fillna("").astype(str)
-    index = {
-        (str(key[0]), str(key[1])): positions
-        for key, positions in df.groupby([code, source], sort=False).indices.items()
-    }
+    if df.empty:
+        index = {}
+    else:
+        codes = df["cancer_code"].to_numpy(copy=False)
+        sources = df["source_cohort"].fillna("").to_numpy(copy=False)
+        starts_new_source = np.empty(len(df), dtype=bool)
+        starts_new_source[0] = True
+        starts_new_source[1:] = (codes[1:] != codes[:-1]) | (sources[1:] != sources[:-1])
+        starts = np.flatnonzero(starts_new_source)
+        ends = np.append(starts[1:], len(df))
+        all_positions = np.arange(len(df), dtype=np.int64)
+        index = {}
+        for start, end in zip(starts, ends):
+            key = (str(codes[start]), str(sources[start]))
+            positions = all_positions[start:end]
+            if key in index:
+                positions = np.concatenate([index[key], positions])
+            index[key] = positions
     _REFERENCE_SUMMARY_ROW_INDEX = (df, index)
     return index
 
@@ -3660,26 +3704,42 @@ def _reference_summary_source_table() -> pd.DataFrame:
     ]
     if df.empty:
         return pd.DataFrame(columns=columns)
-    work = df.copy()
-    work["cancer_code"] = work["cancer_code"].astype(str)
-    work["source_cohort"] = work["source_cohort"].fillna("").astype(str)
-    for optional_col in ("processing_pipeline", "notes"):
-        if optional_col not in work.columns:
-            work[optional_col] = pd.NA
-    grouped = (
-        work.groupby(["cancer_code", "source_cohort"], dropna=False, sort=False)
-        .agg(
-            source_project=("source_project", "first"),
-            source_version=("source_version", "first"),
-            tumor_origin=("tumor_origin", "first"),
-            metastasis_site=("metastasis_site", "first"),
-            n_reference_genes=("Ensembl_Gene_ID", "nunique"),
-            n_reference_samples=("n_samples", "max"),
-            processing_pipeline=("processing_pipeline", "first"),
-            notes=("notes", "first"),
+    source_columns = [
+        column
+        for column in (
+            "Ensembl_Gene_ID",
+            "n_samples",
+            "source_project",
+            "source_version",
+            "tumor_origin",
+            "metastasis_site",
+            "processing_pipeline",
+            "notes",
         )
-        .reset_index()
-    )
+        if column in df.columns
+    ]
+    source_column_positions = [df.columns.get_loc(column) for column in source_columns]
+    records = []
+    for (code, source), positions in _reference_summary_row_index().items():
+        source_rows = df.iloc[positions, source_column_positions]
+        first = source_rows.iloc[0]
+        records.append(
+            {
+                "cancer_code": code,
+                "source_cohort": source,
+                "source_project": first.get("source_project"),
+                "source_version": first.get("source_version"),
+                "tumor_origin": first.get("tumor_origin"),
+                "metastasis_site": first.get("metastasis_site"),
+                "n_reference_genes": source_rows["Ensembl_Gene_ID"].nunique(),
+                "n_reference_samples": pd.to_numeric(
+                    source_rows["n_samples"], errors="coerce"
+                ).max(),
+                "processing_pipeline": first.get("processing_pipeline"),
+                "notes": first.get("notes"),
+            }
+        )
+    grouped = pd.DataFrame.from_records(records)
     grouped["_origin_rank"] = (
         grouped["tumor_origin"]
         .fillna("")
@@ -3972,10 +4032,40 @@ def _pool_reference_expression_rows(long: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(out_rows, columns=cols)
 
 
-def _reference_summary_source_metadata(code: str) -> dict[str, str | bool | int | float | None]:
-    selected = _reference_summary_selected_source(code)
+def _unavailable_reference_summary_metadata() -> dict[str, str | bool | int | float | None]:
+    return {
+        "source_cohort": None,
+        "source_project": None,
+        "source_version": None,
+        "source_type": None,
+        "unit": None,
+        "source_scale_class": "unknown",
+        "linear_tpm_comparable": False,
+        "tumor_origin": None,
+        "metastasis_site": None,
+        "n_reference_genes": None,
+        "n_reference_samples": None,
+        "tpm_proxy": False,
+    }
+
+
+def _reference_summary_source_metadata(
+    code: str,
+    *,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
+) -> dict[str, str | bool | int | float | None] | None:
+    sources = _filter_reference_summary_sources(
+        _reference_summary_source_table(),
+        source_kinds=source_kinds,
+        source_cohorts=source_cohorts,
+        exclude_microarray_proxy=exclude_microarray_proxy,
+    )
+    matches = sources.loc[sources["cancer_code"].astype(str) == str(code)]
+    selected = None if matches.empty else matches.iloc[0].to_dict()
     if selected is None:
-        return _selected_expression_source_metadata(code)
+        return None
     meta = _selected_expression_source_metadata(code, source_cohort=str(selected["source_cohort"]))
     text = " ".join(
         str(selected.get(c) or "")
@@ -4009,14 +4099,35 @@ def _reference_sample_qc_label(mode: str, sample_qc: str) -> str:
 
 
 def _reference_expression_provenance(
-    code: str, mode: str, method: str, *, sample_qc: str, reference_source: str
+    code: str,
+    mode: str,
+    method: str,
+    *,
+    sample_qc: str,
+    reference_source: str,
+    source_kinds: set[str] | None = None,
+    source_cohorts: set[str] | None = None,
+    exclude_microarray_proxy: bool = False,
 ) -> dict:
-    if method == _REFERENCE_SUMMARY_METHOD:
-        meta = _reference_summary_source_metadata(code)
+    if method == _REFERENCE_SUMMARY_ALL_METHOD:
+        meta = (
+            _reference_summary_source_metadata(
+                code,
+                source_kinds=source_kinds,
+                source_cohorts=source_cohorts,
+                exclude_microarray_proxy=exclude_microarray_proxy,
+            )
+            or _unavailable_reference_summary_metadata()
+        )
+    elif method == _REFERENCE_SUMMARY_METHOD:
+        meta = _reference_summary_source_metadata(code) or _selected_expression_source_metadata(
+            code
+        )
     else:
         meta = _selected_expression_source_metadata(code)
     return {
-        "source_cohort": meta["source_cohort"] or code,
+        "source_cohort": meta["source_cohort"]
+        or (None if method == _REFERENCE_SUMMARY_ALL_METHOD else code),
         "source_project": meta.get("source_project"),
         "source_version": meta.get("source_version"),
         "source_type": meta.get("source_type"),
@@ -5218,8 +5329,31 @@ def _add_computed_pan_cancer_raw_columns(
     return out, raw_cols, added
 
 
+_PAN_CANCER_POOLED_SERIES_CACHE: tuple[pd.DataFrame, dict[tuple[str, ...], pd.Series]] | None = None
+
+
+def _clear_pan_cancer_pooled_series_cache() -> None:
+    global _PAN_CANCER_POOLED_SERIES_CACHE
+    _PAN_CANCER_POOLED_SERIES_CACHE = None
+
+
+_register_derived_cache(_clear_pan_cancer_pooled_series_cache)
+
+
 def _pooled_reference_expression_series_for_pan_cancer(member_codes: tuple[str, ...]) -> pd.Series:
     """n-sample-weighted raw TPM medians for a computed pan-cancer aggregate."""
+    global _PAN_CANCER_POOLED_SERIES_CACHE
+    summary = _reference_summary_frame()
+    cached = _PAN_CANCER_POOLED_SERIES_CACHE
+    if cached is None or cached[0] is not summary:
+        cached = (summary, {})
+        _PAN_CANCER_POOLED_SERIES_CACHE = cached
+    if member_codes not in cached[1]:
+        cached[1][member_codes] = _compute_pooled_reference_expression_series(member_codes)
+    return cached[1][member_codes]
+
+
+def _compute_pooled_reference_expression_series(member_codes: tuple[str, ...]) -> pd.Series:
     try:
         rows = _selected_reference_summary_rows_for_pan_cancer(member_codes)
     except (FileNotFoundError, KeyError, TypeError):
@@ -5254,17 +5388,21 @@ def _selected_reference_summary_rows_for_pan_cancer(member_codes: tuple[str, ...
     ].copy()
     if selected.empty:
         return pd.DataFrame()
-    selected["_source_key"] = selected["source_cohort"].fillna("").astype(str)
-    summary = _reference_summary_frame().copy()
+    summary = _reference_summary_frame()
     if summary.empty:
         return pd.DataFrame()
-    summary["_source_key"] = summary["source_cohort"].fillna("").astype(str)
-    rows = summary.merge(
-        selected[["cancer_code", "_source_key"]],
-        how="inner",
-        on=["cancer_code", "_source_key"],
-    )
-    return rows.drop(columns=["_source_key"])
+    row_index = _reference_summary_row_index()
+    positions = []
+    for row in selected.itertuples(index=False):
+        source_key = (str(row.cancer_code), str(row.source_cohort))
+        if source_key in row_index:
+            positions.append(row_index[source_key])
+    if not positions:
+        return pd.DataFrame(columns=["Ensembl_Gene_ID", "TPM_median", "n_samples"])
+    selected_positions = np.sort(np.concatenate(positions))
+    needed_columns = ["Ensembl_Gene_ID", "TPM_median", "n_samples"]
+    column_positions = [summary.columns.get_loc(column) for column in needed_columns]
+    return summary.iloc[selected_positions, column_positions].copy()
 
 
 def _pan_cancer_column_style(column_style: str | None) -> str:

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1172,6 +1172,13 @@ def test_per_sample_expression_canonicalizes_alias_genes(tmp_path, monkeypatch):
     )
 
 
+def _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, frame):
+    monkeypatch.setattr(expression, "get_data", lambda *args, **kwargs: frame.copy())
+    monkeypatch.setattr(
+        expression, "_computed_expression_reference_members", lambda cancer_code: ()
+    )
+
+
 def test_pan_cancer_expression_canonicalizes_alias_genes(monkeypatch):
     # pan_cancer_expression is dense canonical too: cohort/tissue columns are linear
     # abundances (nTPM/FPKM), so summing an alt copy into its primary row is exact.
@@ -1185,7 +1192,7 @@ def test_pan_cancer_expression_canonicalizes_alias_genes(monkeypatch):
             "nTPM_liver": [3.0, 7.0],
         }
     )
-    monkeypatch.setattr(expression, "get_data", lambda name: fixture.copy())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, fixture)
     out = expression.pan_cancer_expression(normalize=None).set_index("Ensembl_Gene_ID")
     assert list(out.index) == [primary]  # alt folded into primary
     assert out.loc[primary, "liver_nTPM_raw"] == pytest.approx(10.0)  # 3 + 7 summed
@@ -2444,6 +2451,21 @@ def test_cancer_reference_expression_summary_rows_all_preserves_sources_and_filt
     assert bool(empty.loc[0, "available"]) is False
     assert empty.loc[0, "missing_reason"] == "no_reference_summary_rows"
 
+    selected = expression.cancer_reference_expression(
+        ["x", "y"],
+        genes="E1",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        source_kind="treehouse",
+        on_missing="empty",
+    )
+    availability = pd.DataFrame(selected.attrs["availability"]).set_index("cancer_code")
+    assert availability.loc["X", "source_cohort"] == "TREE_X"
+    assert bool(availability.loc["X", "available"]) is True
+    assert pd.isna(availability.loc["Y", "source_cohort"])
+    assert bool(availability.loc["Y", "available"]) is False
+    assert availability.loc["Y", "missing_reason"] == "no_reference_summary_rows"
+
     expression._reference_summary_source_table.cache_clear()
     expression._source_cohort_kind_map.cache_clear()
 
@@ -2474,6 +2496,37 @@ def test_reference_summary_row_index_reuses_positions_and_tracks_frame_identity(
     assert rebuilt[("X", "SRC2")].tolist() == [0]
     assert rebuilt[("X", "SRC1")].tolist() == [1]
     expression._clear_reference_summary_row_index()
+
+
+def test_reference_summary_frame_is_shared_and_canonicalizes_sarc_histology_labels(
+    monkeypatch,
+):
+    raw = pd.DataFrame(
+        {
+            "cancer_code": ["SARC_DDLPS", "SARC_WDLPS", "SARC_PLEOLPS", "LUAD"],
+            "source_cohort": [
+                "TREEHOUSE_POLYA_25_01_TCGA_SUBSET",
+                "TREEHOUSE_POLYA_25_01_TCGA_SUBSET",
+                "TREEHOUSE_POLYA_25_01_TCGA_SUBSET",
+                "TREEHOUSE_POLYA_25_01_TCGA_SUBSET",
+            ],
+        }
+    )
+    monkeypatch.setattr(expression, "get_data", lambda *args, **kwargs: raw)
+    expression._reference_summary_frame.cache_clear()
+    try:
+        first = expression._reference_summary_frame()
+        second = expression._reference_summary_frame()
+        assert first is second
+        assert first["source_cohort"].tolist() == [
+            "TREEHOUSE_POLYA_25_01_TCGA_SARC_HISTOLOGY",
+            "TREEHOUSE_POLYA_25_01_TCGA_SARC_HISTOLOGY",
+            "TREEHOUSE_POLYA_25_01_TCGA_SUBSET",
+            "TREEHOUSE_POLYA_25_01_TCGA_SUBSET",
+        ]
+        assert raw["source_cohort"].nunique() == 1
+    finally:
+        expression._reference_summary_frame.cache_clear()
 
 
 def test_cancer_reference_expression_summary_rows_all_pool(monkeypatch):
@@ -2536,6 +2589,23 @@ def test_cancer_reference_expression_summary_rows_all_pool(monkeypatch):
     assert compact.loc[0, "Proteoform_ID"] == "E1"
     assert compact.loc[0, "Member_Ensembl_Gene_IDs"] == "E1"
     assert "processing_pipeline" not in compact.columns
+
+    selected_source = expression.cancer_reference_expression(
+        "x",
+        normalize="tpm",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        source_cohort="SRC2",
+        pool=True,
+        on_missing="empty",
+    )
+    assert len(selected_source) == 1
+    assert selected_source.loc[0, "source_cohort"] == "POOLED"
+    assert selected_source.loc[0, "expression"] == pytest.approx(20.0)
+    availability = selected_source.attrs["availability"]
+    assert len(availability) == 1
+    assert availability[0]["available"] is True
+    assert availability[0]["source_cohort"] == "SRC2"
 
     with pytest.raises(ValueError, match='requires sample_qc="all"'):
         expression.cancer_reference_expression("x", reference_source="summary_rows_all")
@@ -2823,7 +2893,7 @@ def _pan_cancer_fixture():
 
 
 def test_pan_cancer_expression_converts_fpkm_to_tpm(monkeypatch):
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     out = expression.pan_cancer_expression()
     # FPKM_<CODE> tumor columns become entity-first <CODE>_TPM_raw;
     # HPA nTPM columns become <tissue>_nTPM_raw. Clean companions are default.
@@ -2841,7 +2911,7 @@ def test_pan_cancer_expression_converts_fpkm_to_tpm(monkeypatch):
 def test_pan_cancer_expression_preserves_unmeasured_source_values(monkeypatch):
     fixture = _pan_cancer_fixture()
     fixture.loc[0, "FPKM_LUAD"] = np.nan
-    monkeypatch.setattr(expression, "get_data", lambda name: fixture.copy())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, fixture)
 
     out = expression.pan_cancer_expression()
 
@@ -2851,7 +2921,7 @@ def test_pan_cancer_expression_preserves_unmeasured_source_values(monkeypatch):
 
 
 def test_pan_cancer_expression_raw_only(monkeypatch):
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     out = expression.pan_cancer_expression(normalize=None)
     assert "LUAD_FPKM_raw" in out.columns
     assert "LUAD_TPM_raw" in out.columns
@@ -2861,7 +2931,7 @@ def test_pan_cancer_expression_raw_only(monkeypatch):
 
 
 def test_pan_cancer_expression_pirlygenes_column_style(monkeypatch):
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     out = expression.pan_cancer_expression(normalize="tpm", column_style="pirlygenes")
 
     assert {"liver_nTPM", "LUAD_FPKM", "LUAD_TPM"} <= set(out.columns)
@@ -2928,7 +2998,7 @@ def test_pan_cancer_expression_adds_computed_aggregate_tpm_columns(monkeypatch):
         "SGC": ("ADCC",),
     }
 
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    monkeypatch.setattr(expression, "get_data", lambda *args, **kwargs: _pan_cancer_fixture())
     monkeypatch.setattr(
         expression, "_computed_expression_reference_members", lambda code: members.get(code, ())
     )
@@ -2953,7 +3023,7 @@ def test_pan_cancer_expression_adds_computed_aggregate_tpm_columns(monkeypatch):
 
 
 def test_pan_cancer_expression_to_tpm_legacy_keyword(monkeypatch):
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     out = expression.pan_cancer_expression(genes=["ENSG00000001"], to_tpm=True)
 
     assert out["Symbol"].tolist() == ["GENE1"]
@@ -2963,7 +3033,7 @@ def test_pan_cancer_expression_to_tpm_legacy_keyword(monkeypatch):
 
 
 def test_pan_cancer_expression_empty_gene_filter_preserves_schema(monkeypatch):
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     empty = expression.pan_cancer_expression(genes=[], normalize="tpm", column_style="pirlygenes")
     full = expression.pan_cancer_expression(normalize="tpm", column_style="pirlygenes")
 
@@ -2973,13 +3043,13 @@ def test_pan_cancer_expression_empty_gene_filter_preserves_schema(monkeypatch):
 
 
 def test_pan_cancer_expression_bad_column_style(monkeypatch):
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     with pytest.raises(ValueError, match="column_style"):
         expression.pan_cancer_expression(column_style="source")
 
 
 def test_pan_cancer_expression_accepts_clean_tpm_alias(monkeypatch):
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     canonical = expression.pan_cancer_expression(normalize="tpm_clean")
     alias = expression.pan_cancer_expression(normalize="clean_tpm")
     assert "LUAD_TPM_clean" in alias.columns
@@ -2989,7 +3059,7 @@ def test_pan_cancer_expression_accepts_clean_tpm_alias(monkeypatch):
 def test_pan_cancer_expression_housekeeping_mode(monkeypatch):
     import oncoref.gene_families as gf
 
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     monkeypatch.setattr(
         gf, "clean_tpm_biological_housekeeping_gene_ids", lambda: frozenset({"ENSG00000001"})
     )
@@ -3000,7 +3070,7 @@ def test_pan_cancer_expression_housekeeping_mode(monkeypatch):
 
 
 def test_pan_cancer_expression_log_modes(monkeypatch):
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     raw_logged = expression.pan_cancer_expression(normalize="tpm_log1p")
     clean_logged = expression.pan_cancer_expression(normalize="tpm_clean_log1p")
     assert "LUAD_TPM_raw_log1p" in raw_logged.columns
@@ -3012,7 +3082,7 @@ def test_pan_cancer_expression_log_modes(monkeypatch):
 
 
 def test_pan_cancer_expression_gene_filter(monkeypatch):
-    monkeypatch.setattr(expression, "get_data", lambda name: _pan_cancer_fixture())
+    _mock_pan_cancer_data_without_computed_aggregates(monkeypatch, _pan_cancer_fixture())
     # Filter by symbol, and by unversioned Ensembl id (fixture id is versioned).
     by_symbol = expression.pan_cancer_expression(genes="GENE2")
     assert by_symbol["Symbol"].tolist() == ["GENE2"]


### PR DESCRIPTION
Closes #382.
Closes #374.

## Changes
- compute `summary_rows_all` availability provenance from the same source cohort/kind/proxy filters used for expression rows
- expose canonical DDLPS/WDLPS SARC histology labels without relabeling other TCGA sarcoma rows
- keep exact-source pooled rows and mark filtered-out codes unavailable without stale provenance
- replace full five-million-row summary copies/grouping with a shared positional index and narrow aggregate slices
- cache computed pan-cancer aggregate series and isolate unit fixtures from the multi-GB reference artifact

## Verification
- `./test.sh` (770 passed, 1 skipped)
- real-artifact DDLPS/WDLPS/PLEOLPS exact-source smoke test
- real-artifact computed NET/CRC/NSCLC/BTC/SGC pan-cancer smoke test