### PR TITLE
Compact reference expression cache provenance

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -3594,13 +3594,21 @@ def _canonical_reference_summary_source_labels(df: pd.DataFrame) -> pd.DataFrame
     if df.empty:
         return df
     codes = df["cancer_code"]
-    sources = df["source_cohort"].fillna("")
+    sources = df["source_cohort"]
     stale = codes.isin(_SARC_HISTOLOGY_SUMMARY_CODES) & sources.eq(_STALE_SARC_HISTOLOGY_COHORT)
     if not stale.any():
         return df
     out = df.copy(deep=False)
-    canonical_sources = df["source_cohort"].copy()
+    canonical_sources = sources
+    if isinstance(sources.dtype, pd.CategoricalDtype):
+        if _SARC_HISTOLOGY_COHORT not in sources.cat.categories:
+            canonical_sources = sources.cat.add_categories([_SARC_HISTOLOGY_COHORT])
+        canonical_sources = canonical_sources.copy()
+    else:
+        canonical_sources = sources.copy()
     canonical_sources.loc[stale] = _SARC_HISTOLOGY_COHORT
+    if isinstance(canonical_sources.dtype, pd.CategoricalDtype):
+        canonical_sources = canonical_sources.cat.remove_unused_categories()
     out["source_cohort"] = canonical_sources
     return out
 
@@ -3642,8 +3650,10 @@ def _reference_summary_row_index() -> dict[tuple[str, str], np.ndarray]:
     if df.empty:
         index = {}
     else:
-        codes = df["cancer_code"].to_numpy(copy=False)
-        sources = df["source_cohort"].fillna("").to_numpy(copy=False)
+        code_series = df["cancer_code"]
+        source_series = df["source_cohort"]
+        codes = _compact_comparison_values(code_series)
+        sources = _compact_comparison_values(source_series)
         starts_new_source = np.empty(len(df), dtype=bool)
         starts_new_source[0] = True
         starts_new_source[1:] = (codes[1:] != codes[:-1]) | (sources[1:] != sources[:-1])
@@ -3652,13 +3662,24 @@ def _reference_summary_row_index() -> dict[tuple[str, str], np.ndarray]:
         all_positions = np.arange(len(df), dtype=np.int64)
         index = {}
         for start, end in zip(starts, ends):
-            key = (str(codes[start]), str(sources[start]))
+            source = source_series.iloc[start]
+            key = (
+                str(code_series.iloc[start]),
+                "" if pd.isna(source) else str(source),
+            )
             positions = all_positions[start:end]
             if key in index:
                 positions = np.concatenate([index[key], positions])
             index[key] = positions
     _REFERENCE_SUMMARY_ROW_INDEX = (df, index)
     return index
+
+
+def _compact_comparison_values(series: pd.Series) -> np.ndarray:
+    """Return category codes when available, avoiding a large object array."""
+    if isinstance(series.dtype, pd.CategoricalDtype):
+        return series.cat.codes.to_numpy(copy=False)
+    return series.to_numpy(copy=False)
 
 
 def _clear_reference_summary_row_index() -> None:
@@ -3749,7 +3770,7 @@ def _reference_summary_source_table() -> pd.DataFrame:
         .fillna(99)
         .astype(int)
     )
