### PR TITLE
Release 1.8.133

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.132"
+__version__ = "1.8.133"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins


### PR DESCRIPTION
## Included
- #395 / #390: compact owning-cache provenance columns to categorical storage
- #396 / #391: align fusion registry and detail tables
- #397 / #387: derive computed pan-sarcoma registry membership

## Verification
- `./lint.sh`
- 32 release, bundle, and API tests passed
- all three included PRs passed the full GitHub Actions matrix