### PR TITLE
Add robust item-level data availability checks

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -662,7 +662,12 @@ but it is not the clean-TPM biological denominator.
   marker policy, and expected artifact inventory for the active bundle. The
   inventory includes the generated sample-QC manifest, per-cohort build metadata,
   within-sample prevalence shards, and CTA-scope proteoform percentile/prevalence
-  shards, not just the legacy pirlygenes expression tables. Use
+  shards, not just the legacy pirlygenes expression tables.
+  `data_bundle.bundle_is_local()` reports whether the entire downloadable cache is
+  populated. For a side-effect-free check of one required artifact across both an
+  in-repository/package data directory and a partial cache, use
+  `data_bundle.item_is_local(path)` or `data_bundle.find_local_item(path)`. These
+  item-level probes never fetch data and reject empty files or directories. Use
   `data_bundle.bundle_release_manifest()` to fetch and validate only the small
   release manifest/checksum for the active `DATA_VERSION`, including tarball
   sha256 plus any artifact inventory, builder commit, source-matrix version, and

--- a/oncoref/data_bundle.py
+++ b/oncoref/data_bundle.py
@@ -37,10 +37,12 @@ is reused as-is. The ``PIRLYGENES_BUNDLED_DATA`` env var is still honored;
 
 Public API:
   cache_dir()      → version-pinned cache Path
-  is_local()       → bool: every downloadable path present?
+  bundle_is_local() → bool: every downloadable path present in the cache?
+  item_is_local()  → bool: one item present in the package or cache?
   fetch()          → download + extract from the GitHub Release
   ensure_local()   → fetch if missing; safe to call on every access
   find(path)       → cached path or None
+  find_local_item(path) → packaged or cached path, without fetching
   status()         → dict summarizing local state
 """
 
@@ -127,6 +129,7 @@ LEGACY_CACHE_DIR_ENV_VAR = "PIRLYGENES_BUNDLED_DATA"
 #: pirlygenes cache for the current version is reused to avoid a re-download.
 _DEFAULT_CACHE_PARENT = Path.home() / ".cache" / "oncoref" / "bundled_data"
 _LEGACY_CACHE_PARENT = Path.home() / ".cache" / "pirlygenes" / "bundled_data"
+_PACKAGE_DATA_DIR = Path(__file__).parent / "data"
 
 # Names that live in the downloadable tarball (relative to the cache root) and
 # are NOT bundled in the wheel. load_dataset checks here after the wheel data dir.
@@ -425,16 +428,45 @@ def _write_completion_marker(
     os.replace(tmp, marker)
 
 
-def is_local() -> bool:
-    """Every downloadable path is present AND non-empty in the cache."""
+def bundle_is_local() -> bool:
+    """Whether every downloadable item is non-empty in the active cache."""
     root = cache_dir()
     return all(_path_complete(root / p) for p in DOWNLOADABLE_PATHS)
 
 
+def is_local() -> bool:
+    """Backward-compatible alias for :func:`bundle_is_local`."""
+    return bundle_is_local()
+
+
 def find(relative_path: str) -> Path | None:
-    """Resolve a downloadable file to its on-disk cached location, or None."""
+    """Resolve a non-empty item in the active bundle cache, or return ``None``."""
     candidate = cache_dir() / relative_path
-    return candidate if candidate.exists() else None
+    return candidate if _path_complete(candidate) else None
+
+
+def find_local_item(relative_path: str) -> Path | None:
+    """Resolve one non-empty data item without downloading anything.
+
+    The package data directory is checked before the active bundle cache, matching
+    normal read precedence. This deliberately answers a narrower question than
+    :func:`bundle_is_local`: whether this exact item is locally present and non-empty,
+    including an artifact checkout or a partial developer cache. It does not perform
+    checksum or schema validation.
+    """
+    path = Path(relative_path)
+    if path.is_absolute() or not path.parts or ".." in path.parts:
+        raise ValueError("relative_path must stay within a data root")
+    for root in (_PACKAGE_DATA_DIR, cache_dir()):
+        candidate = root / path
+        if _path_complete(candidate):
+            return candidate
+    return None
+
+
+def item_is_local(relative_path: str) -> bool:
+    """Whether one data item is non-empty in the package or active cache."""
+    return find_local_item(relative_path) is not None
 
 
 def bundle_contract() -> dict:
@@ -657,7 +689,7 @@ def ensure_local(*, auto_fetch: bool = True, verbose: bool = True) -> Path:
     triggering a network call — for read-only inspection paths that shouldn't
     surprise users with a large download.
     """
-    if is_local():
+    if bundle_is_local():
         return cache_dir()
     if not auto_fetch:
         raise FileNotFoundError(
@@ -693,7 +725,7 @@ def status() -> dict:
             "verified_sha256": bool(marker and marker.get("verified_sha256")),
         },
         "items": items,
-        "all_local": is_local(),
+        "all_local": bundle_is_local(),
         "contract": contract,
     }
 
@@ -701,9 +733,9 @@ def status() -> dict:
 def verify_local() -> dict:
     """Return :func:`status` only when the current cache has a valid completion marker.
 
-    This is stricter than :func:`is_local`: legacy complete caches remain readable, but
-    callers that need a post-fetch integrity boundary can require the marker written by
-    current oncoref fetches.
+    This is stricter than :func:`bundle_is_local`: legacy complete caches remain
+    readable, but callers that need a post-fetch integrity boundary can require the
+    marker written by current oncoref fetches.
     """
     snap = status()
     if not snap["all_local"]:
