### PR TITLE
Keep artifact reference counts consistent

### DIFF
--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2697,7 +2697,9 @@ def cancer_reference_expression(
     artifact was built. Clean/log-clean modes read the shipped percentile shard;
     raw TPM is recomputed from the bounded per-code source matrix with that code's
     recorded effective policy. Long-form provenance keeps ``sample_qc="artifact"``
-    and reports the applied policy in ``sample_qc_effective``. This mode requires
+    and reports the applied policy in ``sample_qc_effective``.
+    ``n_reference_samples`` is the selected sample count used to build the returned
+    artifact, not the wider raw source-matrix count. This mode requires
     ``reference_source="artifact"``.
 
     Raw-TPM mode needs the per-sample source matrix available; pass
@@ -2896,15 +2898,11 @@ def cancer_reference_expression(
                             if col in ref.columns:
                                 part[col] = ref[col].to_numpy()
                     else:
-                        provenance = _reference_expression_provenance(
-                            code,
-                            method,
-                            sample_qc=sample_qc,
-                            sample_qc_effective=effective_sample_qc,
-                            reference_source=reference_source,
-                        )
-                        for col, value in provenance.items():
-                            part[col] = value
+                        # Availability has already applied the artifact build count
+                        # and QC policy. Reuse it so returned provenance cannot drift
+                        # back to the wider raw source-matrix metadata.
+                        for col in _REFERENCE_PROVENANCE_COLUMNS:
+                            part[col] = getattr(request_row, col)
                     for col in _REFERENCE_PROVENANCE_COLUMNS:
                         if col not in part.columns:
                             part[col] = pd.NA

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.155"
+__version__ = "1.8.156"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -396,6 +396,12 @@ def test_sparse_source_qc_release_artifacts_have_count_and_diagnostic_parity():
         reference_source="artifact",
         sample_qc="artifact",
     ).set_index("cancer_code")
+    artifact_reference = expression.cancer_reference_expression(
+        codes,
+        genes="ENSG00000141510",
+        reference_source="artifact",
+        sample_qc="artifact",
+    )
 
     provenance_path = data_bundle.find(
         "cancer-reference-expression-representatives/_provenance.csv"
@@ -412,6 +418,10 @@ def test_sparse_source_qc_release_artifacts_have_count_and_diagnostic_parity():
         assert metadata.loc[code, "sample_qc_effective"] == "pass"
         assert summary_availability.loc[code, "n_reference_samples"] == counts["pass"]
         assert artifact_availability.loc[code, "n_reference_samples"] == counts["pass"]
+        reference_rows = artifact_reference.loc[artifact_reference["cancer_code"] == code]
+        assert not reference_rows.empty
+        assert set(reference_rows["n_reference_samples"]) == {counts["pass"]}
+        assert set(reference_rows["n_samples"]) == {counts["pass"]}
         assert set(provenance.loc[provenance_codes.eq(code), "n_cohort_samples"]) == {
             counts["pass"]
         }
@@ -3323,7 +3333,7 @@ def test_artifact_build_metadata_uses_loader_source_cohort_identity():
     assert by_code.loc["CML", "build_source_cohort"] == "GEO_HEME_2022"
 
 
-def test_artifact_availability_uses_selected_build_sample_count(monkeypatch):
+def test_artifact_reference_uses_selected_build_sample_count(monkeypatch):
     metadata = pd.DataFrame(
         {
             "cancer_code": ["MCL"],
@@ -3331,10 +3341,29 @@ def test_artifact_availability_uses_selected_build_sample_count(monkeypatch):
             "n_cohort_samples": [10],
         }
     )
+    percentiles = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["E1"],
+            "Symbol": ["A"],
+            "p25": [1.0],
+            "p50": [2.0],
+            "p75": [3.0],
+        }
+    )
     monkeypatch.setattr(expression, "available_percentile_cohorts", lambda: ["MCL"])
     monkeypatch.setattr(expression, "expression_artifact_build_metadata", lambda **kwargs: metadata)
+    monkeypatch.setattr(
+        expression,
+        "cohort_gene_percentiles",
+        lambda *args, **kwargs: percentiles.copy(),
+    )
 
     availability = expression.cancer_reference_expression_availability(
+        "MCL",
+        reference_source="artifact",
+        sample_qc="artifact",
+    )
+    reference = expression.cancer_reference_expression(
         "MCL",
         reference_source="artifact",
         sample_qc="artifact",
@@ -3343,6 +3372,8 @@ def test_artifact_availability_uses_selected_build_sample_count(monkeypatch):
     assert expression.source_matrices.cohort_info("MCL")["n_samples"] == 51
     assert availability.loc[0, "n_reference_samples"] == 10
     assert availability.loc[0, "n_samples"] == 10
+    assert reference["n_reference_samples"].tolist() == [10]
+    assert reference["n_samples"].tolist() == [10]
 
 
 @pytest.mark.parametrize("invalid_count", [-1, 1.5])


### PR DESCRIPTION
## Summary
- reuse the validated availability row as the single provenance source for returned artifact references
- keep `n_reference_samples`/`n_samples` tied to the selected artifact build count rather than raw source-matrix width
- add focused and released-bundle regressions for BL=175 and SARC_PEC=60
- document the sample-count meaning and bump the package to 1.8.156; data bundle remains 5.23.12

## Verification
- `pytest -q` (873 passed, 0 skipped)
- `pytest -q tests/test_expression.py` (148 passed)
- `./lint.sh`
- all 131 available artifact cohorts: returned count equals availability, 0 mismatches

Closes #423