### PR TITLE
Fix artifact QC parity in expression availability

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2265,6 +2265,19 @@ def _artifact_build_metadata_qc_value(row) -> str:
     return ""
 
 
+def _artifact_build_metadata_qc_policies(meta: pd.DataFrame) -> dict[str, tuple[str, ...]]:
+    """Return the recorded effective QC policies for each artifact cohort."""
+    if meta.empty or "cancer_code" not in meta.columns:
+        return {}
+    policies: dict[str, tuple[str, ...]] = {}
+    for code, group in meta.groupby("cancer_code", sort=False):
+        values = sorted(
+            {_artifact_build_metadata_qc_value(row) for _, row in group.iterrows()} - {""}
+        )
+        policies[str(code)] = tuple(values)
+    return policies
+
+
 def _artifact_qc_attrs(
     meta: pd.DataFrame,
     *,
@@ -2300,8 +2313,8 @@ def _require_expression_artifact_sample_qc(
     if meta.empty and meta.attrs.get("missing_reason"):
         return meta
 
-    present = set(meta["cancer_code"].astype(str)) if "cancer_code" in meta.columns else set()
-    missing = [code for code in code_list if code not in present]
+    policies = _artifact_build_metadata_qc_policies(meta)
+    missing = [code for code in code_list if code not in policies]
     if missing:
         raise ValueError(
             "expression artifact build metadata lacks rows for requested cohort(s): "
@@ -2309,11 +2322,11 @@ def _require_expression_artifact_sample_qc(
             + "; pass sample_qc='artifact' only for explicit legacy/audit reads"
         )
 
-    mismatches: list[str] = []
-    for _, row in meta.iterrows():
-        effective = _artifact_build_metadata_qc_value(row)
-        if effective != requested:
-            mismatches.append(f"{row.get('cancer_code')}={effective or 'unknown'}")
+    mismatches = [
+        f"{code}={','.join(policies[code]) or 'unknown'}"
+        for code in code_list
+        if policies[code] != (requested,)
+    ]
     if mismatches:
         raise ValueError(
             "expression artifact sample_qc mismatch for requested cohort(s): "
@@ -2879,13 +2892,21 @@ def cancer_reference_expression_availability(
     aggregate requests to member cohorts) and normalization mode. With
     ``all_sources=True`` and ``reference_source="summary_rows_all"``, it instead
     returns one row per source cohort and normalization without loading the
-    multi-million-row expression frame. Both modes are gene-independent.
+    multi-million-row expression frame. Both modes are gene-independent, so callers
+    can distinguish an empty gene filter from unavailable upstream data. For
+    percentile artifacts, ``artifact_sample_qc`` reports the effective build policy
+    recorded in the compact artifact metadata manifest.
     """
     modes = _reference_normalize_modes(normalize)
-    sample_qc = _validate_sample_qc(sample_qc)
+    sample_qc = _validate_artifact_sample_qc(sample_qc)
     reference_source = _validate_reference_source(reference_source)
     source_kinds = _normalize_source_filter_values(source_kind)
     source_cohorts = _normalize_source_filter_values(source_cohort)
+    if sample_qc == "artifact" and (reference_source != "artifact" or "tpm_raw" in modes):
+        raise ValueError(
+            "sample_qc='artifact' requires reference_source='artifact' and "
+            "clean/log-clean artifact-backed normalization"
+        )
     if reference_source == "summary_rows_all" and sample_qc != "all":
         raise ValueError('reference_source="summary_rows_all" requires sample_qc="all"')
     if all_sources and reference_source != "summary_rows_all":
@@ -3024,6 +3045,7 @@ _REFERENCE_AVAILABILITY_COLUMNS = [
     "notes",
     "reference_method",
     "sample_qc",
+    "artifact_sample_qc",
     "artifact_schema_version",
     "data_version",
     "source_matrix_version",
@@ -3121,6 +3143,13 @@ def _reference_expression_availability_for_requests(
         if reference_source in {"summary_rows", "summary_rows_all"}
         else set()
     )
+    artifact_modes = {"tpm_clean", "tpm_clean_biological", "tpm_clean_log1p"}
+    artifact_qc_policies: dict[str, tuple[str, ...]] = {}
+    artifact_qc_metadata_present = False
+    if reference_source == "artifact" and any(mode in artifact_modes for mode in modes):
+        artifact_qc_meta = expression_artifact_build_metadata(auto_fetch=False, on_missing="empty")
+        artifact_qc_policies = _artifact_build_metadata_qc_policies(artifact_qc_meta)
+        artifact_qc_metadata_present = not bool(artifact_qc_meta.attrs.get("missing_reason"))
     rows: list[dict] = []
     for request in requests:
         code = request["cancer_code"]
@@ -3133,6 +3162,8 @@ def _reference_expression_availability_for_requests(
                 summary_available,
                 sample_qc=sample_qc,
                 reference_source=reference_source,
+                artifact_qc_policies=artifact_qc_policies,
+                artifact_qc_metadata_present=artifact_qc_metadata_present,
             )
             method = _reference_expected_method(
                 mode, sample_qc=sample_qc, reference_source=reference_source
@@ -3148,7 +3179,11 @@ def _reference_expression_availability_for_requests(
                 "artifact_schema_version": REFERENCE_EXPRESSION_SCHEMA_VERSION,
                 "data_version": DATA_VERSION,
                 "source_matrix_version": SOURCE_MATRIX_VERSION,
+                "artifact_sample_qc": pd.NA,
             }
+            if reference_source == "artifact" and mode in artifact_modes:
+                policies = artifact_qc_policies.get(code, ())
+                row["artifact_sample_qc"] = ",".join(policies) if policies else pd.NA
             row.update(
                 _reference_expression_provenance(
                     code,
@@ -3289,6 +3324,8 @@ def _reference_mode_availability(
     *,
     sample_qc: str,
     reference_source: str,
+    artifact_qc_policies: dict[str, tuple[str, ...]],
+    artifact_qc_metadata_present: bool,
 ) -> tuple[bool, str]:
     if reference_source in {"summary_rows", "summary_rows_all"}:
         if sample_qc == "all":
@@ -3300,7 +3337,15 @@ def _reference_mode_availability(
             return False, f"no_source_matrix_samples_matching_{sample_qc}_qc"
         return True, ""
     if mode in {"tpm_clean", "tpm_clean_biological", "tpm_clean_log1p"}:
-        return (True, "") if code in percentile_available else (False, "no_percentile_artifact")
+        if code not in percentile_available:
+            return False, "no_percentile_artifact"
+        if sample_qc == "artifact" or not artifact_qc_metadata_present:
+            return True, ""
+        if code not in artifact_qc_policies:
+            return False, "artifact_build_metadata_missing"
+        if artifact_qc_policies[code] != (sample_qc,):
+            return False, "artifact_sample_qc_mismatch"
+        return True, ""
     if mode == "tpm_raw":
         return (True, "") if code in source_matrix_available else (False, "no_source_matrix")
     raise AssertionError(f"unhandled reference normalize mode: {mode}")

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -447,6 +447,16 @@ def _no_cached_matrix(monkeypatch):
     monkeypatch.setattr(expression, "per_sample_expression", _raise)
 
 
+def _mock_missing_artifact_build_metadata(monkeypatch):
+    missing = pd.DataFrame()
+    missing.attrs["missing_reason"] = "artifact_build_metadata_not_installed"
+    monkeypatch.setattr(
+        expression,
+        "expression_artifact_build_metadata",
+        lambda *args, **kwargs: missing.copy(),
+    )
+
+
 def test_cohort_gene_percentiles_missing_raises(percentile_cache, monkeypatch):
     # No shard AND no cached matrix (on-the-fly can't run) -> clear error.
     _no_cached_matrix(monkeypatch)
@@ -1747,6 +1757,7 @@ def test_cancer_reference_expression_long_and_wide(monkeypatch):
         }
     )
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X", "Y"])
+    _mock_missing_artifact_build_metadata(monkeypatch)
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
     monkeypatch.setattr(expression, "cohort_gene_percentiles", lambda *a, **k: pct.copy())
 
@@ -1855,6 +1866,7 @@ def test_cancer_reference_expression_adds_proteoform_bridge_without_collapse(mon
         }
     )
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    _mock_missing_artifact_build_metadata(monkeypatch)
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
     monkeypatch.setattr(expression, "cohort_gene_percentiles", lambda *a, **k: pct.copy())
 
@@ -1895,6 +1907,7 @@ def test_cancer_reference_expression_cdna_identical_collapse(monkeypatch):
         }
     )
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    _mock_missing_artifact_build_metadata(monkeypatch)
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
     monkeypatch.setattr(expression, "cohort_gene_percentiles", lambda *a, **k: pct.copy())
 
@@ -1976,6 +1989,7 @@ def test_cancer_reference_expression_uses_pirlygenes_identity_style(monkeypatch)
         }
     )
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    _mock_missing_artifact_build_metadata(monkeypatch)
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
     monkeypatch.setattr(expression, "cohort_gene_percentiles", lambda *a, **k: pct.copy())
 
@@ -2008,6 +2022,7 @@ def test_cancer_reference_expression_protein_identical_collapse_and_wide_shape(m
         }
     )
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    _mock_missing_artifact_build_metadata(monkeypatch)
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
     monkeypatch.setattr(expression, "cohort_gene_percentiles", lambda *a, **k: pct.copy())
 
@@ -2061,6 +2076,7 @@ def test_cancer_reference_expression_multiple_normalizations(monkeypatch):
         return pct_tpm.copy() if as_tpm else pct_log.copy()
 
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    _mock_missing_artifact_build_metadata(monkeypatch)
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
     monkeypatch.setattr(expression, "cohort_gene_percentiles", fake_pct)
 
@@ -2079,6 +2095,7 @@ def test_cancer_reference_expression_availability_reports_missing(monkeypatch):
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
     monkeypatch.setattr(expression.source_matrices, "available_cohorts", lambda: ["Y"])
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+    _mock_missing_artifact_build_metadata(monkeypatch)
 
     out = expression.cancer_reference_expression_availability(
         ["x", "z"], normalize=["tpm_clean", "tpm_raw"]
@@ -2108,6 +2125,7 @@ def test_cancer_reference_expression_availability_reports_missing(monkeypatch):
         "notes",
         "reference_method",
         "sample_qc",
+        "artifact_sample_qc",
         "artifact_schema_version",
         "data_version",
         "source_matrix_version",
@@ -2116,9 +2134,68 @@ def test_cancer_reference_expression_availability_reports_missing(monkeypatch):
     keyed = out.set_index(["cancer_code", "normalization"])
     assert bool(keyed.loc[("X", "tpm_clean"), "available"]) is True
     assert keyed.loc[("X", "tpm_clean"), "sample_qc"] == "pass"
+    assert pd.isna(keyed.loc[("X", "tpm_clean"), "artifact_sample_qc"])
     assert keyed.loc[("X", "tpm_raw"), "sample_qc"] == "pass"
     assert keyed.loc[("X", "tpm_raw"), "missing_reason"] == "no_source_matrix"
     assert keyed.loc[("Z", "tpm_clean"), "missing_reason"] == "no_percentile_artifact"
+
+
+def test_cancer_reference_expression_availability_matches_artifact_qc_policy(
+    percentile_cache,
+):
+    shard_path = percentile_cache / "cancer-reference-expression-percentiles" / "PRAD.parquet"
+    shard = pd.read_parquet(shard_path)
+    shard["p25"] = np.log1p([25.0, 50.0]).astype("float16")
+    shard["p75"] = np.log1p([75.0, 150.0]).astype("float16")
+    shard.to_parquet(shard_path, index=False)
+    _write_artifact_build_metadata(percentile_cache, "PRAD", sample_qc="pass_or_warn")
+
+    strict = expression.cancer_reference_expression_availability("PRAD", sample_qc="pass")
+    assert strict["available"].tolist() == [False]
+    assert strict["missing_reason"].tolist() == ["artifact_sample_qc_mismatch"]
+    assert strict["sample_qc"].tolist() == ["pass"]
+    assert strict["artifact_sample_qc"].tolist() == ["pass_or_warn"]
+
+    strict_load = expression.cancer_reference_expression(
+        "PRAD", sample_qc="pass", on_missing="empty"
+    )
+    assert strict_load.empty
+    assert strict_load.attrs["missing_requests"][0]["missing_reason"] == (
+        "artifact_sample_qc_mismatch"
+    )
+
+    compatible = expression.cancer_reference_expression_availability(
+        "PRAD", sample_qc="pass_or_warn"
+    )
+    assert compatible["available"].tolist() == [True]
+    assert compatible["artifact_sample_qc"].tolist() == ["pass_or_warn"]
+    assert not expression.cancer_reference_expression(
+        "PRAD", sample_qc="pass_or_warn", on_missing="empty"
+    ).empty
+
+    audit = expression.cancer_reference_expression_availability("PRAD", sample_qc="artifact")
+    assert audit["available"].tolist() == [True]
+    assert audit["artifact_sample_qc"].tolist() == ["pass_or_warn"]
+
+
+def test_cancer_reference_expression_availability_rejects_missing_artifact_metadata_row(
+    monkeypatch,
+):
+    monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X"])
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
+    monkeypatch.setattr(
+        expression,
+        "expression_artifact_build_metadata",
+        lambda *args, **kwargs: pd.DataFrame(
+            {"cancer_code": ["Y"], "sample_qc_effective": ["pass"]}
+        ),
+    )
+
+    out = expression.cancer_reference_expression_availability("X", sample_qc="pass")
+
+    assert out["available"].tolist() == [False]
+    assert out["missing_reason"].tolist() == ["artifact_build_metadata_missing"]
+    assert out["artifact_sample_qc"].isna().all()
 
 
 def test_cancer_reference_expression_missing_empty_and_raise(monkeypatch):
@@ -2175,6 +2252,7 @@ def test_cancer_reference_expression_request_metadata_for_aggregate(monkeypatch)
         }
     )
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X", "Y"])
+    _mock_missing_artifact_build_metadata(monkeypatch)
     monkeypatch.setattr(expression, "cohort_aggregates", lambda: {"AGG": ["X", "Y"]})
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
     monkeypatch.setattr(expression, "cohort_gene_percentiles", lambda *a, **k: pct.copy())
@@ -2926,6 +3004,7 @@ def test_cancer_reference_expression_wide_merges_by_gene_id_not_symbol(monkeypat
         ),
     }
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["X", "Y"])
+    _mock_missing_artifact_build_metadata(monkeypatch)
     monkeypatch.setattr(expression, "resolve_cancer_type", lambda code: str(code).upper())
     monkeypatch.setattr(
         expression, "cohort_gene_percentiles", lambda code, *a, **k: by_code[code].copy()


### PR DESCRIPTION
Fixes #389.

## Summary
- make `cancer_reference_expression_availability()` accept the same artifact QC modes and validation rules as the loader
- read the compact artifact build manifest without loading expression shards
- report `artifact_sample_qc` separately from the requested `sample_qc`
- return specific unavailable reasons for policy mismatches and missing cohort metadata
- share effective-policy parsing with the loader so the two paths cannot interpret build metadata differently

## Verification
- `./lint.sh`
- 118 expression tests passed
- full serial suite: 791 passed, 1 skipped
- live ESS bundle check: `pass` is unavailable with `artifact_sample_qc_mismatch`; `pass_or_warn` and `artifact` both advertise and load both ESS cohorts