@@ -820,14 +852,17 @@ __all__ = [
     "TARBALL_FILENAME",
     "BundleIntegrityError",
     "bundle_contract",
+    "bundle_is_local",
     "bundle_release_manifest",
     "cache_dir",
     "cache_root",
     "ensure_local",
     "fetch",
     "find",
+    "find_local_item",
     "is_downloadable",
     "is_local",
+    "item_is_local",
     "list_cache_versions",
     "prune_cache",
     "status",

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -92,7 +92,7 @@ from .gene_ids import (
     unversioned,
 )
 from .gene_qc import TECHNICAL_RNA_GROUPS, classify_gene_qc
-from .load_dataset import _BUNDLED_DATA_DIR, _register_derived_cache, get_data
+from .load_dataset import _register_derived_cache, get_data
 from .normalization import clean_tpm, percentile_rank, tpm_to_housekeeping_normalized
 from .version import DATA_VERSION, SOURCE_MATRIX_VERSION
 
@@ -209,12 +209,9 @@ def _bundle_subdir(name: str, *, auto_fetch: bool = True) -> Path:
 
     ``auto_fetch=False`` skips the potentially large bundle download; the
     returned path simply won't exist when the shard is absent locally."""
-    in_repo = Path(_BUNDLED_DATA_DIR) / name
-    if in_repo.exists():
-        return in_repo
-    cached = data_bundle.find(name)
-    if cached is not None:
-        return cached
+    local = data_bundle.find_local_item(name)
+    if local is not None:
+        return local
     if auto_fetch:
         data_bundle.ensure_local()
     return data_bundle.cache_dir() / name

--- a/oncoref/load_dataset.py
+++ b/oncoref/load_dataset.py
@@ -98,9 +98,7 @@ def _ensure_downloadable(name: str) -> None:
     for cand in candidates:
         if not data_bundle.is_downloadable(cand):
             continue
-        if (_BUNDLED_DATA_DIR / cand).exists():
-            return
-        if data_bundle.find(cand) is not None:
+        if data_bundle.find_local_item(cand) is not None:
             return
         data_bundle.ensure_local()
         return

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.136"
+__version__ = "1.8.137"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -26,6 +26,49 @@ def test_is_downloadable_distinguishes_bundle_from_wheel():
     assert not data_bundle.is_downloadable("cancer-tmb")
 
 
+def test_item_availability_checks_package_then_partial_cache(monkeypatch, tmp_path):
+    package_root = tmp_path / "package"
+    cache_root = tmp_path / "cache"
+    item = "cancer-reference-expression-percentiles"
+    monkeypatch.setattr(data_bundle, "_PACKAGE_DATA_DIR", package_root)
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(cache_root))
+
+    packaged = package_root / item
+    packaged.mkdir(parents=True)
+    (packaged / "LUAD.parquet").write_text("packaged")
+    cached = cache_root / item
+    cached.mkdir(parents=True)
+    (cached / "SKCM.parquet").write_text("cached")
+
+    assert data_bundle.item_is_local(item)
+    assert data_bundle.find_local_item(item) == packaged
+
+    (packaged / "LUAD.parquet").unlink()
+    assert data_bundle.find_local_item(item) == cached
+
+
+def test_item_availability_rejects_missing_and_empty_items(monkeypatch, tmp_path):
+    package_root = tmp_path / "package"
+    cache_root = tmp_path / "cache"
+    item = "cancer-reference-expression-percentiles"
+    monkeypatch.setattr(data_bundle, "_PACKAGE_DATA_DIR", package_root)
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(cache_root))
+
+    (package_root / item).mkdir(parents=True)
+    (cache_root / item).mkdir(parents=True)
+
+    assert not data_bundle.item_is_local(item)
+    assert data_bundle.find_local_item(item) is None
+
+
+def test_find_rejects_empty_cached_item(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    empty = tmp_path / "cancer-reference-expression-percentiles"
+    empty.mkdir()
+
+    assert data_bundle.find(empty.name) is None
+
+
 def test_cache_dir_env_override(monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path / "vX"))
     assert data_bundle.cache_dir() == tmp_path / "vX"

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -864,7 +864,15 @@ def test_representatives_reject_mismatched_artifact_sample_qc(monkeypatch, tmp_p
 
 def test_representative_empty_long_schema_includes_requested_provenance(monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
-    (tmp_path / "cancer-reference-expression-representatives").mkdir(parents=True)
+    shard_dir = tmp_path / "cancer-reference-expression-representatives"
+    shard_dir.mkdir(parents=True)
+    pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG1"],
+            "Symbol": ["GENE1"],
+            "OTHER__rep1": [1.0],
+        }
+    ).to_parquet(shard_dir / "OTHER.parquet", index=False)
 
     df = expression.representative_cohort_samples("PRAD", format="long", include_provenance=True)
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -236,9 +236,9 @@ def test_cli_plot_threshold_tpm_is_opt_in(monkeypatch, tmp_path):
 
 # ---- CTA expression heatmap (needs the expression bundle / percentile data) ----
 
-_HAS_PERCENTILES = data_bundle.is_local()
+_HAS_PERCENTILES = data_bundle.item_is_local("cancer-reference-expression-percentiles")
 _needs_bundle = pytest.mark.skipif(
-    not _HAS_PERCENTILES, reason="expression bundle (percentile artifacts) not present"
+    not _HAS_PERCENTILES, reason="percentile artifacts not present locally"
 )
 
 


### PR DESCRIPTION
Follow-up to #401.

## Changes
- distinguish complete-bundle availability from item-level local presence
- resolve individual artifacts across package/in-repo data and the active partial cache without fetching
- reject empty cached items consistently
- use the item-level probe for the percentile plot regression gate
- release as 1.8.137

## Verification
- `./lint.sh`
- `python -m pytest -q` (809 passed, 1 skipped)
- empty-cache `tests/test_plots.py` collection leaves the cache empty
- focused release/data/plot rerun (30 passed)