### PR TITLE
Gate PyPI workflow to package releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,39 @@ on:
     types: [published]
 
 jobs:
+  classify-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      publish: ${{ steps.classify.outputs.publish }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Classify release
+        id: classify
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: python scripts/pypi_release_gate.py
+
   build-and-publish:
-    if: ${{ !contains(github.event.release.body, '<!-- oncoref-deploy-pypi-published -->') }}
+    needs: classify-release
+    if: ${{ needs.classify-release.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/project/oncoref/
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout repository

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.153"
+__version__ = "1.8.154"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/scripts/pypi_release_gate.py
+++ b/scripts/pypi_release_gate.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Classify whether a GitHub release should publish the oncoref package."""
+
+from __future__ import annotations
+
+import os
+import runpy
+from pathlib import Path
+
+DEPLOY_PYPI_PUBLISHED_MARKER = "<!-- oncoref-deploy-pypi-published -->"
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_VERSION_PATH = _REPO_ROOT / "oncoref" / "version.py"
+
+
+def should_publish_to_pypi(
+    *,
+    release_tag: str,
+    release_body: str,
+    package_version: str,
+) -> bool:
+    """Return whether this is an unpublished release of the package version."""
+    package_tag = f"v{package_version}"
+    already_published = DEPLOY_PYPI_PUBLISHED_MARKER in release_body
+    return release_tag == package_tag and not already_published
+
+
+def package_version_from_source() -> str:
+    """Read the package version without importing oncoref or its dependencies."""
+    return str(runpy.run_path(str(_VERSION_PATH))["__version__"])
+
+
+def write_github_output() -> None:
+    """Write the release decision in GitHub Actions job-output format."""
+    release_tag = os.environ.get("RELEASE_TAG", "")
+    release_body = os.environ.get("RELEASE_BODY", "")
+    publish = should_publish_to_pypi(
+        release_tag=release_tag,
+        release_body=release_body,
+        package_version=package_version_from_source(),
+    )
+
+    output_path = Path(os.environ["GITHUB_OUTPUT"])
+    with output_path.open("a", encoding="utf-8") as output:
+        output.write(f"publish={str(publish).lower()}\n")
+
+
+if __name__ == "__main__":
+    write_github_output()

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,5 +1,13 @@
 from pathlib import Path
 
+import yaml
+from scripts.pypi_release_gate import (
+    DEPLOY_PYPI_PUBLISHED_MARKER,
+    package_version_from_source,
+    should_publish_to_pypi,
+    write_github_output,
+)
+
 
 def test_build_backend_supports_declared_pep_639_license_metadata():
     pyproject = Path("pyproject.toml").read_text()
@@ -9,11 +17,57 @@ def test_build_backend_supports_declared_pep_639_license_metadata():
     assert 'license-files = ["LICENSE"]' in pyproject
 
 
-def test_release_workflow_skips_deploy_sh_created_releases():
-    workflow = Path(".github/workflows/release.yml").read_text()
+def test_release_classifier_accepts_only_unpublished_package_tag():
+    package_version = "1.2.3"
+    cases = [
+        ("v1.2.3", "Package release", True),
+        ("v1.2.3", DEPLOY_PYPI_PUBLISHED_MARKER, False),
+        ("v5.23.12", "Data bundle 5.23.12", False),
+        ("source-v5.22.8", "Source matrices 5.22.8", False),
+        ("v1.2.2", "Older package release", False),
+    ]
 
-    assert "oncoref-deploy-pypi-published" in workflow
-    assert "gh-action-pypi-publish" in workflow
+    for release_tag, release_body, expected in cases:
+        assert (
+            should_publish_to_pypi(
+                release_tag=release_tag,
+                release_body=release_body,
+                package_version=package_version,
+            )
+            is expected
+        )
+
+
+def test_release_workflow_gates_pypi_job_before_build():
+    workflow = yaml.safe_load(Path(".github/workflows/release.yml").read_text())
+    jobs = workflow["jobs"]
+    classifier = jobs["classify-release"]
+    publisher = jobs["build-and-publish"]
+    classify_step = next(step for step in classifier["steps"] if step.get("id") == "classify")
+
+    assert classifier["outputs"]["publish"] == "${{ steps.classify.outputs.publish }}"
+    assert classify_step["run"] == "python scripts/pypi_release_gate.py"
+    assert publisher["needs"] == "classify-release"
+    assert publisher["if"] == "${{ needs.classify-release.outputs.publish == 'true' }}"
+    assert publisher["permissions"] == {"contents": "read", "id-token": "write"}
+    assert any(
+        step.get("uses") == "pypa/gh-action-pypi-publish@release/v1" for step in publisher["steps"]
+    )
+
+
+def test_release_classifier_writes_github_job_output(monkeypatch, tmp_path):
+    output_path = tmp_path / "github-output"
+    package_tag = f"v{package_version_from_source()}"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("RELEASE_TAG", package_tag)
+    monkeypatch.setenv("RELEASE_BODY", "Package release")
+
+    write_github_output()
+    assert output_path.read_text() == "publish=true\n"
+
+    monkeypatch.setenv("RELEASE_BODY", DEPLOY_PYPI_PUBLISHED_MARKER)
+    write_github_output()
+    assert output_path.read_text() == "publish=true\npublish=false\n"
 
 
 def test_deploy_uses_one_virtualenv_python_interpreter():


### PR DESCRIPTION
## Summary
- classify published releases against the package version at the release tag
- permit the PyPI job only for an exact package tag that lacks the deploy-published marker
- skip data bundle, source matrix, stale package, and deploy-created package releases before build/upload
- make classifier Python and publisher permissions explicit
- bump the package to 1.8.154

## Verification
- `pytest -q` (872 passed, 0 skipped)
- `pytest -q tests/test_release_workflow.py` (5 passed)
- `ruff check oncoref tests`
- `ruff format --check oncoref tests`
- focused lint/format for `scripts/pypi_release_gate.py`

Closes #437