-    grouped["_source_sort"] = grouped["source_cohort"].fillna("").astype(str)
+    grouped["_source_sort"] = grouped["source_cohort"].astype("string").fillna("")
     grouped = grouped.sort_values(
         ["cancer_code", "n_reference_genes", "n_reference_samples", "_origin_rank", "_source_sort"],
         ascending=[True, False, False, True, True],
@@ -3820,7 +3841,8 @@ def _filter_reference_summary_sources(
         kind_map = _source_cohort_kind_map()
         out = out.loc[out["source_cohort"].astype(str).map(kind_map).isin(source_kinds)]
     if exclude_microarray_proxy:
-        pipeline = out.get("processing_pipeline", pd.Series("", index=out.index)).fillna("")
+        pipeline = out.get("processing_pipeline", pd.Series("", index=out.index))
+        pipeline = pipeline.astype("string").fillna("")
         text = pipeline.astype(str).str.lower()
         out = out.loc[~text.str.contains("microarray|tpm_proxy|tpm-proxy", regex=True)]
     return out
@@ -3922,9 +3944,9 @@ def _attach_summary_row_provenance(df: pd.DataFrame, *, code: str) -> pd.DataFra
     source_meta = source_counts.set_index("source_cohort").to_dict("index")
     meta_by_source = {
         str(source): _selected_expression_source_metadata(code, source_cohort=str(source))
-        for source in out["source_cohort"].fillna("").astype(str).unique()
+        for source in out["source_cohort"].astype("string").fillna("").unique()
     }
-    source_key = out["source_cohort"].fillna("").astype(str)
+    source_key = out["source_cohort"].astype("string").fillna("")
     out["source_type"] = source_key.map(
         lambda source: meta_by_source.get(source, {}).get("source_type")
     )

--- a/oncoref/load_dataset.py
+++ b/oncoref/load_dataset.py
@@ -38,6 +38,27 @@ _BUNDLED_DATA_DIR = Path(__file__).parent / "data"
 _DATASET_PATHS = None
 _CACHED_DATAFRAMES: dict = {}
 
+# Bump this when the representation written to the concatenated-shard parquet
+# cache changes. The source-file signature alone cannot invalidate an older
+# parquet file whose dtypes no longer match the owning cache contract.
+_SHARD_CACHE_SCHEMA_VERSION = 2
+
+# These columns repeat a small set of provenance values across millions of gene
+# rows. Keeping them as Python objects dominates the resident size of the
+# cancer-reference-expression frame. Categoricals preserve the values and
+# comparisons while storing one compact integer code per row.
+_CATEGORICAL_COLUMNS_BY_DATASET = {
+    "cancer-reference-expression": (
+        "cancer_code",
+        "source_cohort",
+        "source_project",
+        "source_version",
+        "processing_pipeline",
+        "notes",
+        "tumor_origin",
+    ),
+}
+
 # Back-compat alias.
 _DATA_DIR = _BUNDLED_DATA_DIR
 
@@ -119,6 +140,23 @@ def get_all_csv_paths() -> list:
     return list(seen.values())
 
 
+def _optimize_cached_dataframe(dataset_name: str, df: pd.DataFrame) -> pd.DataFrame:
+    """Apply the owning cache's compact dtype policy for ``dataset_name``."""
+    for column in _CATEGORICAL_COLUMNS_BY_DATASET.get(dataset_name, ()):
+        if column in df.columns and not isinstance(df[column].dtype, pd.CategoricalDtype):
+            df[column] = df[column].astype("category")
+    return df
+
+
+def _read_shards_for_cache(shard_dir: Path, paths: list[Path]) -> list[pd.DataFrame]:
+    """Read shards while compacting each one before the next is retained."""
+    frames = []
+    for path in paths:
+        frame = pd.read_csv(str(path), low_memory=False)
+        frames.append(_optimize_cached_dataframe(shard_dir.name, frame))
+    return frames
+
+
 def _load_shard_directory(shard_dir: Path) -> pd.DataFrame:
     """Concatenate every ``*.csv[.gz]`` shard in a sharded dataset directory.
 
@@ -130,14 +168,20 @@ def _load_shard_directory(shard_dir: Path) -> pd.DataFrame:
     if not paths:
         raise FileNotFoundError(f"no CSV shards found under {shard_dir}")
     sig = repr(
-        (len(paths), sum(p.stat().st_size for p in paths), max(p.stat().st_mtime_ns for p in paths))
+        (
+            _SHARD_CACHE_SCHEMA_VERSION,
+            len(paths),
+            sum(p.stat().st_size for p in paths),
+            max(p.stat().st_mtime_ns for p in paths),
+        )
     )
     cache_dir = Path.home() / ".cache" / "oncoref" / "shard_cache"
     cache_file = cache_dir / f"{shard_dir.name}.parquet"
     sig_file = cache_dir / f"{shard_dir.name}.sig"
     try:
         if cache_file.exists() and sig_file.exists() and sig_file.read_text() == sig:
-            return pd.read_parquet(cache_file)
+            cached = pd.read_parquet(cache_file)
+            return _optimize_cached_dataframe(shard_dir.name, cached)
     except Exception as e:
         # Corrupt/unreadable cache: self-heal by removing it (so it doesn't fail
         # every run) and surface a warning, then rebuild from the authoritative
@@ -149,7 +193,8 @@ def _load_shard_directory(shard_dir: Path) -> pd.DataFrame:
         for stale in (cache_file, sig_file):
             with contextlib.suppress(OSError):
                 stale.unlink()
-    df = pd.concat([pd.read_csv(str(p), low_memory=False) for p in paths], ignore_index=True)
+    df = pd.concat(_read_shards_for_cache(shard_dir, paths), ignore_index=True)
+    _optimize_cached_dataframe(shard_dir.name, df)
     try:
         cache_dir.mkdir(parents=True, exist_ok=True)
         df.to_parquet(cache_file, index=False)

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pandas as pd
+
+from oncoref import load_dataset
+
+
+def _reference_rows(n_rows=20_000):
+    return pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": [f"ENSG{i:011d}" for i in range(n_rows)],
+            "Symbol": [f"GENE{i}" for i in range(n_rows)],
+            "cancer_code": ["SARC_DDLPS"] * n_rows,
+            "source_cohort": ["GSE30929_SINGER_2007_LPS"] * n_rows,
+            "source_project": ["GEO"] * n_rows,
+            "source_version": ["2026-07-18"] * n_rows,
+            "processing_pipeline": ["source_summary_rows"] * n_rows,
+            "notes": ["Repeated provenance note"] * n_rows,
+            "tumor_origin": ["primary"] * n_rows,
+            "metastasis_site": [None] * n_rows,
+            "TPM_clean_median": [1.0] * n_rows,
+        }
+    )
+
+
+def test_reference_expression_owning_cache_categorizes_repeated_provenance():
+    raw = _reference_rows()
+    raw_bytes = raw.memory_usage(index=True, deep=True).sum()
+
+    optimized = load_dataset._optimize_cached_dataframe("cancer-reference-expression", raw)
+
+    for column in load_dataset._CATEGORICAL_COLUMNS_BY_DATASET["cancer-reference-expression"]:
+        assert isinstance(optimized[column].dtype, pd.CategoricalDtype)
+    optimized_bytes = optimized.memory_usage(index=True, deep=True).sum()
+    assert optimized_bytes < raw_bytes * 0.35
+
+
+def test_reference_expression_parquet_cache_preserves_compact_dtypes(tmp_path, monkeypatch):
+    shard_dir = tmp_path / "cancer-reference-expression"
+    shard_dir.mkdir()
+    _reference_rows(n_rows=20).iloc[:10].to_csv(shard_dir / "a.csv", index=False)
+    _reference_rows(n_rows=20).iloc[10:].to_csv(shard_dir / "b.csv", index=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    built = load_dataset._load_shard_directory(shard_dir)
+    loaded = load_dataset._load_shard_directory(shard_dir)
+
+    pd.testing.assert_frame_equal(loaded, built)
+    assert isinstance(loaded["source_cohort"].dtype, pd.CategoricalDtype)
+    signature = (
+        tmp_path / ".cache" / "oncoref" / "shard_cache" / "cancer-reference-expression.sig"
+    ).read_text()
+    assert signature.startswith(f"({load_dataset._SHARD_CACHE_SCHEMA_VERSION},")
+
+
+def test_reference_expression_csv_shards_are_compacted_before_concatenation(tmp_path, monkeypatch):
+    shard_dir = tmp_path / "cancer-reference-expression"
+    shard_dir.mkdir()
+    paths = []
+    for index, cohort in enumerate(("SOURCE_A", "SOURCE_B")):
+        path = shard_dir / f"{index}.csv"
+        frame = _reference_rows(n_rows=10)
+        frame["source_cohort"] = cohort
+        frame.to_csv(path, index=False)
+        paths.append(path)
+
+    optimized_shards = []
+    real_optimize = load_dataset._optimize_cached_dataframe
+
+    def record_optimized_shard(dataset_name, frame):
+        result = real_optimize(dataset_name, frame)
+        optimized_shards.append(result)
+        return result
+
+    monkeypatch.setattr(load_dataset, "_optimize_cached_dataframe", record_optimized_shard)
+    loaded = load_dataset._read_shards_for_cache(shard_dir, paths)
+
+    assert loaded == optimized_shards
+    assert len(loaded) == 2
+    assert all(isinstance(frame["source_cohort"].dtype, pd.CategoricalDtype) for frame in loaded)


### PR DESCRIPTION
Fixes #390.

## Summary
- categorize repeated provenance columns before cancer-reference-expression shards enter the owning cache
- persist the compact representation in the concatenated parquet cache and version its schema signature to invalidate older object-dtype caches
- compact each CSV shard before retaining the next one, reducing one-time rebuild peak memory
- make reference-summary canonicalization and indexing category-safe, using categorical codes instead of recreating multi-million-row object arrays

## Verification
- `./lint.sh`
- `python -m pytest tests/ --cov=oncoref --cov-report=term-missing` (792 passed, 1 skipped)
- focused loader/expression suite (119 passed)