### PR TITLE
Move workflows to Node 24 actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -39,18 +39,18 @@ jobs:
         run: mkdocs build --strict
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           enablement: true
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           name: ${{ env.PAGES_ARTIFACT_NAME }}
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
         with:
           artifact_name: ${{ env.PAGES_ARTIFACT_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
       publish: ${{ steps.classify.outputs.publish }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -40,10 +40,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -79,10 +79,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -93,7 +93,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Cache Ensembl genome data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .ci-cache/pyensembl
           key: pyensembl-v2-human93

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.156"
+__version__ = "1.8.157"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_docs_workflow.py
+++ b/tests/test_docs_workflow.py
@@ -10,10 +10,12 @@ def test_pages_artifact_name_is_unique_per_run_attempt():
     upload_step = next(
         step
         for step in deploy_job["steps"]
-        if step.get("uses") == "actions/upload-pages-artifact@v3"
+        if step.get("uses", "").startswith("actions/upload-pages-artifact@")
     )
     deploy_step = next(
-        step for step in deploy_job["steps"] if step.get("uses") == "actions/deploy-pages@v4"
+        step
+        for step in deploy_job["steps"]
+        if step.get("uses", "").startswith("actions/deploy-pages@")
     )
 
     assert deploy_job["env"]["PAGES_ARTIFACT_NAME"] == artifact_name

--- a/tests/test_workflow_actions.py
+++ b/tests/test_workflow_actions.py
@@ -1,0 +1,39 @@
+import re
+from pathlib import Path
+
+import yaml
+
+NODE24_ACTION_MAJORS = {
+    "actions/cache": 5,
+    "actions/checkout": 6,
+    "actions/configure-pages": 6,
+    "actions/deploy-pages": 5,
+    "actions/setup-python": 6,
+    "actions/upload-pages-artifact": 5,
+}
+
+
+def test_workflows_use_node24_action_generations():
+    observed = {action: [] for action in NODE24_ACTION_MAJORS}
+
+    for path in sorted(Path(".github/workflows").glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text())
+        for job_name, job in workflow["jobs"].items():
+            for step in job.get("steps", []):
+                uses = step.get("uses", "")
+                action, separator, version = uses.partition("@")
+                if action not in observed:
+                    continue
+                assert separator, f"{path}:{job_name} has an unversioned {action} action"
+                observed[action].append((path, job_name, version))
+
+    for action, minimum_major in NODE24_ACTION_MAJORS.items():
+        assert observed[action], f"no workflow uses expected action {action}"
+        for path, job_name, version in observed[action]:
+            match = re.fullmatch(r"v(\d+)(?:\.\d+\.\d+)?", version)
+            assert match, f"{path}:{job_name} uses an unrecognized {action} version: {version}"
+            actual_major = int(match.group(1))
+            assert actual_major >= minimum_major, (
+                f"{path}:{job_name} uses {action}@{version}; "
+                f"Node 24 requires v{minimum_major} or newer"
+            )


### PR DESCRIPTION
## Summary
- upgrade checkout/setup-python/cache to their supported Node 24 generations across Tests, Docs, and Release
- upgrade configure-pages, upload-pages-artifact, and deploy-pages to their Node 24 releases
- add a structured YAML regression guard for every affected action
- keep the Pages artifact wiring test independent from action versions
- bump the package to 1.8.157; data bundle remains 5.23.12

## Verification
- `pytest -q` (874 passed, 0 skipped)
- `pytest -q tests/test_workflow_actions.py tests/test_docs_workflow.py tests/test_release_workflow.py`
- `./lint.sh`
- verified the upgraded official action definitions preserve every input used by oncoref

Closes #443