### PR TITLE
Make pyensembl an optional genome extra

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,45 @@ on:
   pull_request:
 
 jobs:
+  minimal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install core dependencies only
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Verify minimal base-layer contract
+        run: |
+          python - <<'PY'
+          import importlib.util
+
+          assert importlib.util.find_spec("pyensembl") is None
+
+          import oncoref
+
+          assert oncoref.canonical_gene_id("TP53") == "ENSG00000141510"
+          assert oncoref.canonical_gene_id("NOT_A_REAL_GENE") is None
+          assert not oncoref.cancer_tmb_df().empty
+          assert not oncoref.cancer_type_registry_df().empty
+
+          try:
+              oncoref.genomes()
+          except ImportError as exc:
+              assert "oncoref[genome]" in str(exc)
+          else:
+              raise AssertionError("genome API should require the optional extra")
+          PY
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           assert oncoref.canonical_gene_id("TP53") == "ENSG00000141510"
           assert oncoref.canonical_gene_id("NOT_A_REAL_GENE") is None
           assert not oncoref.cancer_tmb_df().empty
-          assert not oncoref.cancer_type_registry_df().empty
+          assert not oncoref.cancer_type_registry().empty
 
           try:
               oncoref.genomes()

--- a/README.md
+++ b/README.md
@@ -174,10 +174,11 @@ od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (wit
   `display_gene_name`, `short_gene_name`, `canonical_gene_id_and_name`,
   `find_gene_id_by_name`, `find_gene_name_from_ensembl_{gene,transcript}_id`,
   and `aggregate_gene_expression` (symbol/synonym/legacy-Ensembl-ID ↔ canonical
-  Ensembl-ID resolution). pyensembl ships with the package, but some
-  pyensembl-backed symbol resolution needs a downloaded human release once:
+  Ensembl-ID resolution). The bundled canonical gene space and aliases work in the
+  base install. Install `oncoref[genome]` for arbitrary pyensembl-backed lookup, then
+  download a human release once:
   `pyensembl install --release 111 --species homo_sapiens` (the accessors return
-  `None` until then).
+  `None` until a release is installed).
 - **Legacy/compat response signatures** — `oncoref.response_signatures` ships a
   small historical checkpoint-response signature surface used by oncoref plots.
   Treat it as transitional: new therapy-response signature panels belong in

--- a/docs/api.md
+++ b/docs/api.md
@@ -164,8 +164,8 @@ choices in packages such as trufflepig.
 
 - `oncoref.gene_ids` — canonical ENSG space, alt-haplotype / retired Ensembl ID
   migration, symbol/synonym resolution, and report-facing gene labels.
-- `oncoref.genome` — pyensembl-backed transcript/gene lookup and transcript to
-  gene aggregation for source matrices.
+- `oncoref.genome` — optional (`pip install 'oncoref[genome]'`) pyensembl-backed
+  transcript/gene lookup and transcript-to-gene aggregation for source matrices.
 
 Use the gene-id helpers before building expression artifacts or joining
 downstream gene sets to oncoref references. `canonical_gene_id()` is the primary
@@ -624,8 +624,8 @@ but it is not the clean-TPM biological denominator.
 
 - `oncoref.gene_ids` — bundled canonical Ensembl gene space, cross-release alias
   resolution, symbol synonyms, and biotype checks.
