### PR TITLE
Release 1.8.132

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.131"
+__version__ = "1.8.132"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins


### PR DESCRIPTION
## Summary

- release the row-by-row key-gene citation audit from #392
- publish the key-gene citation ledger and accessor
- ship corrected biomarker, target, phase, approval, and osteosarcoma source provenance

## Verification

- `./lint.sh`
- release and API-structure tests
- #392 local full suite: 789 passed, 1 skipped
- #392 GitHub Actions: Python 3.9-3.12 and lint passed
