### PR TITLE
Canonicalize physical SARC source shards

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.135"
+__version__ = "1.8.136"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins
@@ -23,7 +23,8 @@ __version__ = "1.8.135"
 # percentile, within-sample, source-QC, and reference-expression shards.
 # 5.23.5 adds physical source grouping, actual source-sample QC, representative
 # roles, and benchmark-eligibility provenance to representative artifacts.
-DATA_VERSION = "5.23.5"
+# 5.23.6 canonicalizes the physical DDLPS/WDLPS TCGA-SARC source identities.
+DATA_VERSION = "5.23.6"
 
 # Version of the per-cohort RAW source matrices (source_matrices.py). Independent of
 # DATA_VERSION: the source matrices are the unchanging raw-TPM inputs, while DATA_VERSION

--- a/scripts/canonicalize_reference_summary_sources.py
+++ b/scripts/canonicalize_reference_summary_sources.py
@@ -1,0 +1,140 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Rewrite the two legacy TCGA-SARC summary shards to canonical source identities.
+
+This migration streams one gzip row at a time. It is intended for a staged data bundle,
+not an installed cache that callers may be reading concurrently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gzip
+import io
+import json
+from pathlib import Path
+
+
+SUMMARY_DIR = "cancer-reference-expression"
+LEGACY_SOURCE = "TREEHOUSE_POLYA_25_01_TCGA_SUBSET"
+CANONICAL_SOURCE = "TREEHOUSE_POLYA_25_01_TCGA_SARC_HISTOLOGY"
+SARC_HISTOLOGY_CODES = ("SARC_DDLPS", "SARC_WDLPS")
+
+
+def _shard_path(root: Path, source: str, code: str) -> Path:
+    return root / SUMMARY_DIR / f"{source}__{code}.csv.gz"
+
+
+def _validate_rows(path: Path, *, code: str, source: str) -> int:
+    with gzip.open(path, "rt", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        required = {"cancer_code", "source_cohort"}
+        missing = required - set(reader.fieldnames or ())
+        if missing:
+            raise ValueError(f"{path} lacks required columns: {', '.join(sorted(missing))}")
+        n_rows = 0
+        for row_number, row in enumerate(reader, start=2):
+            if row["cancer_code"] != code:
+                raise ValueError(
+                    f"{path}:{row_number} has cancer_code={row['cancer_code']!r}; expected {code!r}"
+                )
+            if row["source_cohort"] != source:
+                raise ValueError(
+                    f"{path}:{row_number} has source_cohort={row['source_cohort']!r}; "
+                    f"expected {source!r}"
+                )
+            n_rows += 1
+    if n_rows == 0:
+        raise ValueError(f"{path} contains no data rows")
+    return n_rows
+
+
+def _rewrite_shard(root: Path, code: str) -> dict[str, object]:
+    legacy_path = _shard_path(root, LEGACY_SOURCE, code)
+    canonical_path = _shard_path(root, CANONICAL_SOURCE, code)
+    if legacy_path.exists() and canonical_path.exists():
+        raise FileExistsError(f"both legacy and canonical shards exist for {code}")
+    if canonical_path.exists():
+        return {
+            "cancer_code": code,
+            "rows": _validate_rows(canonical_path, code=code, source=CANONICAL_SOURCE),
+            "changed": False,
+            "path": str(canonical_path),
+        }
+    if not legacy_path.exists():
+        raise FileNotFoundError(f"missing legacy summary shard for {code}: {legacy_path}")
+
+    temporary_path = canonical_path.with_name(f".{canonical_path.name}.tmp")
+    try:
+        with gzip.open(legacy_path, "rt", encoding="utf-8", newline="") as source_handle:
+            reader = csv.DictReader(source_handle)
+            required = {"cancer_code", "source_cohort"}
+            missing = required - set(reader.fieldnames or ())
+            if missing:
+                raise ValueError(
+                    f"{legacy_path} lacks required columns: {', '.join(sorted(missing))}"
+                )
+            with temporary_path.open("wb") as raw_handle:
+                with gzip.GzipFile(
+                    filename="", mode="wb", fileobj=raw_handle, mtime=0
+                ) as gzip_handle:
+                    with io.TextIOWrapper(
+                        gzip_handle, encoding="utf-8", newline=""
+                    ) as target_handle:
+                        writer = csv.DictWriter(
+                            target_handle,
+                            fieldnames=reader.fieldnames,
+                            lineterminator="\n",
+                        )
+                        writer.writeheader()
+                        n_rows = 0
+                        for row_number, row in enumerate(reader, start=2):
+                            if row["cancer_code"] != code:
+                                raise ValueError(
+                                    f"{legacy_path}:{row_number} has "
+                                    f"cancer_code={row['cancer_code']!r}; expected {code!r}"
+                                )
+                            if row["source_cohort"] != LEGACY_SOURCE:
+                                raise ValueError(
+                                    f"{legacy_path}:{row_number} has "
+                                    f"source_cohort={row['source_cohort']!r}; "
+                                    f"expected {LEGACY_SOURCE!r}"
+                                )
+                            row["source_cohort"] = CANONICAL_SOURCE
+                            writer.writerow(row)
+                            n_rows += 1
+        if n_rows == 0:
+            raise ValueError(f"{legacy_path} contains no data rows")
+        temporary_path.replace(canonical_path)
+        legacy_path.unlink()
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    return {
+        "cancer_code": code,
+        "rows": n_rows,
+        "changed": True,
+        "path": str(canonical_path),
+    }
+
+
+def canonicalize_sarc_histology_sources(root: Path) -> list[dict[str, object]]:
+    """Canonicalize the DDLPS/WDLPS physical shards under a staged bundle root."""
+    return [_rewrite_shard(root, code) for code in SARC_HISTOLOGY_CODES]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle_root", type=Path, help="staged data-bundle directory")
+    args = parser.parse_args()
+    print(json.dumps(canonicalize_sarc_histology_sources(args.bundle_root), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_canonicalize_reference_summary_sources.py
+++ b/tests/test_canonicalize_reference_summary_sources.py
@@ -1,0 +1,85 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import csv
+import gzip
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "canonicalize_reference_summary_sources.py"
+_SPEC = importlib.util.spec_from_file_location("canonicalize_reference_summary_sources", _SCRIPT)
+assert _SPEC and _SPEC.loader
+migration = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(migration)
+
+
+def _write_shard(path: Path, code: str, source: str) -> bytes:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=["Ensembl_Gene_ID", "cancer_code", "source_cohort", "TPM_median"],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "Ensembl_Gene_ID": "ENSG000001",
+                "cancer_code": code,
+                "source_cohort": source,
+                "TPM_median": "1.5",
+            }
+        )
+    return path.read_bytes()
+
+
+def _read_rows(path: Path) -> list[dict[str, str]]:
+    with gzip.open(path, "rt", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def test_canonicalize_sarc_histology_sources_rewrites_only_two_shards(tmp_path):
+    summary = tmp_path / migration.SUMMARY_DIR
+    for code in migration.SARC_HISTOLOGY_CODES:
+        _write_shard(
+            summary / f"{migration.LEGACY_SOURCE}__{code}.csv.gz",
+            code,
+            migration.LEGACY_SOURCE,
+        )
+    pleolps = summary / f"{migration.LEGACY_SOURCE}__SARC_PLEOLPS.csv.gz"
+    pleolps_bytes = _write_shard(pleolps, "SARC_PLEOLPS", migration.LEGACY_SOURCE)
+
+    result = migration.canonicalize_sarc_histology_sources(tmp_path)
+
+    assert [row["cancer_code"] for row in result] == ["SARC_DDLPS", "SARC_WDLPS"]
+    assert all(row["changed"] is True and row["rows"] == 1 for row in result)
+    for code in migration.SARC_HISTOLOGY_CODES:
+        assert not (summary / f"{migration.LEGACY_SOURCE}__{code}.csv.gz").exists()
+        canonical = summary / f"{migration.CANONICAL_SOURCE}__{code}.csv.gz"
+        assert _read_rows(canonical)[0]["source_cohort"] == migration.CANONICAL_SOURCE
+    assert pleolps.read_bytes() == pleolps_bytes
+
+    repeated = migration.canonicalize_sarc_histology_sources(tmp_path)
+    assert all(row["changed"] is False for row in repeated)
+
+
+def test_canonicalize_sarc_histology_sources_preserves_invalid_input(tmp_path):
+    summary = tmp_path / migration.SUMMARY_DIR
+    for code in migration.SARC_HISTOLOGY_CODES:
+        _write_shard(
+            summary / f"{migration.LEGACY_SOURCE}__{code}.csv.gz",
+            code,
+            migration.LEGACY_SOURCE,
+        )
+    invalid = summary / f"{migration.LEGACY_SOURCE}__SARC_DDLPS.csv.gz"
+    original = _write_shard(invalid, "SARC_PLEOLPS", migration.LEGACY_SOURCE)
+
+    with pytest.raises(ValueError, match="cancer_code='SARC_PLEOLPS'"):
+        migration.canonicalize_sarc_histology_sources(tmp_path)
+
+    assert invalid.read_bytes() == original
+    assert not (summary / f"{migration.CANONICAL_SOURCE}__SARC_DDLPS.csv.gz").exists()

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -11,7 +11,7 @@ import pytest
 
 pytest.importorskip("matplotlib")
 
-from oncoref import cli, plots
+from oncoref import cli, data_bundle, plots
 
 
 @pytest.fixture(autouse=True)
@@ -236,7 +236,7 @@ def test_cli_plot_threshold_tpm_is_opt_in(monkeypatch, tmp_path):
 
 # ---- CTA expression heatmap (needs the expression bundle / percentile data) ----
 
-_HAS_PERCENTILES = bool(__import__("oncoref").available_percentile_cohorts())
+_HAS_PERCENTILES = data_bundle.is_local()
 _needs_bundle = pytest.mark.skipif(
     not _HAS_PERCENTILES, reason="expression bundle (percentile artifacts) not present"
 )


### PR DESCRIPTION
Completes the remaining artifact-level work in #374.

## Summary
- add a streaming migration for the two legacy DDLPS/WDLPS summary shards
- assert every row has the expected cancer code and legacy source before rewriting
- write deterministic gzip output atomically and support idempotent validation
- leave the generic SARC_PLEOLPS shard untouched
- pin package 1.8.136 to data bundle 5.23.6

## Bundle verification
- 34,337 rows rewritten for SARC_DDLPS
- 34,337 rows rewritten for SARC_WDLPS
- second run reports both shards unchanged and valid
- SARC_PLEOLPS SHA-256 is unchanged
- public tarball checksum: `2da1e6e70af958fc5e6ebfbf65822d7393308ec3a3a1869c1703f2dcb173bba1`
- public release: https://github.com/pirl-unc/oncoref/releases/tag/v5.23.6
- 28 focused bundle/migration tests and lint pass locally

The initial matrix run reached the new pin before the data release was published and received a 404. The assets are now public and verified; the failed jobs were rerun without a code change.