### PR TITLE
Harden release interpreter and artifact availability checks

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,17 +2,32 @@
 set -euo pipefail
 
 REPO="${GITHUB_REPOSITORY:-pirl-unc/oncoref}"
-VERSION="$(python3 -c 'from oncoref.version import __version__; print(__version__)')"
+PYTHON_COMMAND="${PYTHON:-python}"
+if ! PYTHON_BIN="$(command -v "$PYTHON_COMMAND")"; then
+    echo "Python interpreter not found: $PYTHON_COMMAND" >&2
+    exit 1
+fi
+if ! "$PYTHON_BIN" -c \
+    'import sys; raise SystemExit(0 if sys.prefix != sys.base_prefix else 1)'
+then
+    echo "deploy.sh requires a virtualenv Python; activate one or set PYTHON" >&2
+    exit 1
+fi
+
+# Keep lint.sh and test.sh on the same interpreter used to build and upload.
+export PATH="$(dirname "$PYTHON_BIN"):$PATH"
+
+VERSION="$("$PYTHON_BIN" -c 'from oncoref.version import __version__; print(__version__)')"
 TAG="v${VERSION}"
 PYPI_URL="https://pypi.org/project/oncoref/${VERSION}/"
 PYPI_PUBLISHED_MARKER="<!-- oncoref-deploy-pypi-published -->"
 
 ./lint.sh
 ./test.sh
-python3 -m pip install --upgrade build twine
+"$PYTHON_BIN" -m pip install --upgrade build twine
 rm -rf dist
-python3 -m build
-python3 -m twine upload dist/*
+"$PYTHON_BIN" -m build
+"$PYTHON_BIN" -m twine upload dist/*
 if git rev-parse "$TAG" >/dev/null 2>&1; then
     echo "tag $TAG already exists locally"
 else

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.143"
+__version__ = "1.8.144"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -236,14 +236,11 @@ def test_cli_plot_threshold_tpm_is_opt_in(monkeypatch, tmp_path):
 
 # ---- CTA expression heatmap (needs the expression bundle / percentile data) ----
 
-_HAS_PERCENTILES = data_bundle.item_is_local("cancer-reference-expression-percentiles")
-_needs_bundle = pytest.mark.skipif(
-    not _HAS_PERCENTILES, reason="percentile artifacts not present locally"
-)
 
-
-@_needs_bundle
 def test_cta_expression_heatmap_renders(tmp_path):
+    if not data_bundle.item_is_local("cancer-reference-expression-percentiles"):
+        pytest.skip("percentile artifacts not present locally")
+
     out = tmp_path / "cta.png"
     cohorts = __import__("oncoref").available_percentile_cohorts()[:6]
     fig = plots.cta_expression_heatmap(

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -6,3 +6,18 @@ def test_release_workflow_skips_deploy_sh_created_releases():
 
     assert "oncoref-deploy-pypi-published" in workflow
     assert "gh-action-pypi-publish" in workflow
+
+
+def test_deploy_uses_one_virtualenv_python_interpreter():
+    script = Path("deploy.sh").read_text()
+
+    assert 'PYTHON_COMMAND="${PYTHON:-python}"' in script
+    assert "sys.prefix != sys.base_prefix" in script
+    assert 'export PATH="$(dirname "$PYTHON_BIN"):$PATH"' in script
+    assert 'VERSION="$("$PYTHON_BIN" -c' in script
+    assert '"$PYTHON_BIN" -m pip install --upgrade build twine' in script
+    assert '"$PYTHON_BIN" -m build' in script
+    assert '"$PYTHON_BIN" -m twine upload' in script
+
+    command_lines = [line.strip() for line in script.splitlines()]
+    assert not any(line.startswith(("python ", "python3 ")) for line in command_lines)


### PR DESCRIPTION
## Summary
- resolve one explicit virtualenv Python for release versioning, tests, build, and upload
- fail before package mutation when the selected interpreter is not a virtualenv
- evaluate percentile artifact availability when the heatmap test executes instead of freezing it at collection
- release as oncoref 1.8.144

## Root causes
`deploy.sh` mixed `python3` with the `python` used by `test.sh`, allowing a passing test run to be followed by a PEP 668 failure in Homebrew Python. The plotting test also cached a false availability result before another test populated the bundle.

## Validation
- `bash -n deploy.sh`
- `ruff check oncoref tests`
- `ruff format --check oncoref tests`
- focused release, heatmap, and genome tests: 7 passed
- post-fix full suite: 840 passed, 1 skipped (only the optional 22 GB external parity fixture)

Closes #424
Closes #425