### PR TITLE
Release 1.8.130

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.129"
+__version__ = "1.8.130"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins


### PR DESCRIPTION
## Included
- add SARC_MPLPS and its explicit expression data gap (#377)
- close figures returned by batch plot regeneration (#363)
- align DDLPS/WDLPS summary labels and filtered availability provenance (#374, #382)
- remove multi-gigabyte full-summary copies from pan-cancer aggregate access

## Verification
- full suite on merged code: 770 passed, 1 skipped
- release-version smoke tests: 3 passed
- lint clean

After merge, `./deploy.sh` will publish PyPI, tag `v1.8.130`, and create the GitHub release.