### PR TITLE
Release 1.8.134

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.133"
+__version__ = "1.8.134"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins


### PR DESCRIPTION
## Included
- #398 / #393: add a compact source-union availability manifest and all-source availability reporting
- include the missing GSE235092 source registry row and exact source metadata

## Verification
- `./lint.sh`
- 19 focused availability, manifest, bundle, and version tests passed
- #398 passed the full GitHub Actions matrix