### PR TITLE
Release 1.8.135

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.134"
+__version__ = "1.8.135"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins


### PR DESCRIPTION
## Included
- #399 / #389: make expression availability enforce artifact sample-QC compatibility
- report the effective artifact build policy in `artifact_sample_qc`
- preserve the compact all-source availability manifest from 1.8.134

## Verification
- `./lint.sh`
- 14 focused availability, artifact-QC, bundle, and version tests passed
- #399 passed the full GitHub Actions matrix
- local combined suite: 804 passed, 1 skipped