### PR TITLE
Preserve explicit empty source filters

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2600,7 +2600,8 @@ def cancer_reference_expression(
     supports ``source_kind``, ``source_cohort``, ``exclude_microarray_proxy``, and
     long-form ``pool=True``. Because the shipped sidecars are all-sample summaries,
     this mode requires ``sample_qc="all"``; use ``summary_rows`` for the current
-    QC-filtered richest-source recompute path.
+    QC-filtered richest-source recompute path. For both source filters, ``None``
+    means unfiltered; an empty iterable or blank scalar explicitly matches no sources.
 
     ``sample_qc="artifact"`` reads each clean/log-clean percentile shard using
     the QC policy recorded when that shard was built. It is intentionally valid
@@ -2647,9 +2648,10 @@ def cancer_reference_expression(
     gene_universe = _validate_artifact_gene_universe(gene_universe)
     source_kinds = _normalize_source_filter_values(source_kind)
     source_cohorts = _normalize_source_cohort_filter_values(source_cohort)
+    has_source_filter = source_kinds is not None or source_cohorts is not None
     if reference_source == "summary_rows_all" and sample_qc != "all":
         raise ValueError('reference_source="summary_rows_all" requires sample_qc="all"')
-    if (source_kinds or source_cohorts or exclude_microarray_proxy or pool) and (
+    if (has_source_filter or exclude_microarray_proxy or pool) and (
         reference_source != "summary_rows_all"
     ):
         raise ValueError(
@@ -2900,6 +2902,7 @@ def cancer_reference_expression_availability(
     reference_source = _validate_reference_source(reference_source)
     source_kinds = _normalize_source_filter_values(source_kind)
     source_cohorts = _normalize_source_cohort_filter_values(source_cohort)
+    has_source_filter = source_kinds is not None or source_cohorts is not None
     if sample_qc == "artifact" and (reference_source != "artifact" or "tpm_raw" in modes):
         raise ValueError(
             "sample_qc='artifact' requires reference_source='artifact' and "
@@ -2909,9 +2912,7 @@ def cancer_reference_expression_availability(
         raise ValueError('reference_source="summary_rows_all" requires sample_qc="all"')
     if all_sources and reference_source != "summary_rows_all":
         raise ValueError('all_sources=True requires reference_source="summary_rows_all"')
-    if (source_kinds or source_cohorts or exclude_microarray_proxy) and (
-        reference_source != "summary_rows_all"
-    ):
+    if (has_source_filter or exclude_microarray_proxy) and (reference_source != "summary_rows_all"):
         raise ValueError(
             "source_kind, source_cohort, and exclude_microarray_proxy are only "
             "supported with reference_source='summary_rows_all'"
@@ -3994,6 +3995,7 @@ def _reference_summary_selected_rows(code: str) -> pd.DataFrame:
 
 
 def _normalize_source_filter_values(values: str | Iterable[str] | None) -> set[str] | None:
+    """Normalize a source filter while preserving ``None`` versus no matches."""
     if values is None:
         return None
     raw = [values] if isinstance(values, str) else list(values)
@@ -4031,9 +4033,9 @@ def _filter_reference_summary_sources(
     out = table.copy()
     if out.empty:
         return out
-    if source_cohorts:
+    if source_cohorts is not None:
         out = out.loc[out["source_cohort"].astype(str).isin(source_cohorts)]
-    if source_kinds:
+    if source_kinds is not None:
         kind_map = _source_cohort_kind_map()
         out = out.loc[out["source_cohort"].astype(str).map(kind_map).isin(source_kinds)]
     if exclude_microarray_proxy:

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.139"
+__version__ = "1.8.140"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -2586,6 +2586,95 @@ def test_cancer_reference_expression_summary_rows_all_preserves_sources_and_filt
     expression._source_cohort_kind_map.cache_clear()
 
 
+def test_source_filter_normalization_distinguishes_unfiltered_from_no_matches():
+    assert expression._normalize_source_filter_values(None) is None
+    assert expression._normalize_source_filter_values([]) == set()
+    assert expression._normalize_source_filter_values("") == set()
+    assert expression._normalize_source_cohort_filter_values(None) is None
+    assert expression._normalize_source_cohort_filter_values([]) == set()
+
+
+@pytest.mark.parametrize(
+    "filter_kwargs",
+    [
+        pytest.param({"source_cohort": []}, id="empty-cohort-list"),
+        pytest.param({"source_cohort": ""}, id="blank-cohort-scalar"),
+        pytest.param({"source_kind": []}, id="empty-kind-list"),
+    ],
+)
+@pytest.mark.parametrize("pool", [False, True])
+def test_explicit_empty_source_filters_match_nothing(monkeypatch, filter_kwargs, pool):
+    summary = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1"],
+            "Symbol": ["A"],
+            "cancer_code": ["X"],
+            "source_cohort": ["SRC_X"],
+            "source_project": ["TEST"],
+            "source_version": ["v1"],
+            "TPM_median": [10.0],
+            "TPM_q1": [9.0],
+            "TPM_q3": [11.0],
+            "TPM_clean_median": [1.0],
+            "TPM_clean_q1": [0.9],
+            "TPM_clean_q3": [1.1],
+            "n_samples": [4],
+            "n_detected": [3],
+            "processing_pipeline": ["rna_seq"],
+            "notes": [""],
+            "tumor_origin": ["primary"],
+            "metastasis_site": [pd.NA],
+        }
+    )
+    compact = pd.DataFrame(
+        {
+            "cancer_code": ["X"],
+            "source_cohort": ["SRC_X"],
+            "n_reference_genes": [1],
+            "n_reference_samples": [4],
+        }
+    )
+    registry = pd.DataFrame({"cohort_id": ["SRC_X"], "kind": ["test"]})
+    expression._reference_summary_source_table.cache_clear()
+    expression._source_cohort_kind_map.cache_clear()
+    monkeypatch.setattr(expression, "_reference_summary_frame", lambda: summary)
+    monkeypatch.setattr(expression, "_reference_summary_availability_table", lambda: compact)
+    monkeypatch.setattr(expression, "cohort_registry_df", lambda: registry)
+    monkeypatch.setattr(expression, "resolve_cancer_type", lambda code, **k: str(code).upper())
+    monkeypatch.setattr(expression.source_matrices, "available_cohorts", lambda: [])
+
+    out = expression.cancer_reference_expression(
+        "x",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        on_missing="empty",
+        pool=pool,
+        **filter_kwargs,
+    )
+
+    assert out.empty
+    assert len(out.attrs["availability"]) == 1
+    assert out.attrs["availability"][0]["available"] is False
+    assert out.attrs["availability"][0]["missing_reason"] == "no_reference_summary_rows"
+    assert len(out.attrs["missing_requests"]) == 1
+    assert out.attrs["missing_requests"][0]["cancer_code"] == "X"
+    assert out.attrs["missing_requests"][0]["missing_reason"] == "no_reference_summary_rows"
+
+    availability = expression.cancer_reference_expression_availability(
+        "x",
+        reference_source="summary_rows_all",
+        sample_qc="all",
+        all_sources=True,
+        **filter_kwargs,
+    )
+    assert len(availability) == 1
+    assert not bool(availability.loc[0, "available"])
+    assert availability.loc[0, "missing_reason"] == "no_reference_summary_rows"
+
+    expression._reference_summary_source_table.cache_clear()
+    expression._source_cohort_kind_map.cache_clear()
+
+
 def test_summary_provenance_uses_only_observed_source_categories(monkeypatch):
     summary = pd.DataFrame(
         {


### PR DESCRIPTION
Fixes #412.

## Summary
- preserve the semantic difference between `None` (unfiltered) and an empty normalized source filter (match nothing)
- apply explicit empty cohort/kind filters before availability, row loading, and pooling
- make blank scalar cohort filters match nothing instead of broadening to all sources
- keep output rows, availability, and `missing_requests` consistent
- prepare package version 1.8.140

## Root cause
The normalizers returned `set()` for an explicit empty input, but downstream truthiness checks treated that set like `None` and skipped filtering. The public entry points and shared filter now test presence with `is not None`.

## Verification
- 9 focused source-filter/pooling tests passed
- 168 expression, API, release-workflow, and bundle tests passed
- `ruff check oncoref tests`
- `ruff format --check oncoref tests`
- `git diff --check`