### PR TITLE
Reorganize documentation for progressive disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,71 +5,53 @@
 
 Curated cancer reference data — cancer-type ontology, tumor mutational burden
 (TMB), incidence/mortality, checkpoint-inhibitor (ICI) response, per-cohort
-RNA-seq expression, HPA normal-tissue expression, and HPA-derived
-cancer-testis antigen references — behind one small Python API, a data
-fetch/cache CLI, and a set of reference plots.
+RNA-seq expression, Human Protein Atlas (HPA) normal-tissue expression, and
+HPA-derived cancer-testis antigen references — behind one small Python API, a
+data fetch/cache CLI, and a set of reference plots.
 
-## Where oncoref fits
+## Role in the stack
 
 The openvax/PIRL tools are split by ownership boundary, not by file format.
-Newcomers should think of the stack as three layers:
+`oncoref` is the base layer: downstream packages can depend on it, but it never
+imports its consumers.
 
 - **oncoref** is the empirical base: what is true, measured, or canonically named
   about cancer types, cohorts, genes, and reference datasets. It owns gene
   identity and canonicalization, the cancer-type ontology/registry, expression
-  reference data and normalization, epidemiology, TMB, ICI/aPD1 response, and
+  reference data and normalization, epidemiology, TMB, ICI/anti-PD-1 response, and
   source-anchored cancer-testis antigen (CTA) facts. If a row has an `n`, a
   confidence interval, a source cohort, or a PMID/DOI anchoring a measurement,
   it is usually an oncoref fact.
 - [**pirlygenes**](https://github.com/pirl-unc/pirlygenes) owns curated gene
   sets and panels: which genes are useful for a purpose. That includes
-  lineage/family/compartment/supertype panels, discriminators, surfaceome, TME
-  and stem-cell markers, response-signature panels, target-to-therapy registries,
-  and other opinionated selections keyed to oncoref cancer codes and gene IDs. An
-  empty set can be a valid pirlygenes answer.
+  lineage/family/compartment/supertype panels, discriminators, surfaceome, tumor
+  microenvironment (TME) and stem-cell markers, response-signature panels,
+  target-to-therapy registries, and other opinionated selections keyed to
+  oncoref cancer codes and gene IDs. An empty set can be a valid pirlygenes
+  answer.
 - [**trufflepig**](https://github.com/pirl-unc/trufflepig) owns per-sample
-  interpretation: QC narration, library-prep/source warnings, deconvolution,
-  scoring, and rule tables that fire against one tumor sample.
+  interpretation: quality-control (QC) narration, library-prep/source warnings,
+  deconvolution, scoring, and rule tables that fire against one tumor sample.
 
-That division keeps the dependency direction simple: pirlygenes and trufflepig
-can depend on oncoref, but oncoref never imports its consumers. When a shared
-fact is wrong, incomplete, or poorly anchored, fix it in oncoref. When a panel
-or rule is purpose-specific, keep it in the downstream package and key it to
-oncoref's ontology and gene identifiers.
+Adoption is staged: consumers can delegate parity-clean primitives while
+retaining their own curated artifacts and compatibility APIs. Shared facts and
+identifiers should be fixed here; purpose-specific panels and per-sample rules
+stay downstream.
 
-## oncoref is the base layer
+## Core model
 
-`oncoref` is **designed as the base layer** of the openvax/PIRL stack — the
-intended upstream home for shared cancer reference mechanics and data, meant to
-become a common dependency of
-[pirlygenes](https://github.com/pirl-unc/pirlygenes),
-[trufflepig](https://github.com/pirl-unc/trufflepig), and
-[tsarina](https://github.com/pirl-unc/tsarina). Adoption is staged: downstream
-packages can delegate parity-clean primitives while keeping their own curated
-tables, packaged artifacts, and compatibility APIs until those surfaces are
-ready to move. Architecturally oncoref stays at the bottom: it depends only on
-pandas / numpy / pyarrow / PyYAML, it **never imports its consumers** (data and
-logic flow only downward), and shared definitions should be fixed or exposed
-here rather than reimplemented separately downstream.
-
-Use oncoref for shared questions about
-
-- **gene expression of cancer samples** — per-cohort RNA-seq in a normalized,
-  comparable space: summary stats, tail-weighted percentiles, and medoid/exemplar
-  samples per cancer type/subtype. Downstream packages may still keep packaged
-  expression artifacts and compatibility wrappers while parity checks converge;
-- **HPA protein / RNA** normal-tissue expression;
-- the **HPA-derived cancer-testis antigen call** — the HPA tissue-restriction
-  call over the candidate list (HPA-only; no pirlygenes therapy/MS curation
-  layer);
-- the **ontology of cancer types** — codes, the parent/child hierarchy, subtypes,
-  families, characteristic driver fusions, and the cross-cutting MSI/POLE/HPV
-  groupings; and
-- **checkpoint-inhibitor response rates** and **TMB** per cancer type.
-
-Everything keys on the cancer-type registry. The small curated tables ship in the
-wheel; the heavy per-cohort expression bundle downloads on first use from
-oncoref's own GitHub Release.
+- **Canonical identities first.** Cancer facts key on the cancer-type registry;
+  expression cohorts and evidence scopes are explicit rather than inferred from
+  names. Gene APIs resolve to a canonical Ensembl space.
+- **Small facts in the wheel, large matrices on demand.** Ontology, gene,
+  burden, response, and provenance tables install with the package. The large
+  expression bundle and HPA datasets use versioned download caches.
+- **Provenance is part of the result.** Reference rows expose source scope,
+  sample counts, versions, and review status. Missing or ineligible data stays
+  distinguishable from a valid empty result.
+- **Consumer policy stays downstream.** oncoref exposes HPA-derived CTA calls
+  and empirical expression facts; it does not turn them into therapy panels or
+  one-sample decisions.
 
 ## Install
 
@@ -77,13 +59,20 @@ oncoref's own GitHub Release.
 pip install oncoref
 ```
 
-## Python API
+Optional integrations are explicit extras:
+
+```bash
+pip install 'oncoref[genome]'  # pyensembl-backed transcript and gene lookup
+pip install 'oncoref[plots]'   # reference plotting
+```
+
+## Quick start
 
 The flat `oncoref` namespace remains available for compatibility and quick
 interactive use. For new code, prefer the semantic submodules in
-[docs/api.md](docs/api.md); they make it clearer whether you are working with
-the cancer ontology, cohorts, ICI response, CTA coverage, generic antigen-panel
-coverage, or CTA-specific peptides.
+the [API guide](https://pirl-unc.github.io/oncoref/api/); they make it clearer
+whether you are working with the cancer ontology, cohorts, ICI response, CTA
+coverage, generic antigen-panel coverage, or CTA-specific peptides.
 
 ```python
 import oncoref as od
@@ -93,7 +82,7 @@ od.cancer_type_info("SARC_RMS_ARMS")      # full registry record + burden + tmb
 od.cancer_tmb("LUAD_EGFR")                # 6.9  (inherited from LUAD)
 od.cancer_burden("pancreas", metric="us_mortality_pct")
 od.burden_category("SARC_OS")             # -> "bone_and_joint" (incidence/mortality bucket)
-od.cancer_ici_response("SKCM")            # 42  (anti-PD-1 ORR %; fallback aPD-1 → aPD-L1 → combo)
+od.cancer_ici_response("SKCM")            # 42% objective response rate
 od.cancer_ici_response("SKCM", regimen="PD-1+CTLA-4")   # 57.6  (pin a regimen)
 
 # Cancer-testis antigens (HPA-derived tissue-restriction):
@@ -106,89 +95,23 @@ od.cohort_gene_percentiles("PRAD")        # per-gene p0…p100 vector (within-co
 od.within_sample_top_fraction("PRAD")     # per-gene frac of samples top-5% (within-sample)
 ```
 
-### Domains
+## Domain map
 
-- **Cancer ontology** — `oncoref.cancer_ontology`: `cancer_type_registry`,
-  `resolve_cancer_type`, `cancer_type_records`, `cancer_type_codes`,
-  `cancer_type_path`, `cancer_type_reference_data`, `cancer_type_category_schema`,
-  `cancer_type_category_summary`, tree/family/lineage helpers, explicit
-  `ontology_level` / `ontology_kind` fields, molecular subtype groups, typed
-  `reference_source` backing (`own_cohort`, `member_union`, `parent`, `none`),
-  `cancer_type_reference_source`, `cancer_type_reference_code`,
-  compatibility `is_classification_target` / `classification_target_codes`,
-  `computed_union_codes`, MMR/MSI classifier-axis helpers, source-scoped
-  evidence resolution, matched normal tissue helpers, `viral_status`,
-  `fusion_status`. Use these level, reference-source, and computed-union fields
-  for category-aware code, not the legacy `mixture_cohort` flag. For example
-  `COAD_MSI` / `READ_MSI` are own cohorts, while `CRC_MSI` is the member union
-  over those two MSI expression partitions. Use `cancer_type_category_schema()`
-  before building filters that depend on ontology/category vocabulary.
-- **Cohorts** — `oncoref.cohorts`: `cohort_registry`, `cohort_aggregates`,
-  `cohort_source_version`, and mixture-cohort helpers.
-- **TMB** — `cancer_tmb`, `cancer_tmb_df` (parent-chain inheritance).
-- **Incidence / mortality** — `cancer_burden`, `burden_category` (ACS /
-  GLOBOCAN). `cancer_burden_df()` is the auditable source table: percentage
-  columns are the current lookup surface, while raw-count, source-locator,
-  source-site, derivation, and rounding columns are explicit provenance fields.
-  Legacy rows mark source-local anchors as `not_extracted` until the row-level
-  ACS/GLOBOCAN audit fills them.
-- **Checkpoint response** — `oncoref.ici_response`: regimen-aware ORR anchors,
-  anti-PD-1 shortcuts, endpoint estimates, and pooled response summaries. The
-  long endpoint table exposes stable `estimate_id` values plus structured
-  CI/value status fields; compact ORR records point back to those estimate rows
-  via `source_estimate_id`.
-- **Expression** — `cohort_gene_percentiles`, `within_sample_top_fraction`,
-  `representative_cohort_samples` over the lazy-downloaded per-cohort bundle, plus
-  `representative_cohort_availability` for source-scale and benchmark qualification;
-  `oncoref.expression_builders` for source-matrix ingestion into canonical
-  per-code per-sample TPM parquet plus mapping/parse/QC sidecars and
-  per-gene-per-cohort `summary_rows` for reference-expression shards. Generic
-  `source_type: geo-matrix` entries in `expression_sources.yaml` are executable
-  via `scripts/build_geo_matrix.py`, registry-encoded GDC STAR-counts sources
-  via `scripts/build_gdc_source.py`, and `source_type: recount3` entries via
-  `scripts/build_recount3_source.py`; downstream packages should read the
-  bundled source registry through `expression_source_registry_entries()` and
-  consume builder-produced `summary_rows` rather than shipping a second YAML copy
-  or re-deriving the stat suite.
-- **Clean TPM / normalization** — `oncoref.normalization` for the 16/9/75
-  compartment transform and `oncoref.gene_families` for clean-TPM censored
-  compartment IDs plus the biological housekeeping denominator panel.
-- **Cancer-testis antigens** — `oncoref.cta`: `cta_gene_names`/`cta_gene_ids`,
-  `cta_evidence`, `cta_clinical_target_evidence`, `synthesize_restriction`
-  (HPA-only tissue-restriction; MS evidence stays in the target-selection layer).
-  The strict default keeps normal-tissue safety conservative; clinical/canonical
-  targets that fail that filter remain discoverable through the explicit clinical
-  tier with exclusion-driving tissue and nTPM values attached. Use
-  `cta_specificity_audit()` for machine-readable demotion and candidate-only
-  specificity decisions.
-- **CTA coverage / peptides** — `oncoref.cta_coverage` for patient coverage and
-  `oncoref.cta_peptides` for CTA-specific 9-mer count maps and load.
-- **Generic antigen-panel coverage** — `oncoref.antigen_coverage` for explicit
-  non-CTA gene lists supplied by the caller. This computes coverage for a panel;
-  it does not make oncoref the owner of downstream panel curation.
-- **HPA normal tissue** — `hpa_rna_consensus`, `hpa_normal_tissue` (IHC),
-  `hpa_single_cell`, and per-gene lookups (`gene_tissue_ntpm`,
-  `gene_protein_tissues`, `gene_cell_type_ntpm`) over HPA v23, fetched on demand
-  (`oncoref data fetch hpa`).
-- **Genome reference** — `canonical_gene_id`, `canonical_gene_symbol`,
-  `display_gene_name`, `short_gene_name`, `canonical_gene_id_and_name`,
-  `find_gene_id_by_name`, `find_gene_name_from_ensembl_{gene,transcript}_id`,
-  and `aggregate_gene_expression` (symbol/synonym/legacy-Ensembl-ID ↔ canonical
-  Ensembl-ID resolution). The bundled canonical gene space and aliases work in the
-  base install. Install `oncoref[genome]` for arbitrary pyensembl-backed lookup, then
-  download a human release once:
-  `pyensembl install --release 111 --species homo_sapiens` (the accessors return
-  `None` until a release is installed).
-- **Legacy/compat response signatures** — `oncoref.response_signatures` ships a
-  small historical checkpoint-response signature surface used by oncoref plots.
-  Treat it as transitional: new therapy-response signature panels belong in
-  pirlygenes, and this small surface should not be extended in oncoref unless it
-  is recast as source-anchored empirical fact/provenance rows.
-- **Plots** (`pip install oncoref[plots]`) — `oncoref.plots.apd1_vs_tmb`,
-  `apd1_orr_bars`, `incidence_vs_mortality`, the CTA/coverage figures, and
-  `oncoref.cta_curation_plots.render`.
+| Question | Preferred modules |
+| --- | --- |
+| What does this cancer code mean? | `oncoref.cancer_ontology`, `oncoref.cohorts` |
+| What expression reference is available? | `oncoref.expression`, `oncoref.source_matrices` |
+| How is expression normalized or filtered? | `oncoref.normalization`, `oncoref.gene_families` |
+| What is the canonical gene identity? | `oncoref.gene_ids`, `oncoref.genome`, `oncoref.proteoforms` |
+| What is the TMB, burden, or ICI response evidence? | `oncoref.tmb`, `oncoref.incidence`, `oncoref.ici_response` |
+| Which genes meet the HPA-derived CTA definition? | `oncoref.cta`, `oncoref.cta_coverage`, `oncoref.cta_peptides` |
+| Where is a dataset cached or downloaded? | `oncoref.catalog`, `oncoref.data_bundle`, `oncoref.hpa` |
 
-## CLI
+The [API guide](https://pirl-unc.github.io/oncoref/api/) explains each domain,
+its provenance contract, and the distinction between reader, builder, and
+compatibility APIs.
+
+## Command line
 
 ```bash
 oncoref cancer-type prostate     # registry info as JSON
@@ -199,13 +122,16 @@ oncoref cta --count             # number of expressed CTAs
 oncoref plot apd1-vs-tmb --out apd1_vs_tmb.png
 oncoref plot patient-coverage --gene-set cta --out coverage_out
 oncoref plot cta-curation --out cta_curation_out
+```
 
-# managed data downloads/cache:
+### Data cache
+
+```bash
 oncoref data list               # every wheel/bundle/HPA/source dataset
 oncoref data status bundle      # expression-bundle cache state (no download)
 oncoref data metadata           # package/data/cache/release contract JSON
 oncoref data fetch bundle       # download the large expression bundle
-oncoref data fetch hpa          # download HPA reference data (RNA / IHC / single-cell)
+oncoref data fetch hpa          # HPA RNA / immunohistochemistry / single-cell data
 oncoref data dir bundle         # where the data bundle is cached
 oncoref data prune --yes        # delete stale bundle version caches
 oncoref version

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,18 +17,36 @@ bundle-integrity rule, or source-QC decision affects shared reference artifacts,
 the durable fix should live or be exposed here rather than only in a downstream
 compatibility layer.
 
+## Guide Map
+
+Read the guide from concepts to operations:
+
+| Layer | Start here |
+| --- | --- |
+| Canonical cancer and gene identities | [Cancer Vocabulary](#cancer-vocabulary), [Gene Identity](#gene-identity) |
+| Expression reads, artifacts, and normalization | [Expression And Normalization](#expression-and-normalization) |
+| Clinical and epidemiological reference facts | [ICI Response](#ici-response), [Burden, TMB, Fusions, and Signatures](#burden-tmb-fusions-and-signatures) |
+| Cancer-testis antigen and panel calculations | [CTA Antigens](#cta-antigens), [Generic Antigen Panels](#generic-antigen-panels) |
+| Downloads, caches, and release metadata | [Data Management](#data-management) |
+| Historical import paths | [Compatibility Modules](#compatibility-modules) |
+
+Within each section, the intended use and primary modules come first. Detailed
+schema, provenance, fallback, and migration contracts follow.
+
 ## Cancer Vocabulary
 
 - `oncoref.cancer_ontology` — cancer-type registry, aliases, parent/child tree,
-  lineage/family groupings, molecular subtype axes, MMR/MSI classifier-status
-  semantics, matched normal tissues, source-scoped evidence resolution, and
-  display helpers.
+  lineage/family groupings, molecular subtype axes, mismatch repair (MMR) and
+  microsatellite instability (MSI) classifier-status semantics, matched normal
+  tissues, source-scoped evidence resolution, and display helpers.
 - `oncoref.cohorts` — expression/source cohort IDs, computed aggregate cohorts,
   source versions, and mixture-cohort flags.
 
 Use these when asking "what cancer type or cohort does this code mean?"
 Prefer the DataFrame-returning query helpers when code will be passed into
 other oncoref domains; they keep the result type and columns stable.
+
+### Ontology and category model
 
 The registry separates hierarchy from taxonomic level. `parent_code` is the
 tree edge, while `ontology_level` (`grouping`, `type`,
@@ -45,6 +63,8 @@ look like groupings with missing children. Differentiation and grade are
 orthogonal sparse axes: use `differentiation="NEC"` for native neuroendocrine
 lineage labels, or `grade_tier="high"` for normalized high-grade rows, without
 treating either one as a parentless cancer type.
+
+### Expression and classification backing
 
 Expression/classification backing is explicit. Use `reference_source`,
 `cancer_type_reference_source()`, `cancer_type_reference_code()`, or
@@ -76,6 +96,8 @@ registry rows whose `expression_source="computed"` and
 references, including source-scope unions such as `CRC_MSI`, `NSCLC`, `BTC`, and
 `SGC`.
 
+### Category queries
+
 For category-aware downstream code, start with
 `cancer_type_category_schema()` and `cancer_type_category_summary()`. The schema
 is the compact public vocabulary for `ontology_level`, the observed
@@ -83,6 +105,8 @@ is the compact public vocabulary for `ontology_level`, the observed
 example codes for every observed level/kind/reference-source combination. This
 is the intended replacement for ad hoc tests like "has children", "is
 mixture_cohort", or "does the code name contain MSI".
+
+### Examples
 
 ```python
 from oncoref import cancer_ontology, cohorts, expression
@@ -145,6 +169,8 @@ cancer_ontology.matched_normal_tissue_expression("COAD", genes=["ENSG00000141510
 cohorts.cohort_registry_df()
 ```
 
+### Consumer readiness
+
 `expression_reference_coverage()` is the ontology-wide readiness table for
 classifier consumers. It reports direct observed-bulk source-matrix coverage,
 computed member-union references for curated grouping/source-scope codes such as
@@ -170,6 +196,8 @@ choices in packages such as trufflepig.
 - `oncoref.genome` — optional (`pip install 'oncoref[genome]'`) pyensembl-backed
   transcript/gene lookup and transcript-to-gene aggregation for source matrices.
 
+### Resolution contract
+
 Use the gene-id helpers before building expression artifacts or joining
 downstream gene sets to oncoref references. `canonical_gene_id()` is the primary
 any-identifier entry point for the shipped ENSG + symbol/synonym space: it
@@ -187,6 +215,8 @@ Ensembl-alias coverage explicit for migration audits, including non-unique
 symbols and missing-symbol rows. They do not claim that RefSeq or UniProt
 coverage is complete.
 
+### Examples
+
 ```python
 from oncoref import canonical_gene_id, canonical_gene_symbol, display_gene_name, gene_ids
 
@@ -200,12 +230,16 @@ gene_ids.gene_identifier_mapping_summary()
 ## ICI Response
 
 - `oncoref.ici_response` — checkpoint-inhibitor response anchors, anti-PD-1
-  shortcuts, regimen-aware lookups, extracted endpoint estimates, and pooled
-  response summaries.
+  shortcuts, regimen-aware lookups, extracted objective response rate (ORR)
+  estimates, and pooled response summaries.
+
+### Regimen selection
 
 `DEFAULT_ICI_REGIMEN_PRIORITY` is the unpinned regimen priority
 (`PD-1`, then `PD-L1`, then `PD-1+CTLA-4`). The older
 `REGIMEN_FALLBACK` name remains available in `oncoref.ici` for compatibility.
+
+### Examples
 
 ```python
 from oncoref import ici_response
@@ -215,6 +249,8 @@ ici_response.best_available_ici_response("SARC_ASPS")
 ici_response.ici_response_by_regimen("SKCM")
 ici_response.ici_response_estimates_df()
 ```
+
+### Evidence rows
 
 `ici_response_estimates_df()` is the auditable long table behind the compact
 ORR anchors. Each row has a stable `estimate_id`; compact
@@ -229,9 +265,9 @@ paper/table/supplement locator is audited row by row.
 
 A cancer-testis antigen (CTA) is encoded by a gene that is normally restricted
 to reproductive tissues but can be reactivated in tumors. In oncoref, a
-candidate is called a CTA by an explicit HPA normal-tissue expression rule; the
-call is not evidence that its antigen is presented by MHC or that it is a
-validated therapy target.
+candidate is called a CTA by an explicit Human Protein Atlas (HPA) normal-tissue
+expression rule; the call is not evidence that its antigen is presented by the
+major histocompatibility complex (MHC) or that it is a validated therapy target.
 
 - `oncoref.cta` — CTA definition, HPA restriction tiers, axes, aliases, and gene
   ID/name sets. Strict helpers such as `cta_gene_names()` and
@@ -281,6 +317,14 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
 
 ## Expression And Normalization
 
+Expression readers are the stable downstream surface. Builder, registry, and
+engine modules produce and audit those artifacts; they are separated below so
+read-time choices do not get mixed with source-ingestion details.
+Expression values use transcripts per million (TPM) unless a section states a
+different unit.
+
+### Reader APIs
+
 - `oncoref.expression` — read-time accessors for per-sample expression,
   percentile vectors, representative samples, within-sample top fractions, and
   pan-cancer reference tables. `sample_expression_qc` reports per-sample
@@ -303,6 +347,9 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   floors as hard evidence only where `recommended_for_absolute_tpm_floor` is true;
   microarray/proxy or otherwise non-linear sources stay visible as warning/rank
   calibration inputs, not vetoes.
+
+### Builder APIs
+
 - `oncoref.expression_builders` — build-time ingestion and artifact cores used by
   data-bundle generation scripts. `GeoMatrixSource` /
   `build_source_matrices` own the generic supplementary-matrix path from raw
@@ -349,6 +396,9 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   strict QC-pass samples only through explicit source-aware fallbacks recorded in
   the build metadata, and clip invalid negative source expression values to zero
   with per-cohort counts.
+
+### Registry and low-level APIs
+
 - `oncoref.expression_registry` — source-registry inspection helpers over the
   bundled `expression_sources.yaml`. Use `expression_source_registry_entries()`
   for the full raw YAML dictionaries, `expression_source_registry_entries(source_type="geo-matrix")`
@@ -374,6 +424,9 @@ antigen_coverage.greedy_antigen_coverage("LUAD", gene_ids={"ENSG00000141510"})
   Use `source_matrices.sample_qc(code)` for the live source-matrix QC audit and
   `source_matrices.sample_qc_manifest(...)` for the optional generated-bundle QC
   manifest that records which samples fed derived artifacts.
+
+### Normalization API
+
 - `oncoref.normalization` — TPM conversion, clean TPM, technical-RNA filtering,
   log transforms, percentile ranks, and housekeeping normalization.
 
@@ -381,6 +434,8 @@ The normalization helpers are intended to be reusable directly. Expression
 accessors and bundles are also reusable, but downstream packages may keep their
 own packaged expression artifacts until row-set, value, provenance, and QC
 contracts are parity-clean for the specific accessor they want to replace.
+
+### Pan-cancer table
 
 `expression.pan_cancer_expression()` defaults to oncoref's entity-first schema:
 HPA normal tissue columns are `<tissue>_nTPM_raw`, TCGA source/provenance
@@ -394,6 +449,8 @@ grouping/source-scope references (`NET`, `CRC`, `NSCLC`, `BTC`, `SGC`) by poolin
 the selected `cancer-reference-expression` summary rows with n-sample weights.
 Existing directly sourced columns, including `SARC` and `OV`, keep their current
 source-table behavior.
+
+### Cohort reference expression
 
 `expression.cancer_reference_expression()` returns cohort-level tumor reference
 expression with stable long or wide output. It accepts canonical cancer codes,
@@ -453,6 +510,8 @@ Set at most one. These modes sum `expression`, `q1`, and `q3` in linear TPM
 space inside each source context and leave wide output in the historical
 `Ensembl_Gene_ID`, `Symbol`, value-column shape.
 
+### Availability and missing data
+
 Use `expression.cancer_reference_expression_availability()` before delegating a
 downstream reference-expression accessor that must distinguish unavailable
 oncoref artifacts from empty gene filters. It returns one row per requested
@@ -464,6 +523,8 @@ missing rows in `df.attrs["missing_requests"]`; `on_missing="raise"` fails fast
 for required cohorts. `include_request_metadata=True` adds request/availability
 columns to long expression output, which is useful when a requested aggregate
 expands to child expression cohorts.
+
+### Derived artifact contracts
 
 Representative and percentile artifact readers have explicit downstream-facing
 contracts:
@@ -541,6 +602,8 @@ contracts:
   need to distinguish unavailable upstream data from private downstream fallback
   data.
 
+### Bundle contents and gene-universe parity
+
 The QC-policy expression bundle ships representative, percentile,
 within-sample, CTA-scope proteoform percentile, CTA-scope proteoform
 within-sample, sample-QC, and build-metadata artifacts. Non-shipped proteoform
@@ -577,6 +640,8 @@ oncoref-only technical-extra ENSG IDs for a product/cohort filter. This surface 
 intentionally provenance: it makes differences explicit for migration code, but
 does not synthesize missing expression rows or alter artifact values.
 
+### Clean TPM compartments
+
 Clean TPM has one public compartment contract:
 
 - `clean-tpm-censored-genes.csv:category == "ribosomal_protein"` — 16%
@@ -594,6 +659,8 @@ gene_families.clean_tpm_ribosomal_gene_ids()
 gene_families.clean_tpm_other_technical_gene_ids()
 gene_families.clean_tpm_censored_gene_ids()
 ```
+
+### Housekeeping normalization
 
 For clean-TPM housekeeping denominators, use the biological HPA-stable panel:
 
@@ -669,7 +736,12 @@ but it is not the clean-TPM biological denominator.
 
 ## Data Management
 
+### Dataset catalog
+
 - `oncoref.catalog` — unified dataset inventory and fetch/status/path operations.
+
+### Expression bundle
+
 - `oncoref.data_bundle` — heavy expression bundle cache. Use
   `data_bundle.bundle_contract()` to inspect the downstream-stable package/data
   version linkage, release asset URLs, cache environment variables, completion
@@ -695,6 +767,9 @@ but it is not the clean-TPM biological denominator.
   prints the composed dependency state, and `oncoref data release-manifest
   [oncoref|pirlygenes]` prints only the validated release manifest/checksum
   metadata.
+
+### HPA data
+
 - `oncoref.reference_data` / `oncoref.hpa` — HPA reference-data cache and HPA
   tissue/cell-type accessors.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,32 +1,55 @@
 # oncoref
 
 `oncoref` is the base-layer package for shared cancer reference data:
-cancer-type ontology, cohorts, expression, clean-TPM normalization, TMB,
-incidence/mortality, ICI response, HPA normal-tissue expression, and
-HPA-derived cancer-testis antigen references.
+cancer-type ontology, cohorts, expression, clean transcripts-per-million (TPM)
+normalization, tumor mutational burden (TMB), incidence/mortality,
+immune-checkpoint inhibitor (ICI) response, Human Protein Atlas (HPA)
+normal-tissue expression, and HPA-derived cancer-testis antigen references.
 
 Downstream packages such as [pirlygenes](https://github.com/pirl-unc/pirlygenes)
 and [trufflepig](https://github.com/pirl-unc/trufflepig) should delegate
 parity-clean shared primitives here, but they keep different kinds of work:
 pirlygenes owns curated gene sets and panels, while trufflepig owns per-sample
-interpretation and rule firing.
+interpretation, quality-control (QC) narration, and rule firing.
 
 Use this page as the quick orientation. The [API guide](api.md) is the detailed
 module map, with examples and notes about compatibility modules.
 
+## Install
+
+```bash
+pip install oncoref
+```
+
 ## Stack Boundary
 
 - **oncoref**: empirical base facts and canonical identifiers. Use it for cancer
-  codes, gene IDs, reference expression/normalization, epidemiology, TMB, ICI/aPD1
-  response, HPA normal tissue, and source-anchored cancer-testis antigen (CTA)
-  facts. If a row has an `n`, confidence interval, source cohort, or PMID/DOI
-  anchoring a measurement, it usually belongs here.
+  codes, gene IDs, reference expression/normalization, epidemiology, TMB,
+  ICI/anti-PD-1 response, HPA normal tissue, and source-anchored cancer-testis
+  antigen (CTA) facts. If a row has an `n`, confidence interval, source cohort,
+  or PMID/DOI anchoring a measurement, it usually belongs here.
 - **pirlygenes**: curated gene selections. Use it for lineage/family/compartment
   panels, discriminators, surfaceome, TME and stem-cell markers, response
   signature panels, target-to-therapy registries, and other purpose-specific
   gene sets keyed to oncoref IDs.
 - **trufflepig**: per-sample application. Use it for sample QC narration,
   library-prep/source warnings, deconvolution, scoring, and tumor-sample rules.
+
+## Data Model
+
+Three distinctions keep oncoref results interpretable:
+
+1. A cancer ontology code, an expression cohort, and a clinical evidence scope
+   are related but not interchangeable. Registry fields state whether a code has
+   its own cohort, a computed member union, a parent fallback, or no expression
+   backing.
+2. Small reference and provenance tables ship in the Python wheel. Large
+   expression matrices and HPA datasets live in versioned download caches.
+3. Availability and eligibility are explicit. Accessors distinguish a missing
+   artifact, a QC-ineligible reference, and a valid empty gene selection.
+
+Public results use canonical cancer codes and Ensembl gene IDs so downstream
+packages can join domains without maintaining private name mappings.
 
 ## Start Here
 
@@ -45,8 +68,8 @@ from oncoref import cancer_ontology, ici_response
 crc_msi = cancer_ontology.cancer_type_records(subtype_group="MSI", under="CRC")
 crc_msi[["code", "parent_code", "ontology_level", "ontology_kind", "evidence_source_code"]]
 
-# MMR/MSI classifier queries keep positive, negative, and confounder classes
-# explicit, and can be restricted to direct expression-backed codes.
+# Mismatch repair (MMR) / microsatellite instability (MSI) queries keep
+# positive, negative, and confounder classes explicit.
 cancer_ontology.mmrd_cancer_codes(expression_only=True)
 cancer_ontology.mmr_confounder_cancer_codes()
 
@@ -67,9 +90,3 @@ ici_response.best_available_ici_response("COAD_MSI")
 | Other references | [`oncoref.tmb`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.incidence`](api.md#burden-tmb-fusions-and-signatures), [`oncoref.fusions`](api.md#burden-tmb-fusions-and-signatures) | TMB, incidence/mortality burden, defining fusions |
 | Legacy compatibility | [`oncoref.response_signatures`](api.md#burden-tmb-fusions-and-signatures) | Transitional historical response-signature surface; new or extended therapy-signature panels belong in pirlygenes |
 | Data management | [`oncoref.catalog`](api.md#data-management), [`oncoref.data_bundle`](api.md#data-management), [`oncoref.reference_data`](api.md#data-management), [`oncoref.hpa`](api.md#data-management) | Dataset inventory, download/cache status, HPA reference data |
-
-## Install
-
-```bash
-pip install oncoref
-```

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.151"
+__version__ = "1.8.152"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ oncoref = "oncoref.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/pirl-unc/oncoref"
+Documentation = "https://pirl-unc.github.io/oncoref/"
 Repository = "https://github.com/pirl-unc/oncoref"
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Summary
- make the README an orientation and quick-start document instead of a second exhaustive API reference
- explain the stack boundary, canonical identity model, data tiers, provenance, and missing-data semantics before examples
- add a task-oriented domain map and stable deployed-documentation links
- organize the API guide into explicit ontology, reader, builder, registry, availability, artifact, parity, normalization, and cache sections
- expand domain acronyms at first use, including CTA, HPA, TPM, MMR/MSI, ORR, MHC, and QC
- expose the documentation site in package metadata
- bump package version to 1.8.152; the data bundle remains 5.23.12

## Verification
- `mkdocs build --strict`
- `ruff check oncoref tests`
- `ruff format --check oncoref tests`
- 12 focused API/release/base-layer tests passed
- isolated wheel build succeeded with setuptools 83
- `twine check` passed