### PR TITLE
Align artifact build metadata identity

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -1470,7 +1470,7 @@ _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p", "tpm_clean_h
 _SAMPLE_QC_MODES = ("all", "pass", "pass_or_warn")
 _ARTIFACT_SAMPLE_QC_MODES = ("artifact", *_SAMPLE_QC_MODES)
 SAMPLE_EXPRESSION_QC_POLICY_VERSION = "sample_expression_qc_v2"
-EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION = "expression_artifact_build_metadata_v1"
+EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION = "expression_artifact_build_metadata_v2"
 SOURCE_MATRIX_SAMPLE_QC_MANIFEST_PATH = "source-matrix-sample-qc.csv"
 EXPRESSION_ARTIFACT_BUILD_METADATA_PATH = "expression-artifact-build-metadata.csv"
 EXPRESSION_ARTIFACT_BUILD_METADATA_JSON_PATH = "expression-artifact-build-metadata.json"
@@ -1517,6 +1517,7 @@ _SOURCE_MATRIX_SAMPLE_QC_MANIFEST_COLUMNS = [
 _EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS = [
     "cancer_code",
     "source_cohort",
+    "build_source_cohort",
     "source_version",
     "source_matrix_path",
     "sample_qc",
@@ -2234,10 +2235,12 @@ def expression_artifact_build_metadata(
 ) -> pd.DataFrame:
     """Read per-cohort build metadata for generated expression artifacts.
 
-    The rows are emitted by ``scripts/rebuild_expression_artifacts.py`` and record the
-    selected source matrix, QC policy, selected sample count, and QC pass/warn/fail
-    counts for each cohort. Missing current-bundle metadata returns a schema-stable
-    empty frame by default.
+    ``source_cohort`` is the canonical cohort identity used by the source-matrix and
+    expression artifact loaders. ``build_source_cohort`` preserves the cohort label
+    physically recorded when the bundle was built, which can differ in older bundles.
+    The remaining fields record the selected source matrix, QC policy, selected sample
+    count, and QC pass/warn/fail counts. Missing current-bundle metadata returns a
+    schema-stable empty frame by default.
     """
     mode = _validate_metadata_on_missing(on_missing)
     path = _optional_bundle_metadata_path(
@@ -2256,9 +2259,20 @@ def expression_artifact_build_metadata(
         )
 
     out = pd.read_csv(path)
+    if "source_cohort" not in out.columns:
+        out["source_cohort"] = pd.NA
+    if "build_source_cohort" not in out.columns:
+        out["build_source_cohort"] = out["source_cohort"]
     for col in _EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS:
         if col not in out.columns:
             out[col] = pd.NA
+
+    registry = source_matrices.registry()
+    loader_source_by_code = dict(
+        zip(registry["cancer_code"].astype(str), registry["source_cohort"].astype(str))
+    )
+    loader_sources = out["cancer_code"].astype(str).map(loader_source_by_code)
+    out["source_cohort"] = loader_sources.where(loader_sources.notna(), out["source_cohort"])
     extra_cols = [
         col for col in out.columns if col not in _EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS
     ]

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.141"
+__version__ = "1.8.142"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/scripts/rebuild_expression_artifacts.py
+++ b/scripts/rebuild_expression_artifacts.py
@@ -38,6 +38,7 @@ are large and ship via the release tarball, so they're never committed):
     <out>/cancer-reference-expression-representatives/<CODE>.parquet + _provenance.csv
     <out>/cancer-reference-expression-within-sample-top5/<CODE>.parquet (biology-only)
     <out>/source-matrix-sample-qc.csv                          (per-sample QC manifest)
+    <out>/expression-artifact-build-metadata.csv               (per-cohort provenance)
     <out>/expression-artifact-build-metadata.json              (QC/build policy metadata)
 
 ``--validate`` additionally correlates each rebuilt percentile vector against the
@@ -65,6 +66,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from oncoref.cancer_types import cohort_source_version
 from oncoref.expression import (
+    EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION,
     SAMPLE_EXPRESSION_QC_POLICY_VERSION,
     SHARD_DATASETS,
     _canonicalize_gene_rows,
@@ -357,6 +359,7 @@ def rebuild(
         build_row = {
             "cancer_code": code,
             "source_cohort": source_cohort,
+            "build_source_cohort": source_cohort,
             "source_version": source_version,
             "source_matrix_path": str(source_path),
             "sample_qc": sample_qc,
@@ -460,6 +463,7 @@ def rebuild(
     pd.DataFrame(build_rows).to_csv(out / "expression-artifact-build-metadata.csv", index=False)
     metadata = {
         "artifact": "expression-derived-shards",
+        "schema_version": EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION,
         "sample_qc": sample_qc,
         "sample_qc_policy_version": SAMPLE_EXPRESSION_QC_POLICY_VERSION,
         "sample_qc_fallbacks": int(

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -2230,11 +2230,14 @@ def test_rebuild_expression_artifacts_defaults_to_qc_passing_samples(tmp_path, m
     assert list(qc["sample_id"]) == ["pass_sample", "warn_sample", "fail_sample"]
 
     build_meta = pd.read_csv(out / "expression-artifact-build-metadata.csv")
+    assert build_meta.loc[0, "source_cohort"] == "TEST_SOURCE"
+    assert build_meta.loc[0, "build_source_cohort"] == "TEST_SOURCE"
     assert build_meta.loc[0, "n_source_samples"] == 3
     assert build_meta.loc[0, "n_cohort_samples"] == 1
     assert build_meta.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v2"
 
     metadata = json.loads((out / "expression-artifact-build-metadata.json").read_text())
+    assert metadata["schema_version"] == "expression_artifact_build_metadata_v2"
     assert metadata["sample_qc"] == "pass"
     assert metadata["sample_qc_manifest"] == "source-matrix-sample-qc.csv"
     assert metadata["n_source_samples"] == 3

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -2934,7 +2934,7 @@ def test_artifact_build_metadata_uses_loader_source_cohort_identity():
     assert (comparison["source_cohort_loader"] == comparison["source_cohort_metadata"]).all()
 
     by_code = comparison.set_index("cancer_code")
-    assert by_code.loc["LUAD", "source_cohort_metadata"] == ("TREEHOUSE_POLYA_25_01_TCGA_SAMPLES")
+    assert by_code.loc["LUAD", "source_cohort_metadata"] == "TREEHOUSE_POLYA_25_01_TCGA_SAMPLES"
     assert by_code.loc["LUAD", "build_source_cohort"] == "TREEHOUSE_POLYA_25_01"
     assert by_code.loc["CML", "source_cohort_metadata"] == "GSE100026_DING_2017"
     assert by_code.loc["CML", "build_source_cohort"] == "GEO_HEME_2022"

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1594,6 +1594,16 @@ def test_source_matrix_sample_qc_manifest_reads_filters_and_exports(tmp_path, mo
 
 def test_expression_artifact_build_metadata_and_summary(tmp_path, monkeypatch):
     monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    monkeypatch.setattr(
+        expression.source_matrices,
+        "registry",
+        lambda: pd.DataFrame(
+            {
+                "cancer_code": ["PRAD", "BRCA"],
+                "source_cohort": ["CANONICAL_PRAD", "CANONICAL_BRCA"],
+            }
+        ),
+    )
     pd.DataFrame(
         {
             "cancer_code": ["PRAD", "BRCA"],
@@ -1618,7 +1628,8 @@ def test_expression_artifact_build_metadata_and_summary(tmp_path, monkeypatch):
     meta = expression.expression_artifact_build_metadata("PRAD", auto_fetch=False)
     summary = expression.expression_artifact_build_summary(auto_fetch=False)
 
-    assert meta["source_cohort"].tolist() == ["SRC_PRAD"]
+    assert meta["source_cohort"].tolist() == ["CANONICAL_PRAD"]
+    assert meta["build_source_cohort"].tolist() == ["SRC_PRAD"]
     assert meta["extra_future_column"].tolist() == ["x"]
     assert "n_qc_pass" in meta.columns
     assert (
@@ -2897,6 +2908,36 @@ def test_artifact_sources_are_registry_backed_with_effective_sample_counts():
     assert availability["n_reference_samples"].tolist() == [4, 9]
     assert availability["n_samples"].tolist() == [4, 9]
     assert availability["processing_pipeline"].notna().all()
+
+
+def test_artifact_build_metadata_uses_loader_source_cohort_identity():
+    matrix_registry = expression.source_matrices.registry()
+    codes = matrix_registry["cancer_code"].astype(str).tolist()
+    metadata = expression.expression_artifact_build_metadata(
+        codes, auto_fetch=False, on_missing="raise"
+    )
+    availability = expression.cancer_reference_expression_availability(
+        codes,
+        reference_source="artifact",
+        sample_qc="artifact",
+    )
+
+    comparison = availability.loc[
+        availability["available"], ["cancer_code", "source_cohort"]
+    ].merge(
+        metadata[["cancer_code", "source_cohort", "build_source_cohort"]],
+        on="cancer_code",
+        suffixes=("_loader", "_metadata"),
+        validate="one_to_one",
+    )
+    assert len(comparison) == len(matrix_registry)
+    assert (comparison["source_cohort_loader"] == comparison["source_cohort_metadata"]).all()
+
+    by_code = comparison.set_index("cancer_code")
+    assert by_code.loc["LUAD", "source_cohort_metadata"] == ("TREEHOUSE_POLYA_25_01_TCGA_SAMPLES")
+    assert by_code.loc["LUAD", "build_source_cohort"] == "TREEHOUSE_POLYA_25_01"
+    assert by_code.loc["CML", "source_cohort_metadata"] == "GSE100026_DING_2017"
+    assert by_code.loc["CML", "build_source_cohort"] == "GEO_HEME_2022"
 
 
 def test_artifact_availability_uses_selected_build_sample_count(monkeypatch):


### PR DESCRIPTION
Closes #413.

## What changed
- make `expression_artifact_build_metadata().source_cohort` match the loader-facing source-matrix identity
- preserve the source label recorded by legacy bundles as `build_source_cohort`
- emit the explicit field and v2 schema from future artifact rebuilds
- add registry-wide regression coverage across all 126 artifact cohorts

## Why
Compact build metadata exposed stale source labels for 37 current cohorts, so downstream provenance manifests disagreed with the artifact loader. The accessor now performs a schema-stable compatibility migration without requiring a 21 GB source-matrix or derived-bundle rebuild.

## Validation
- `./lint.sh`
- `./test.sh` (`828 passed, 1 skipped`)
- explicit 126-row audit: zero loader/metadata source-cohort mismatches and 37 legacy build labels preserved