### PR TITLE
Fix CTA reproductive RNA agreement

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -269,6 +269,14 @@ candidate is called a CTA by an explicit Human Protein Atlas (HPA) normal-tissue
 expression rule; the call is not evidence that its antigen is presented by the
 major histocompatibility complex (MHC) or that it is a validated therapy target.
 
+### Restriction synthesis
+
+`synthesize_restriction()` prefers the HPA protein restriction when protein data
+exist and otherwise uses the RNA restriction. Confidence increases when the
+modalities agree. The broad RNA call `REPRODUCTIVE` supports `TESTIS`,
+`PLACENTAL`, or `REPRODUCTIVE` protein calls; it never supports a `SOMATIC`
+protein call.
+
 - `oncoref.cta` — CTA definition, HPA restriction tiers, axes, aliases, and gene
   ID/name sets. Strict helpers such as `cta_gene_names()` and
   `cta_filtered_gene_names()` preserve the HPA reproductive-restriction default;

--- a/oncoref/cta.py
+++ b/oncoref/cta.py
@@ -97,6 +97,7 @@ NON_CTA_EXCLUDED_GENE_IDS: frozenset[str] = _non_cta_excluded_gene_ids()
 _PASSES_FILTERS_COLUMN = "passes_filters"
 _LEGACY_FILTERED_COLUMN = "filtered"
 _NO_PROTEIN_RELIABILITY = {"no data", "nan", ""}
+_REPRODUCTIVE_RESTRICTION_LABELS = frozenset({"TESTIS", "PLACENTAL", "REPRODUCTIVE"})
 _CANONICAL_ALIAS_OVERRIDES: dict[str, str] = {
     "NYESO1": "CTAG1B",
     "ESO1": "CTAG1B",
@@ -106,6 +107,20 @@ _CANONICAL_ALIAS_OVERRIDES: dict[str, str] = {
 def _normalize_alias(name: object) -> str:
     """Case- and punctuation-insensitive key for CTA symbols and aliases."""
     return "".join(ch for ch in str(name).upper() if ch.isalnum())
+
+
+def _rna_restriction_agrees(selected_restriction: str, rna_restriction: str) -> bool:
+    """Whether an RNA call supports the selected HPA restriction.
+
+    Exact calls agree. The broader RNA label ``REPRODUCTIVE`` also supports a
+    more specific reproductive protein call, but never a ``SOMATIC`` call.
+    """
+    if rna_restriction == selected_restriction:
+        return True
+    return (
+        rna_restriction == "REPRODUCTIVE"
+        and selected_restriction in _REPRODUCTIVE_RESTRICTION_LABELS
+    )
 
 
 def synthesize_restriction(row) -> tuple[str, str]:
@@ -140,8 +155,7 @@ def synthesize_restriction(row) -> tuple[str, str]:
             score += 0.5
     if rna_has_data:
         sources += 1
-        rna_agrees = rna_r == tissue or (rna_r == "REPRODUCTIVE" and protein_has_data)
-        if rna_agrees:
+        if _rna_restriction_agrees(tissue, rna_r):
             score += 1.0
             if rna_level == "STRICT":
                 score += 0.5

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.152"
+__version__ = "1.8.153"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/test_cta.py
+++ b/tests/test_cta.py
@@ -128,8 +128,7 @@ def test_shipped_restriction_is_hpa_only_synthesis():
 
 
 def test_synthesize_restriction_drops_ms():
-    # A protein-SOMATIC row is SOMATIC regardless of any ms_restriction value —
-    # confirms the synthesis ignores MS columns entirely.
+    # The synthesis ignores MS columns entirely.
     row = {
         "protein_restriction": "TESTIS",
         "protein_reliability": "Enhanced",
@@ -140,6 +139,27 @@ def test_synthesize_restriction_drops_ms():
     tissue, conf = cta.synthesize_restriction(row)
     assert tissue == "TESTIS"
     assert conf == "HIGH"  # protein(1.5)+rna-agree(1.5) over 2 sources = 1.5 >= 1.2
+
+
+def test_reproductive_rna_does_not_agree_with_somatic_protein():
+    row = {
+        "protein_restriction": "SOMATIC",
+        "protein_reliability": "Enhanced",
+        "rna_restriction": "REPRODUCTIVE",
+        "rna_restriction_level": "STRICT",
+    }
+    assert cta.synthesize_restriction(row) == ("SOMATIC", "LOW")
+
+
+def test_reproductive_rna_agrees_with_reproductive_protein():
+    for protein_restriction in ("TESTIS", "PLACENTAL", "REPRODUCTIVE"):
+        row = {
+            "protein_restriction": protein_restriction,
+            "protein_reliability": "Enhanced",
+            "rna_restriction": "REPRODUCTIVE",
+            "rna_restriction_level": "STRICT",
+        }
+        assert cta.synthesize_restriction(row) == (protein_restriction, "HIGH")
 
 
 def test_gene_id_to_name():

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,6 +1,14 @@
 from pathlib import Path
 
 
+def test_build_backend_supports_declared_pep_639_license_metadata():
+    pyproject = Path("pyproject.toml").read_text()
+
+    assert 'requires = ["setuptools>=77.0.0", "wheel"]' in pyproject
+    assert 'license = "Apache-2.0"' in pyproject
+    assert 'license-files = ["LICENSE"]' in pyproject
+
+
 def test_release_workflow_skips_deploy_sh_created_releases():
     workflow = Path(".github/workflows/release.yml").read_text()
 


### PR DESCRIPTION
## Summary
- count broad REPRODUCTIVE RNA as agreement only for reproductive protein restrictions
- regress SOMATIC discordance and preserve TESTIS/PLACENTAL agreement
- document the HPA restriction synthesis after the high-level CTA definition
- require setuptools 77+, the first release supporting the declared PEP 639 license metadata
- bump the package to 1.8.153; data bundle remains 5.23.12 because HPA regeneration produced zero cell changes

## Verification
- `pytest -q` (869 passed, 0 skipped before the packaging-only review fix)
- `python scripts/regenerate_cta_table.py` (397 rows, zero cell changes)
- isolated wheel build and `twine check`
- `mkdocs build --strict`
- `ruff check oncoref tests`
- `ruff format --check oncoref tests`

Closes #435