### PR TITLE
Exercise pyensembl genome tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      # Keep pyensembl data under the workspace so actions/cache can archive it.
+      PYENSEMBL_CACHE_DIR: ${{ github.workspace }}/.ci-cache/pyensembl
     strategy:
       fail-fast: true
       matrix:
@@ -88,6 +91,28 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+
+      - name: Cache Ensembl genome data
+        uses: actions/cache@v4
+        with:
+          path: .ci-cache/pyensembl
+          key: pyensembl-v2-human93
+
+      - name: Install Ensembl release
+        run: |
+          pyensembl install \
+            --release 93 \
+            --species human \
+            --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCh38.93/
+
+      - name: Verify Ensembl release
+        run: |
+          python - <<'PY'
+          import oncoref
+
+          releases = oncoref.genomes()
+          assert any(genome.release == 93 for genome in releases), releases
+          PY
 
       - name: Run unit tests
         run: pytest tests/ -v --cov=oncoref --cov-report=xml


### PR DESCRIPTION
## Summary
- redirect pyensembl data to a workspace-local CI cache
- restore/install human Ensembl release 93 from the OpenVax mirror in every normal Python matrix job
- fail before pytest unless oncoref discovers the installed release
- leave the separate minimal-install job intentionally pyensembl-free

## Why
The dev extra installs the pyensembl package, but fresh runners had no downloaded Ensembl release. `tests/test_genome.py` could therefore skip in normal CI even though local development exercised it. This adopts vaxrank's proven cache/install pattern while keeping the optional core dependency contract tested independently. GitHub Actions caches are repository-scoped, so oncoref uses its own cache with the same layout and release source.

## Validation
- cold-cache Ensembl install and release-discovery assertion passed on Python 3.9, 3.10, 3.11, and 3.12
- all four `tests/test_genome.py` tests passed in the Python 3.12 job
- full matrix, minimal install, and lint: 6/6 checks passed
- workflow parsed with PyYAML
- `git diff --check`