### PR TITLE
Make Pages retry artifacts unique

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      PAGES_ARTIFACT_NAME: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -44,8 +46,11 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
+          name: ${{ env.PAGES_ARTIFACT_NAME }}
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: ${{ env.PAGES_ARTIFACT_NAME }}

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.154"
+__version__ = "1.8.155"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_docs_workflow.py
+++ b/tests/test_docs_workflow.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_pages_artifact_name_is_unique_per_run_attempt():
+    workflow = yaml.safe_load(Path(".github/workflows/docs.yml").read_text())
+    deploy_job = workflow["jobs"]["deploy"]
+    artifact_name = "github-pages-${{ github.run_id }}-${{ github.run_attempt }}"
+    upload_step = next(
+        step
+        for step in deploy_job["steps"]
+        if step.get("uses") == "actions/upload-pages-artifact@v3"
+    )
+    deploy_step = next(
+        step for step in deploy_job["steps"] if step.get("uses") == "actions/deploy-pages@v4"
+    )
+
+    assert deploy_job["env"]["PAGES_ARTIFACT_NAME"] == artifact_name
+    assert upload_step["with"]["name"] == "${{ env.PAGES_ARTIFACT_NAME }}"
+    assert deploy_step["with"]["artifact_name"] == "${{ env.PAGES_ARTIFACT_NAME }}"


### PR DESCRIPTION
## Summary
- name Pages artifacts with both GitHub run ID and run attempt
- pass the exact same name to upload-pages-artifact and deploy-pages
- add a structured workflow regression test for retry-safe artifact naming
- bump the package to 1.8.155

## Verification
- `pytest -q` (873 passed, 0 skipped)
- `pytest -q tests/test_docs_workflow.py tests/test_release_workflow.py`
- `mkdocs build --strict`
- `ruff check oncoref tests`
- `ruff format --check oncoref tests`

Closes #440