-- `oncoref.genome` — pyensembl-backed gene/transcript lookup against installed
-  Ensembl releases.
+- `oncoref.genome` — optional (`pip install 'oncoref[genome]'`) pyensembl-backed
+  gene/transcript lookup against installed Ensembl releases.
 - `oncoref.proteoforms` — identical-protein paralog grouping and expression
   collapse helpers.
 - `oncoref.gene_qc` / `oncoref.gene_families` — technical-RNA and gene-family

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -13,8 +13,9 @@
 """oncoref — curated cancer reference data (ontology, TMB, incidence/
 mortality, and expression) with a single fetch/cache surface.
 
-Bottom-of-stack: depends only on pandas/numpy/pyarrow, never on the analysis
-or target-selection libraries that consume it.
+Bottom-of-stack: the core install depends only on pandas/numpy/pyarrow/PyYAML and
+never on the analysis or target-selection libraries that consume it. Optional
+genome and plotting features add only their named extras.
 """
 
 from . import (

--- a/oncoref/gene_ids.py
+++ b/oncoref/gene_ids.py
@@ -98,9 +98,12 @@ def canonical_gene_id(identifier: str, *, source_version: str | None = None) -> 
     resolved = symbol_index.get(official.upper())
     if resolved is not None:
         return resolved
-    from .genome import canonical_gene_id_and_name  # lazy: avoids genome/pyensembl dep here
+    from .genome import GenomeDependencyError, canonical_gene_id_and_name
 
-    gid, _ = canonical_gene_id_and_name(official)
+    try:
+        gid, _ = canonical_gene_id_and_name(official)
+    except GenomeDependencyError:
+        return None
     return gid
 
 

--- a/oncoref/genome.py
+++ b/oncoref/genome.py
@@ -17,10 +17,10 @@ This is the genome-reference resolver that the curated pandas ID layer
 Ensembl transcript or gene ID to a gene, and a symbol to its canonical Ensembl gene
 ID, against the installed Ensembl release(s).
 
-``pyensembl`` is a core dependency, but it still needs a **downloaded** human Ensembl
-release at runtime (``pyensembl install --release N --species homo_sapiens``); with no
-release installed, :func:`genomes` is empty and the resolvers return ``None`` rather
-than raising.
+Install the optional ``genome`` extra to use this module (``pip install
+'oncoref[genome]'``). pyensembl still needs a **downloaded** human Ensembl release at
+runtime (``pyensembl install --release N --species homo_sapiens``); with the extra but
+no release installed, :func:`genomes` is empty and the resolvers return ``None``.
 
 Resolution order for a symbol mirrors pirlygenes: each installed release (newest
 first) by name + curated display aliases, then the bundled NCBI symbol-synonym
@@ -34,6 +34,16 @@ import logging
 from functools import lru_cache
 
 from .gene_ids import resolve_symbol, unversioned
+
+
+class GenomeDependencyError(ImportError):
+    """Raised when a pyensembl-backed API is used without the genome extra."""
+
+
+_GENOME_EXTRA_MESSAGE = (
+    "pyensembl is required for genome and peptide APIs; "
+    "install it with `pip install 'oncoref[genome]'`"
+)
 
 #: Curated literary display aliases used as extra symbol candidates (NY-ESO-1 ↔
 #: CTAG1B, gp100 ↔ PMEL, …). Small, base-layer reference — not a full alias table.
@@ -75,7 +85,12 @@ def _installed_ensembl_releases():
     level = root.level
     disabled = root.disabled
     try:
-        from pyensembl.shell import collect_all_installed_ensembl_releases
+        try:
+            from pyensembl.shell import collect_all_installed_ensembl_releases
+        except ModuleNotFoundError as exc:
+            if exc.name and exc.name.split(".", 1)[0] == "pyensembl":
+                raise GenomeDependencyError(_GENOME_EXTRA_MESSAGE) from exc
+            raise
 
         return tuple(collect_all_installed_ensembl_releases())
     finally:

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.138"
+__version__ = "1.8.139"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,12 @@ dependencies = [
     "numpy",
     "pyarrow",
     "PyYAML",
-    "pyensembl",
 ]
 
 [project.optional-dependencies]
+genome = [
+    "pyensembl",
+]
 plots = [
     "matplotlib",
     "adjustText",
@@ -47,6 +49,7 @@ dev = [
     "matplotlib",
     "adjustText",
     "matplotlib_venn>=1.0",
+    "pyensembl",
 ]
 
 [project.scripts]

--- a/scripts/generate_canonical_gene_space.py
+++ b/scripts/generate_canonical_gene_space.py
@@ -24,7 +24,8 @@ primary gene via the alias map, so they are never their own canonical entry.
 Versioned by the Ensembl release it derives from (``--target-release``, default 115);
 the release is recorded in the ``ensembl_release`` column for auditability.
 
-pyensembl is a BUILD-TIME tool only (cf. the alias/proteoform generators). Run:
+This generator requires the optional genome dependency (``pip install
+'oncoref[genome]'``); pyensembl is not part of oncoref's core dependency set. Run:
 
     python scripts/generate_canonical_gene_space.py
 

--- a/scripts/generate_ensembl_id_aliases.py
+++ b/scripts/generate_ensembl_id_aliases.py
@@ -37,9 +37,9 @@ EXCLUDED: a short gene nested in a host gene's intron (a snoRNA, an antisense ln
 overlaps it ~100% yet is a *distinct* gene — empirically those "successors" co-occur
 with the old gene in ~all modern cohorts, proving they are not the same gene.
 
-pyensembl is a BUILD-TIME tool only (not a runtime dependency of oncoref, cf. the
-percentile/proteoform generators); it reads each release's GTF, which this script
-queries directly for speed. Run:
+This generator requires the optional genome dependency (``pip install
+'oncoref[genome]'``); pyensembl is not part of oncoref's core dependency set. It
+reads each release's GTF, which this script queries directly for speed. Run:
 
     python scripts/generate_ensembl_id_aliases.py
 

--- a/scripts/generate_proteoform_groups.py
+++ b/scripts/generate_proteoform_groups.py
@@ -35,8 +35,8 @@ The genome registry is the opt-in variant (issue #12): genome-wide summation
 shifts many more genes' expression than the focused CTA subset, so it is offered,
 not shipped as the default for the percentile/within-sample artifacts.
 
-pyensembl is a BUILD-TIME tool only — it is deliberately not a runtime dependency
-of oncoref (cf. the within-sample/percentile generators). Run:
+This generator requires the optional genome dependency (``pip install
+'oncoref[genome]'``); pyensembl is not part of oncoref's core dependency set. Run:
 
     python scripts/generate_proteoform_groups.py               # CTA-scoped (default)
     python scripts/generate_proteoform_groups.py --scope genome  # genome-wide

--- a/tests/test_base_layer.py
+++ b/tests/test_base_layer.py
@@ -76,7 +76,10 @@ from oncoref import genome
 root = logging.getLogger()
 assert len(root.handlers) == 0
 assert root.level == logging.WARNING
-genome.genomes()
+try:
+    genome.genomes()
+except genome.GenomeDependencyError:
+    pass
 assert len(root.handlers) == 0, root.handlers
 assert root.level == logging.WARNING, logging.getLevelName(root.level)
 """

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -11,8 +11,13 @@ from oncoref import genome as gx
 
 # The dev extra installs pyensembl, but resolution still needs a downloaded human
 # Ensembl release; skip when none is installed.
+try:
+    _GENOMES = gx.genomes()
+except gx.GenomeDependencyError:
+    _GENOMES = []
 pytestmark = pytest.mark.skipif(
-    not gx.genomes(), reason="no human Ensembl release installed (pyensembl install ...)"
+    not _GENOMES,
+    reason="genome extra or installed human Ensembl release is unavailable",
 )
 
 

--- a/tests/test_genome.py
+++ b/tests/test_genome.py
@@ -9,7 +9,7 @@ import pytest
 
 from oncoref import genome as gx
 
-# pyensembl is a core dependency, but resolution still needs a downloaded human
+# The dev extra installs pyensembl, but resolution still needs a downloaded human
 # Ensembl release; skip when none is installed.
 pytestmark = pytest.mark.skipif(
     not gx.genomes(), reason="no human Ensembl release installed (pyensembl install ...)"

--- a/tests/test_optional_genome_dependency.py
+++ b/tests/test_optional_genome_dependency.py
@@ -1,0 +1,48 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import subprocess
+import sys
+from pathlib import Path
+
+_PROJECT = Path(__file__).resolve().parents[1]
+
+
+def test_base_layer_without_pyensembl():
+    code = r"""
+import builtins
+
+real_import = builtins.__import__
+
+def without_pyensembl(name, *args, **kwargs):
+    if name == "pyensembl" or name.startswith("pyensembl."):
+        raise ModuleNotFoundError("blocked optional dependency", name="pyensembl")
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = without_pyensembl
+
+import oncoref
+
+assert oncoref.canonical_gene_id("TP53") == "ENSG00000141510"
+assert oncoref.canonical_gene_id("NOT_A_REAL_GENE") is None
+assert not oncoref.cancer_tmb_df().empty
+
+try:
+    oncoref.genomes()
+except ImportError as exc:
+    assert "oncoref[genome]" in str(exc)
+else:
+    raise AssertionError("genome API should require the optional extra")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=_PROJECT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout


### PR DESCRIPTION
Fixes #364.

## Summary
- remove pyensembl from the four-package core dependency set
- add `oncoref[genome]` and retain pyensembl in the dev extra
- preserve bundled canonical gene/alias resolution without the extra
- raise a clear install-extra error from explicit genome and peptide APIs
- add a core-only GitHub Actions job and subprocess regression
- update README/API dependency contracts
- prepare package version 1.8.139

## Verification
- built wheel metadata: no core pyensembl requirement; pyensembl is present in `genome` and `dev`
- wheel and sdist pass `twine check`
- normal dev environment: 43 focused tests passed with zero skips, including all pyensembl-backed genome tests
- isolated core-only environment: 4 passed, 4 expected genome-release skips
- full serial suite against data bundle 5.23.7: 815 passed, 1 skipped (optional 22 GB ACC/pirlygenes parity fixture absent)
- `ruff check oncoref tests` and `ruff format --check oncoref tests`