### PR TITLE
Publish source-grouped representative partitions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -397,13 +397,15 @@ different unit.
   (`--sample-qc pass`) and emits `source-matrix-sample-qc.csv` plus
   `expression-artifact-build-metadata.*` in the staging directory so bundle
   releases record which source samples fed percentiles, representatives,
-  proteoform summaries, and within-sample summaries. Representative
-  sample selection uses `representative_sample_columns` / `cohort_medoids` on the
-  biological clean-TPM view, then stores the selected samples' full
-  clean_tpm_16_9_75 vectors. Release builds retain curated cohorts that have no
-  strict QC-pass samples only through explicit source-aware fallbacks recorded in
-  the build metadata, and clip invalid negative source expression values to zero
-  with per-cohort counts.
+  proteoform summaries, and within-sample summaries. The rebuild also assigns
+  every representative source group to the released train/validation partition
+  and records the policy, role counts, and per-cohort validation coverage in the
+  same metadata. Representative sample selection uses
+  `representative_sample_columns` / `cohort_medoids` on the biological clean-TPM
+  view, then stores the selected samples' full clean_tpm_16_9_75 vectors. Release
+  builds retain curated cohorts that have no strict QC-pass samples only through
+  explicit source-aware fallbacks recorded in the build metadata, and clip
+  invalid negative source expression values to zero with per-cohort counts.
 
 ### Registry and low-level APIs
 
@@ -532,7 +534,45 @@ for required cohorts. `include_request_metadata=True` adds request/availability
 columns to long expression output, which is useful when a requested aggregate
 expands to child expression cohorts.
 
-### Derived artifact contracts
+### Representative evaluation partitions
+
+Representative vectors are real source samples. A model trained on all of them
+must not report accuracy on those same vectors as an estimate of generalization.
+Use `expression.representative_partition_manifest()` to obtain the released
+training and evaluation assignment before fitting or benchmarking:
+
+```python
+from oncoref import representative_partition_manifest
+
+partition = representative_partition_manifest()
+train_ids = partition.loc[partition["partition_role"] == "train", "representative_id"]
+validation_ids = partition.loc[
+    partition["partition_role"].isin(["validation", "validation_external"]),
+    "representative_id",
+]
+```
+
+The physical `source_group_id`, not the displayed representative ID or cancer
+label, is the partition unit. Parent labels, subtypes, and compatibility aliases
+backed by the same sample therefore always receive one shared role:
+
+- `train` — eligible for model fitting.
+- `validation` — deterministic within-cohort holdout.
+- `validation_external` — a complete independent source project held out when a
+  cohort spans projects.
+- `audit_only` — retained for inspection but excluded from fitting and evaluation
+  because its source group is not benchmark-eligible.
+
+The ordinary within-cohort policy holds out up to two independent groups, never
+more than half of a cohort. A usual five-representative cohort therefore has
+three training and two validation groups. When a cohort spans independent source
+projects, the smallest viable project is instead held out whole and labeled
+`validation_external`. A cohort with only one eligible group remains train-only
+and reports `partition_status="insufficient_independent_groups"` instead of
+claiming validation coverage. `partition_policy_version` makes the exact
+assignment contract release-visible.
+
+### Derived artifact fields
 
 Representative and percentile artifact readers have explicit downstream-facing
 contracts:
@@ -542,9 +582,9 @@ contracts:
   source sample id and stable source-group id, source diagnosis/morphology when a
   sample has been reviewed, effective QC status/reasons, source scale class,
   linear-TPM and absolute-floor comparability flags, representative role and
-  benchmark eligibility, review evidence, cohort sample count, deterministic
-  selection rank/method/basis, artifact schema version, `DATA_VERSION`, and
-  `SOURCE_MATRIX_VERSION`.
+  benchmark eligibility, partition role/status/policy, review evidence, cohort
+  sample count, deterministic selection rank/method/basis, artifact schema
+  version, `DATA_VERSION`, and `SOURCE_MATRIX_VERSION`.
   Treehouse PolyA parent, subset, and annotation-derived cohorts share one physical
   sample namespace, so aliases of the same source vector receive the same
   `source_group_id` even when their displayed source cohorts differ.

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -203,6 +203,7 @@ from .expression import (
     proteoform_within_sample_top_fraction,
     representative_cohort_availability,
     representative_cohort_samples,
+    representative_partition_manifest,
     sample_expression_qc,
     source_matrix_sample_qc_manifest,
     within_sample_top_fraction,
@@ -338,6 +339,7 @@ from .proteoforms import (
     proteoform_symbol,
     proteoform_symbol_map,
 )
+from .representative_partitions import REPRESENTATIVE_PARTITION_POLICY_VERSION
 from .response_signatures import (
     response_signature_direction,
     response_signature_genes,
@@ -371,6 +373,7 @@ __all__ = [
     "REFERENCE_SOURCE_VALUES",
     "REGIMEN_FALLBACK",
     "REGIMEN_LABELS",
+    "REPRESENTATIVE_PARTITION_POLICY_VERSION",
     "RIBOSOMAL_PROTEIN_FRACTION",
     "SHARD_DATASETS",
     "TECHNICAL_FRACTION",
@@ -640,6 +643,7 @@ __all__ = [
     "renormalize_to_million",
     "representative_cohort_availability",
     "representative_cohort_samples",
+    "representative_partition_manifest",
     "resolve_apd1_response_source",
     "resolve_cancer_type",
     "resolve_cohort_id",

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -101,6 +101,9 @@ from .gene_ids import (
 from .gene_qc import TECHNICAL_RNA_GROUPS, classify_gene_qc
 from .load_dataset import _register_derived_cache, get_data
 from .normalization import clean_tpm, percentile_rank, tpm_to_housekeeping_normalized
+from .representative_partitions import (
+    REPRESENTATIVE_PARTITION_POLICY_VERSION as REPRESENTATIVE_PARTITION_POLICY_VERSION,
+)
 from .version import DATA_VERSION, SOURCE_MATRIX_VERSION
 
 
@@ -186,7 +189,7 @@ _REPRESENTATIVES = SHARD_DATASETS["representatives"]
 _PERCENTILES = SHARD_DATASETS["percentiles"]
 _WITHIN_SAMPLE = SHARD_DATASETS["within_sample"]
 
-REPRESENTATIVE_ARTIFACT_SCHEMA_VERSION = "representative_expression_v1"
+REPRESENTATIVE_ARTIFACT_SCHEMA_VERSION = "representative_expression_v2"
 PERCENTILE_ARTIFACT_SCHEMA_VERSION = "cohort_percentile_expression_v1"
 REFERENCE_EXPRESSION_SCHEMA_VERSION = "cancer_reference_expression_v4"
 REPRESENTATIVE_SELECTION_METHOD = "central_medoid_then_farthest_first"
@@ -337,6 +340,15 @@ _REPRESENTATIVE_PROVENANCE_COLUMNS = [
     "selection_scale_class",
     "representative_role",
     "benchmark_eligible",
+    "partition_role",
+    "partition_reason",
+    "partition_policy_version",
+    "partition_validation_target",
+    "partition_status",
+    "n_partition_train",
+    "n_partition_validation",
+    "n_partition_validation_external",
+    "n_partition_audit_only",
     "review_source",
     "review_note",
     "selection_rank",
@@ -363,10 +375,37 @@ _REPRESENTATIVE_AVAILABILITY_COLUMNS = [
     "n_qc_fail",
     "representative_role",
     "benchmark_eligible",
+    "partition_policy_version",
+    "partition_validation_target",
+    "partition_status",
+    "n_partition_train",
+    "n_partition_validation",
+    "n_partition_validation_external",
+    "n_partition_audit_only",
     "selection_scale_class",
     "selection_method",
     "selection_basis",
     "availability_reason",
+]
+
+_REPRESENTATIVE_PARTITION_COLUMNS = [
+    "cancer_code",
+    "representative_id",
+    "source_group_id",
+    "source_cohort",
+    "source_project",
+    "source_sample",
+    "representative_role",
+    "benchmark_eligible",
+    "partition_role",
+    "partition_reason",
+    "partition_policy_version",
+    "partition_validation_target",
+    "partition_status",
+    "n_partition_train",
+    "n_partition_validation",
+    "n_partition_validation_external",
+    "n_partition_audit_only",
 ]
 
 
@@ -651,6 +690,10 @@ def _attach_representative_provenance(long: pd.DataFrame, root: Path) -> pd.Data
         "source_sample",
         "source_group_id",
         "representative_role",
+        "partition_role",
+        "partition_reason",
+        "partition_policy_version",
+        "partition_status",
         "review_source",
         "review_note",
     ):
@@ -662,6 +705,11 @@ def _attach_representative_provenance(long: pd.DataFrame, root: Path) -> pd.Data
         "n_qc_pass",
         "n_qc_warn",
         "n_qc_fail",
+        "partition_validation_target",
+        "n_partition_train",
+        "n_partition_validation",
+        "n_partition_validation_external",
+        "n_partition_audit_only",
     ):
         if col not in long.columns:
             long[col] = pd.NA
@@ -910,6 +958,19 @@ def representative_cohort_availability(
                 "n_qc_fail": _one_provenance_value(group, "n_qc_fail"),
                 "representative_role": role,
                 "benchmark_eligible": benchmark,
+                "partition_policy_version": _one_provenance_value(
+                    group, "partition_policy_version"
+                ),
+                "partition_validation_target": _one_provenance_value(
+                    group, "partition_validation_target"
+                ),
+                "partition_status": _one_provenance_value(group, "partition_status"),
+                "n_partition_train": _one_provenance_value(group, "n_partition_train"),
+                "n_partition_validation": _one_provenance_value(group, "n_partition_validation"),
+                "n_partition_validation_external": _one_provenance_value(
+                    group, "n_partition_validation_external"
+                ),
+                "n_partition_audit_only": _one_provenance_value(group, "n_partition_audit_only"),
                 "selection_scale_class": _one_provenance_value(group, "selection_scale_class"),
                 "selection_method": REPRESENTATIVE_SELECTION_METHOD,
                 "selection_basis": REPRESENTATIVE_SELECTION_BASIS,
@@ -924,6 +985,52 @@ def representative_cohort_availability(
         if expected is not None:
             out = out[out[col].map(_optional_bool) == bool(expected)].copy()
     out.attrs["schema_version"] = REPRESENTATIVE_ARTIFACT_SCHEMA_VERSION
+    out.attrs["data_version"] = DATA_VERSION
+    out.attrs["source_matrix_version"] = SOURCE_MATRIX_VERSION
+    return out.reset_index(drop=True)
+
+
+def representative_partition_manifest(
+    cancer_types: str | Iterable[str] | None = None,
+    *,
+    representative_id_style: str = "pirlygenes",
+) -> pd.DataFrame:
+    """One machine-readable train/validation row per representative vector.
+
+    ``source_group_id`` is the leakage boundary: every parent, subtype, or alias
+    row backed by the same physical sample has one shared partition role.
+    ``validation_external`` holds out a complete independent source project;
+    ``audit_only`` keeps reviewed or QC-fallback vectors out of both model fitting
+    and evaluation. Cohorts without two independent eligible groups remain
+    ``train`` and report ``partition_status="insufficient_independent_groups"``.
+    """
+
+    _validate_representative_id_style(representative_id_style)
+    root = _shard_dir(_REPRESENTATIVES)
+    provenance = _representative_provenance(root)
+
+    if cancer_types is not None and not provenance.empty:
+        requested = set(_resolve_cancer_types(cancer_types, expand_aggregates=True))
+        provenance = provenance[provenance["cancer_code"].isin(requested)].copy()
+
+    for column in _REPRESENTATIVE_PARTITION_COLUMNS:
+        if column not in provenance:
+            provenance[column] = pd.NA
+    out = provenance[_REPRESENTATIVE_PARTITION_COLUMNS].copy()
+    out["representative_id"] = out["representative_id"].map(
+        lambda value: _representative_id_for_style(
+            value,
+            style=representative_id_style,
+        )
+    )
+    out = out.sort_values(["cancer_code", "representative_id"], kind="stable")
+    policy_versions = [
+        str(value) for value in out["partition_policy_version"].dropna().unique() if str(value)
+    ]
+    out.attrs["schema_version"] = REPRESENTATIVE_ARTIFACT_SCHEMA_VERSION
+    out.attrs["partition_policy_version"] = (
+        policy_versions[0] if len(policy_versions) == 1 else ("mixed" if policy_versions else None)
+    )
     out.attrs["data_version"] = DATA_VERSION
     out.attrs["source_matrix_version"] = SOURCE_MATRIX_VERSION
     return out.reset_index(drop=True)
@@ -1484,7 +1591,7 @@ _PER_SAMPLE_NORMALIZE = ("tpm_raw", "tpm_clean", "tpm_clean_log1p", "tpm_clean_h
 _SAMPLE_QC_MODES = ("all", "pass", "pass_or_warn")
 _ARTIFACT_SAMPLE_QC_MODES = ("artifact", *_SAMPLE_QC_MODES)
 SAMPLE_EXPRESSION_QC_POLICY_VERSION = "sample_expression_qc_v2"
-EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION = "expression_artifact_build_metadata_v2"
+EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION = "expression_artifact_build_metadata_v3"
 SOURCE_MATRIX_SAMPLE_QC_MANIFEST_PATH = "source-matrix-sample-qc.csv"
 EXPRESSION_ARTIFACT_BUILD_METADATA_PATH = "expression-artifact-build-metadata.csv"
 EXPRESSION_ARTIFACT_BUILD_METADATA_JSON_PATH = "expression-artifact-build-metadata.json"
@@ -1541,6 +1648,13 @@ _EXPRESSION_ARTIFACT_BUILD_METADATA_COLUMNS = [
     "n_qc_pass",
     "n_qc_warn",
     "n_qc_fail",
+    "partition_policy_version",
+    "partition_validation_target",
+    "partition_status",
+    "n_partition_train",
+    "n_partition_validation",
+    "n_partition_validation_external",
+    "n_partition_audit_only",
 ]
 DEFAULT_MIN_DETECTED_GENES_FOR_QC = 5000
 DEFAULT_MIN_HOUSEKEEPING_GENES_FOR_QC = 10
@@ -2253,8 +2367,8 @@ def expression_artifact_build_metadata(
     expression artifact loaders. ``build_source_cohort`` preserves the cohort label
     physically recorded when the bundle was built, which can differ in older bundles.
     The remaining fields record the selected source matrix, QC policy, selected sample
-    count, and QC pass/warn/fail counts. Missing current-bundle metadata returns a
-    schema-stable empty frame by default.
+    count, QC pass/warn/fail counts, and representative partition coverage. Missing
+    current-bundle metadata returns a schema-stable empty frame by default.
     """
     mode = _validate_metadata_on_missing(on_missing)
     path = _optional_bundle_metadata_path(
@@ -2430,7 +2544,8 @@ def expression_artifact_build_summary(
 ) -> dict:
     """Read bundle-level expression artifact build metadata.
 
-    Returns the JSON summary emitted beside the per-cohort metadata CSV. The summary
+    Returns the JSON summary emitted beside the per-cohort metadata CSV, including the
+    representative partition policy and unique source-group role counts. The summary
     remains optional until a regenerated data bundle ships it; callers that require it
     should pass ``on_missing="raise"``.
     """

--- a/oncoref/representative_partitions.py
+++ b/oncoref/representative_partitions.py
@@ -1,0 +1,323 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Leakage-resistant train/validation roles for representative expression vectors."""
+
+from __future__ import annotations
+
+import hashlib
+from collections import defaultdict
+
+import pandas as pd
+
+REPRESENTATIVE_PARTITION_POLICY_VERSION = "source_grouped_3_train_2_validation_v1"
+REPRESENTATIVE_PARTITION_ROLES = (
+    "train",
+    "validation",
+    "validation_external",
+    "audit_only",
+)
+REPRESENTATIVE_PARTITION_COHORT_COLUMNS = (
+    "cancer_code",
+    "partition_policy_version",
+    "partition_validation_target",
+    "partition_status",
+    "n_partition_train",
+    "n_partition_validation",
+    "n_partition_validation_external",
+    "n_partition_audit_only",
+)
+
+_REQUIRED_COLUMNS = {
+    "cancer_code",
+    "source_group_id",
+    "benchmark_eligible",
+}
+
+
+def _stable_order(value: str) -> tuple[str, str]:
+    digest = hashlib.sha256(
+        f"{REPRESENTATIVE_PARTITION_POLICY_VERSION}:{value}".encode()
+    ).hexdigest()
+    return digest, value
+
+
+def _source_project(source_group_id: str) -> str:
+    """Return the stable source namespace embedded in a source-group ID."""
+
+    return source_group_id.split(":", 1)[0]
+
+
+def _validation_target(n_groups: int) -> int:
+    """Hold out up to two groups, never more than half of a cohort."""
+
+    return min(2, n_groups // 2)
+
+
+def _group_memberships(cohort_groups: dict[str, set[str]]) -> dict[str, set[str]]:
+    memberships: dict[str, set[str]] = defaultdict(set)
+    for cancer_code, groups in cohort_groups.items():
+        for group_id in groups:
+            memberships[group_id].add(cancer_code)
+    return dict(memberships)
+
+
+def _validation_count(groups: set[str], roles: dict[str, str]) -> int:
+    return sum(roles[group_id].startswith("validation") for group_id in groups)
+
+
+def _can_hold_out(
+    candidate_groups: set[str],
+    *,
+    cohort_groups: dict[str, set[str]],
+    memberships: dict[str, set[str]],
+    roles: dict[str, str],
+    enforce_targets: bool,
+) -> bool:
+    affected_cohorts = {
+        cancer_code for group_id in candidate_groups for cancer_code in memberships[group_id]
+    }
+    for cancer_code in affected_cohorts:
+        groups = cohort_groups[cancer_code]
+        held_out = {
+            group_id
+            for group_id in groups
+            if roles[group_id].startswith("validation") or group_id in candidate_groups
+        }
+        if len(held_out) >= len(groups):
+            return False
+        if enforce_targets and len(held_out) > _validation_target(len(groups)):
+            return False
+    return True
+
+
+def _assign_external_projects(
+    *,
+    cohort_groups: dict[str, set[str]],
+    memberships: dict[str, set[str]],
+    roles: dict[str, str],
+) -> None:
+    """Hold out one complete source project when a cohort spans independent projects."""
+
+    for cancer_code in sorted(cohort_groups):
+        groups = cohort_groups[cancer_code]
+        by_project: dict[str, set[str]] = defaultdict(set)
+        for group_id in groups:
+            by_project[_source_project(group_id)].add(group_id)
+        if len(by_project) < 2:
+            continue
+
+        projects = sorted(
+            by_project,
+            key=lambda project: (len(by_project[project]), _stable_order(project)),
+        )
+        for project in projects:
+            candidate_groups = by_project[project]
+            if not _can_hold_out(
+                candidate_groups,
+                cohort_groups=cohort_groups,
+                memberships=memberships,
+                roles=roles,
+                enforce_targets=False,
+            ):
+                continue
+            for group_id in candidate_groups:
+                roles[group_id] = "validation_external"
+            break
+
+
+def _assign_stratified_validation(
+    *,
+    cohort_groups: dict[str, set[str]],
+    memberships: dict[str, set[str]],
+    roles: dict[str, str],
+) -> None:
+    """Fill each cohort's validation target without splitting shared source groups."""
+
+    cohort_order = sorted(cohort_groups, key=lambda code: (len(cohort_groups[code]), code))
+    for cancer_code in cohort_order:
+        groups = cohort_groups[cancer_code]
+        needed = _validation_target(len(groups)) - _validation_count(groups, roles)
+        candidates = sorted(
+            (group_id for group_id in groups if roles[group_id] == "train"),
+            key=_stable_order,
+        )
+        for group_id in candidates:
+            if needed <= 0:
+                break
+            if not _can_hold_out(
+                {group_id},
+                cohort_groups=cohort_groups,
+                memberships=memberships,
+                roles=roles,
+                enforce_targets=True,
+            ):
+                continue
+            roles[group_id] = "validation"
+            needed -= 1
+
+
+def _cohort_partition_summary(
+    cancer_code: str,
+    *,
+    all_cohort_groups: dict[str, set[str]],
+    cohort_groups: dict[str, set[str]],
+    roles: dict[str, str],
+) -> dict[str, int | str]:
+    all_groups = all_cohort_groups[cancer_code]
+    eligible_groups = cohort_groups.get(cancer_code, set())
+    target = _validation_target(len(eligible_groups))
+    n_train = sum(roles[group_id] == "train" for group_id in eligible_groups)
+    n_external = sum(roles[group_id] == "validation_external" for group_id in eligible_groups)
+    n_validation = _validation_count(eligible_groups, roles)
+    n_audit = len(all_groups - eligible_groups)
+
+    if not eligible_groups:
+        status = "no_benchmark_eligible_groups"
+    elif target == 0:
+        status = "insufficient_independent_groups"
+    elif n_validation >= target:
+        status = "available"
+    else:
+        status = "shared_group_constraints"
+
+    return {
+        "partition_validation_target": target,
+        "partition_status": status,
+        "n_partition_train": n_train,
+        "n_partition_validation": n_validation,
+        "n_partition_validation_external": n_external,
+        "n_partition_audit_only": n_audit,
+    }
+
+
+def assign_representative_partitions(provenance: pd.DataFrame) -> pd.DataFrame:
+    """Annotate representative provenance with stable, source-grouped split roles.
+
+    A physical ``source_group_id`` receives exactly one role across every parent,
+    subtype, and alias row. Benchmark-ineligible groups are audit-only. Eligible
+    cohorts hold out up to two groups, never more than half; a cohort with only one
+    independent group remains train-only and is marked as insufficient.
+    """
+
+    missing = sorted(_REQUIRED_COLUMNS - set(provenance.columns))
+    if missing:
+        raise ValueError(f"representative partition input lacks columns: {missing}")
+
+    out = provenance.copy()
+    source_group_ids = out["source_group_id"].astype("string").str.strip()
+    invalid_group_ids = (
+        source_group_ids.isna() | source_group_ids.eq("") | ~source_group_ids.str.contains(":")
+    )
+    if invalid_group_ids.any():
+        raise ValueError(
+            "representative partition input has an invalid source_group_id; "
+            "expected '<source-namespace>:<source-sample>'"
+        )
+    cancer_codes = out["cancer_code"].astype("string").str.strip()
+    if (cancer_codes.isna() | cancer_codes.eq("")).any():
+        raise ValueError("representative partition input has blank cancer_code")
+    out["source_group_id"] = source_group_ids
+    out["cancer_code"] = cancer_codes
+
+    benchmark = out["benchmark_eligible"].astype("boolean")
+    if benchmark.isna().any():
+        raise ValueError("representative partition input has unknown benchmark_eligible")
+    if out.empty:
+        out["partition_role"] = pd.Series(dtype="string")
+        out["partition_reason"] = pd.Series(dtype="string")
+        out["partition_policy_version"] = pd.Series(dtype="string")
+        for column in REPRESENTATIVE_PARTITION_COHORT_COLUMNS[2:]:
+            out[column] = pd.Series(dtype="object")
+        return out
+
+    group_eligible = benchmark.groupby(out["source_group_id"]).all().to_dict()
+    all_cohort_groups = {
+        str(code): set(group["source_group_id"])
+        for code, group in out.groupby("cancer_code", sort=True)
+    }
+    cohort_groups = {
+        code: {group_id for group_id in groups if group_eligible[group_id]}
+        for code, groups in all_cohort_groups.items()
+    }
+    cohort_groups = {code: groups for code, groups in cohort_groups.items() if groups}
+    memberships = _group_memberships(cohort_groups)
+
+    roles = {
+        group_id: ("train" if eligible else "audit_only")
+        for group_id, eligible in group_eligible.items()
+    }
+    _assign_external_projects(
+        cohort_groups=cohort_groups,
+        memberships=memberships,
+        roles=roles,
+    )
+    _assign_stratified_validation(
+        cohort_groups=cohort_groups,
+        memberships=memberships,
+        roles=roles,
+    )
+
+    summaries = {
+        cancer_code: _cohort_partition_summary(
+            cancer_code,
+            all_cohort_groups=all_cohort_groups,
+            cohort_groups=cohort_groups,
+            roles=roles,
+        )
+        for cancer_code in all_cohort_groups
+    }
+    out["partition_role"] = out["source_group_id"].map(roles)
+    out["partition_reason"] = out["partition_role"].map(
+        {
+            "train": "stable_source_group_training",
+            "validation": "stable_source_group_validation",
+            "validation_external": "independent_source_project_holdout",
+            "audit_only": "benchmark_ineligible_source_group",
+        }
+    )
+    out["partition_policy_version"] = REPRESENTATIVE_PARTITION_POLICY_VERSION
+    for column in next(iter(summaries.values())):
+        out[column] = out["cancer_code"].map(
+            {code: summary[column] for code, summary in summaries.items()}
+        )
+    return out
+
+
+def representative_partition_cohort_metadata(partitioned: pd.DataFrame) -> pd.DataFrame:
+    """Return one partition-coverage row per cohort from annotated provenance."""
+
+    missing = sorted(set(REPRESENTATIVE_PARTITION_COHORT_COLUMNS) - set(partitioned.columns))
+    if missing:
+        raise ValueError(f"partitioned representative provenance lacks columns: {missing}")
+    cohort_metadata = partitioned[list(REPRESENTATIVE_PARTITION_COHORT_COLUMNS)].drop_duplicates()
+    if cohort_metadata["cancer_code"].duplicated().any():
+        raise ValueError("partitioned representative provenance has conflicting cohort metadata")
+    return cohort_metadata.reset_index(drop=True)
+
+
+def representative_partition_build_metadata(partitioned: pd.DataFrame) -> dict:
+    """Return the bundle-level partition policy and unique source-group role counts."""
+
+    required = {"source_group_id", "partition_role"}
+    missing = sorted(required - set(partitioned.columns))
+    if missing:
+        raise ValueError(f"partitioned representative provenance lacks columns: {missing}")
+    group_roles = partitioned[list(required)].drop_duplicates()
+    if group_roles["source_group_id"].duplicated().any():
+        raise ValueError("one representative source group has conflicting partition roles")
+    role_counts = group_roles["partition_role"].value_counts().sort_index().astype(int).to_dict()
+    return {
+        "grouping_key": "source_group_id",
+        "policy_version": REPRESENTATIVE_PARTITION_POLICY_VERSION,
+        "role_counts": role_counts,
+    }

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.157"
+__version__ = "1.8.158"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins
@@ -34,7 +34,9 @@ __version__ = "1.8.157"
 # other TCGA-SARC histology cohorts instead of the generic TCGA sample cohort.
 # 5.23.12 marks the duplicated metaplastic BRCA/BRCA_Basal source vector as a
 # reviewed dual-lineage audit representative rather than ordinary benchmark truth.
-DATA_VERSION = "5.23.12"
+# 5.23.13 assigns every representative source group to a deterministic,
+# leakage-resistant train, validation, external-validation, or audit-only role.
+DATA_VERSION = "5.23.13"
 
 # Version of the per-cohort RAW source matrices (source_matrices.py). Independent of
 # DATA_VERSION: the source matrices are the unchanging raw-TPM inputs, while DATA_VERSION

--- a/scripts/build_data_tarball.sh
+++ b/scripts/build_data_tarball.sh
@@ -10,6 +10,8 @@
 #
 # Usage:
 #   scripts/build_data_tarball.sh <source-dir> [output-dir]
+#   ONCOREF_DATA_RELEASE_VERSION=5.23.13 \
+#       scripts/build_data_tarball.sh <source-dir> [output-dir]
 #
 # Then: upload <output-dir>/oncoref-data-v<DATA_VERSION>.tar.gz plus the emitted
 # .sha256 and .manifest.json files to the `v<DATA_VERSION>` release on
@@ -31,7 +33,12 @@ OUT_DIR="$(cd "${OUT_DIR%/}" && pwd)"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-DATA_VERSION="$(python -c 'from oncoref.version import DATA_VERSION; print(DATA_VERSION)')"
+CODE_DATA_VERSION="$(python -c 'from oncoref.version import DATA_VERSION; print(DATA_VERSION)')"
+DATA_VERSION="${ONCOREF_DATA_RELEASE_VERSION:-$CODE_DATA_VERSION}"
+if [[ ! "$DATA_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: data release version must have the form X.Y.Z, got '$DATA_VERSION'" >&2
+    exit 1
+fi
 PACKAGE_VERSION="$(python -c 'from oncoref.version import __version__; print(__version__)')"
 SOURCE_MATRIX_VERSION="$(python -c 'from oncoref.version import SOURCE_MATRIX_VERSION; print(SOURCE_MATRIX_VERSION)')"
 BUILDER_COMMIT="$(git rev-parse HEAD 2>/dev/null || true)"
@@ -124,6 +131,7 @@ if build_json.exists():
         "n_cohort_samples": build_metadata.get("n_cohort_samples"),
         "sample_qc_fallbacks": build_metadata.get("sample_qc_fallbacks"),
         "n_negative_values_clipped": build_metadata.get("n_negative_values_clipped"),
+        "representative_partition": build_metadata.get("representative_partition"),
     }
 manifest.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 PY

--- a/scripts/build_data_tarball.sh
+++ b/scripts/build_data_tarball.sh
@@ -58,7 +58,7 @@ if ((${#missing[@]})); then
 fi
 
 echo "packaging ${#PATHS[@]} bundle paths from $SRC -> $OUT"
-COPYFILE_DISABLE=1 tar -czf "$OUT" -C "$SRC" "${PATHS[@]}"
+COPYFILE_DISABLE=1 tar -cf - -C "$SRC" "${PATHS[@]}" | gzip -n >"$OUT"
 SIZE="$(du -h "$OUT" | cut -f1)"
 echo "wrote $OUT ($SIZE)"
 python - "$OUT" "$SRC" "$MANIFEST_OUT" "$DATA_VERSION" "$PACKAGE_VERSION" "$SOURCE_MATRIX_VERSION" "$BUILDER_COMMIT" "${PATHS[@]}" <<'PY'

--- a/scripts/generate_representatives.py
+++ b/scripts/generate_representatives.py
@@ -58,6 +58,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from oncoref.expression_builders import cohort_medoids, sample_columns
 from oncoref.gene_families import clean_tpm_censored_gene_ids
+from oncoref.representative_partitions import assign_representative_partitions
 from oncoref.source_matrices import source_sample_namespace
 
 _DATA_DIR = Path(__file__).resolve().parents[1] / "oncoref" / "data"
@@ -65,12 +66,15 @@ OUT_DIR = _DATA_DIR / "cancer-reference-expression-representatives"
 _BASE = ["Ensembl_Gene_ID", "Symbol"]
 #: Columns representative_cohort_samples(include_provenance=True) merges back in.
 _PROVENANCE_COLUMNS = [
+    "cancer_code",
     "representative_id",
     "source_cohort",
     "source_project",
     "source_sample",
     "source_group_id",
     "n_cohort_samples",
+    "representative_role",
+    "benchmark_eligible",
 ]
 
 
@@ -132,17 +136,22 @@ def build(input_dir: Path, *, k: int = 5, out_dir: Path = OUT_DIR) -> None:
         for rep_id, src in zip(rep_ids, source_cols):
             provenance.append(
                 {
+                    "cancer_code": code,
                     "representative_id": rep_id,
                     "source_cohort": source_cohort,
                     "source_project": source_project,
                     "source_sample": src,
                     "source_group_id": f"{source_sample_namespace(source_cohort)}:{src}",
                     "n_cohort_samples": n_cohort,
+                    "representative_role": "standard",
+                    "benchmark_eligible": True,
                 }
             )
         n += 1
         print(f"  {code}: {len(rep_ids)} reps of {n_cohort} samples", flush=True)
-    prov_df = pd.DataFrame(provenance, columns=_PROVENANCE_COLUMNS)
+    prov_df = assign_representative_partitions(
+        pd.DataFrame(provenance, columns=_PROVENANCE_COLUMNS)
+    )
     prov_df.to_csv(out_dir / "_provenance.csv", index=False)
     total_mb = sum(f.stat().st_size for f in out_dir.glob("*.parquet")) / 1e6
     print(f"\ndone: {n} cohorts, {total_mb:.1f} MB -> {out_dir}", flush=True)

--- a/scripts/partition_representatives.py
+++ b/scripts/partition_representatives.py
@@ -1,0 +1,122 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Add the released representative partition contract to an existing data bundle.
+
+This migration changes only representative provenance and expression build
+metadata. Expression vectors remain byte-for-byte unchanged.
+
+Run:
+    python scripts/partition_representatives.py --bundle /path/to/bundle-staging
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oncoref.expression import EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION
+from oncoref.representative_partitions import (
+    REPRESENTATIVE_PARTITION_COHORT_COLUMNS,
+    assign_representative_partitions,
+    representative_partition_build_metadata,
+    representative_partition_cohort_metadata,
+)
+
+_REPRESENTATIVE_DIR = "cancer-reference-expression-representatives"
+_PROVENANCE_NAME = "_provenance.csv"
+_COHORT_METADATA_NAME = "expression-artifact-build-metadata.csv"
+_BUILD_METADATA_NAME = "expression-artifact-build-metadata.json"
+
+
+def _atomic_csv(df: pd.DataFrame, path: Path) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    df.to_csv(temporary, index=False)
+    temporary.replace(path)
+
+
+def _atomic_json(value: dict, path: Path) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def partition_existing_bundle(bundle: Path) -> pd.DataFrame:
+    """Partition existing representative provenance and update its build metadata."""
+
+    provenance_path = bundle / _REPRESENTATIVE_DIR / _PROVENANCE_NAME
+    cohort_metadata_path = bundle / _COHORT_METADATA_NAME
+    build_metadata_path = bundle / _BUILD_METADATA_NAME
+    for path in (provenance_path, cohort_metadata_path, build_metadata_path):
+        if not path.exists():
+            raise FileNotFoundError(f"required bundle metadata is missing: {path}")
+
+    provenance = pd.read_csv(provenance_path)
+    if "cancer_code" not in provenance:
+        provenance["cancer_code"] = (
+            provenance["representative_id"]
+            .astype(str)
+            .str.replace(
+                r"__rep\d+$",
+                "",
+                regex=True,
+            )
+        )
+    partitioned = assign_representative_partitions(provenance)
+
+    cohort_metadata = pd.read_csv(cohort_metadata_path)
+    partition_columns = set(REPRESENTATIVE_PARTITION_COHORT_COLUMNS) - {"cancer_code"}
+    cohort_metadata = cohort_metadata.drop(
+        columns=[column for column in partition_columns if column in cohort_metadata],
+    )
+    cohort_metadata = cohort_metadata.merge(
+        representative_partition_cohort_metadata(partitioned),
+        on="cancer_code",
+        how="left",
+        validate="one_to_one",
+    )
+
+    build_metadata = json.loads(build_metadata_path.read_text())
+    build_metadata["schema_version"] = EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION
+    build_metadata["representative_partition"] = representative_partition_build_metadata(
+        partitioned
+    )
+
+    _atomic_csv(partitioned, provenance_path)
+    _atomic_csv(cohort_metadata, cohort_metadata_path)
+    _atomic_json(build_metadata, build_metadata_path)
+    return partitioned
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", required=True, type=Path, help="Existing bundle staging root")
+    args = parser.parse_args(argv)
+    partitioned = partition_existing_bundle(args.bundle.expanduser())
+    group_roles = partitioned.drop_duplicates("source_group_id")["partition_role"]
+    print(
+        f"partitioned {len(group_roles)} source groups across "
+        f"{partitioned['cancer_code'].nunique()} cohorts: "
+        + ", ".join(
+            f"{role}={count}" for role, count in group_roles.value_counts().sort_index().items()
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rebuild_expression_artifacts.py
+++ b/scripts/rebuild_expression_artifacts.py
@@ -86,6 +86,11 @@ from oncoref.expression_registry import expression_source_registry_entries
 from oncoref.gene_families import clean_tpm_censored_gene_ids
 from oncoref.load_dataset import get_data
 from oncoref.normalization import clean_tpm
+from oncoref.representative_partitions import (
+    assign_representative_partitions,
+    representative_partition_build_metadata,
+    representative_partition_cohort_metadata,
+)
 from oncoref.source_matrices import registry as source_registry
 from oncoref.source_matrices import source_sample_namespace
 
@@ -602,6 +607,7 @@ def rebuild(
             )
             provenance.append(
                 {
+                    "cancer_code": code,
                     "representative_id": rep_id,
                     "source_cohort": source_cohort,
                     "source_version": source_version,  # harmonized Ensembl release
@@ -671,12 +677,20 @@ def rebuild(
                 compression="gzip",
             )
 
-    pd.DataFrame(provenance).to_csv(rep_dir / "_provenance.csv", index=False)
+    provenance_df = assign_representative_partitions(pd.DataFrame(provenance))
+    provenance_df.to_csv(rep_dir / "_provenance.csv", index=False)
     if qc_manifest:
         pd.concat(qc_manifest, ignore_index=True).to_csv(
             out / "source-matrix-sample-qc.csv", index=False
         )
-    pd.DataFrame(build_rows).to_csv(out / "expression-artifact-build-metadata.csv", index=False)
+    partition_by_cohort = representative_partition_cohort_metadata(provenance_df)
+    build_df = pd.DataFrame(build_rows).merge(
+        partition_by_cohort,
+        on="cancer_code",
+        how="left",
+        validate="one_to_one",
+    )
+    build_df.to_csv(out / "expression-artifact-build-metadata.csv", index=False)
     metadata = {
         "artifact": "expression-derived-shards",
         "schema_version": EXPRESSION_ARTIFACT_BUILD_METADATA_SCHEMA_VERSION,
@@ -693,6 +707,7 @@ def rebuild(
         "n_negative_values_clipped": int(
             sum(row["n_negative_values_clipped"] for row in build_rows)
         ),
+        "representative_partition": representative_partition_build_metadata(provenance_df),
         "derived_artifacts": [
             "clean",
             _SUMMARY_DIR,

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -2642,6 +2642,11 @@ def test_representatives_generator_writes_shards_and_provenance(tmp_path):
     assert (prov["source_cohort"] == "COHORT_A").all()
     assert set(prov["source_sample"]) <= {f"s{i}" for i in range(6)}
     assert (prov["source_group_id"] == prov["source_cohort"] + ":" + prov["source_sample"]).all()
+    assert prov["partition_role"].value_counts().to_dict() == {
+        "train": 2,
+        "validation": 1,
+    }
+    assert set(prov["partition_status"]) == {"available"}
 
 
 def test_representatives_generator_selects_on_biological_view(tmp_path, monkeypatch):
@@ -2692,6 +2697,54 @@ def test_representatives_generator_groups_treehouse_views_by_physical_sample(tmp
     provenance = pd.read_csv(out / "_provenance.csv").iloc[0]
     assert provenance["source_cohort"] == "TREEHOUSE_POLYA_25_01_TCGA_SAMPLES"
     assert provenance["source_group_id"] == ("TREEHOUSE_POLYA_25_01:TCGA-AC-A2QH-01")
+
+
+def test_partition_existing_bundle_updates_only_provenance_and_metadata(tmp_path):
+    gen = _load_script("partition_representatives")
+    representative_dir = tmp_path / "cancer-reference-expression-representatives"
+    representative_dir.mkdir()
+    shard_path = representative_dir / "A.parquet"
+    shard_path.write_bytes(b"unchanged expression shard")
+    pd.DataFrame(
+        {
+            "representative_id": [f"A__rep{i}" for i in range(1, 6)],
+            "source_group_id": [f"PROJECT:s{i}" for i in range(1, 6)],
+            "benchmark_eligible": [True] * 5,
+        }
+    ).to_csv(representative_dir / "_provenance.csv", index=False)
+    pd.DataFrame(
+        {
+            "cancer_code": ["A"],
+            "source_cohort": ["PROJECT"],
+            "n_cohort_samples": [10],
+        }
+    ).to_csv(tmp_path / "expression-artifact-build-metadata.csv", index=False)
+    (tmp_path / "expression-artifact-build-metadata.json").write_text(
+        json.dumps(
+            {
+                "artifact": "expression-derived-shards",
+                "schema_version": "expression_artifact_build_metadata_v2",
+            }
+        )
+    )
+
+    partitioned = gen.partition_existing_bundle(tmp_path)
+
+    assert shard_path.read_bytes() == b"unchanged expression shard"
+    assert partitioned["partition_role"].value_counts().to_dict() == {
+        "train": 3,
+        "validation": 2,
+    }
+    cohort_metadata = pd.read_csv(tmp_path / "expression-artifact-build-metadata.csv")
+    assert cohort_metadata.loc[0, "partition_status"] == "available"
+    assert cohort_metadata.loc[0, "n_partition_train"] == 3
+    assert cohort_metadata.loc[0, "n_partition_validation"] == 2
+    build_metadata = json.loads((tmp_path / "expression-artifact-build-metadata.json").read_text())
+    assert build_metadata["schema_version"] == "expression_artifact_build_metadata_v3"
+    assert build_metadata["representative_partition"]["role_counts"] == {
+        "train": 3,
+        "validation": 2,
+    }
 
 
 def _write_rebuild_inputs(tmp_path):
@@ -2787,6 +2840,9 @@ def test_rebuild_expression_artifacts_defaults_to_qc_passing_samples(tmp_path, m
     assert prov.loc[0, "n_qc_pass"] == 1
     assert prov.loc[0, "n_qc_warn"] == 1
     assert prov.loc[0, "n_qc_fail"] == 1
+    assert prov.loc[0, "partition_role"] == "train"
+    assert prov.loc[0, "partition_status"] == "insufficient_independent_groups"
+    assert prov.loc[0, "partition_validation_target"] == 0
 
     qc = pd.read_csv(out / "source-matrix-sample-qc.csv")
     assert list(qc["sample_id"]) == ["pass_sample", "warn_sample", "fail_sample"]
@@ -2797,13 +2853,21 @@ def test_rebuild_expression_artifacts_defaults_to_qc_passing_samples(tmp_path, m
     assert build_meta.loc[0, "n_source_samples"] == 3
     assert build_meta.loc[0, "n_cohort_samples"] == 1
     assert build_meta.loc[0, "sample_qc_policy_version"] == "sample_expression_qc_v2"
+    assert build_meta.loc[0, "partition_status"] == "insufficient_independent_groups"
+    assert build_meta.loc[0, "n_partition_train"] == 1
+    assert build_meta.loc[0, "n_partition_validation"] == 0
 
     metadata = json.loads((out / "expression-artifact-build-metadata.json").read_text())
-    assert metadata["schema_version"] == "expression_artifact_build_metadata_v2"
+    assert metadata["schema_version"] == "expression_artifact_build_metadata_v3"
     assert metadata["sample_qc"] == "pass"
     assert metadata["sample_qc_manifest"] == "source-matrix-sample-qc.csv"
     assert metadata["n_source_samples"] == 3
     assert metadata["n_cohort_samples"] == 1
+    assert metadata["representative_partition"] == {
+        "grouping_key": "source_group_id",
+        "policy_version": "source_grouped_3_train_2_validation_v1",
+        "role_counts": {"train": 1},
+    }
 
 
 def test_rebuild_expression_artifacts_applies_reviewed_source_adjudication(tmp_path, monkeypatch):

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -832,6 +832,15 @@ def test_representative_provenance_includes_source_sample_and_selection_metadata
             "source_sample_qc": ["pass"],
             "representative_role": ["standard"],
             "benchmark_eligible": [True],
+            "partition_role": ["validation"],
+            "partition_reason": ["stable_source_group_validation"],
+            "partition_policy_version": [expression.REPRESENTATIVE_PARTITION_POLICY_VERSION],
+            "partition_validation_target": [1],
+            "partition_status": ["available"],
+            "n_partition_train": [1],
+            "n_partition_validation": [1],
+            "n_partition_validation_external": [0],
+            "n_partition_audit_only": [0],
             "review_source": ["https://example.test/review"],
             "review_note": ["reviewed source"],
             "n_cohort_samples": [10],
@@ -848,6 +857,10 @@ def test_representative_provenance_includes_source_sample_and_selection_metadata
     assert df.loc[0, "source_sample_qc"] == "pass"
     assert df.loc[0, "representative_role"] == "standard"
     assert bool(df.loc[0, "benchmark_eligible"]) is True
+    assert df.loc[0, "partition_role"] == "validation"
+    assert (
+        df.loc[0, "partition_policy_version"] == expression.REPRESENTATIVE_PARTITION_POLICY_VERSION
+    )
     assert df.loc[0, "review_source"] == "https://example.test/review"
     assert df.loc[0, "review_note"] == "reviewed source"
     assert df.loc[0, "selection_rank"] == 1
@@ -865,6 +878,94 @@ def test_representative_provenance_includes_source_sample_and_selection_metadata
         representative_id_style="internal",
     )
     assert internal.loc[0, "representative_id"] == "PRAD__rep1"
+
+
+def test_representative_partition_manifest_is_one_row_per_vector(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(tmp_path))
+    shard_dir = tmp_path / "cancer-reference-expression-representatives"
+    shard_dir.mkdir(parents=True)
+    pd.DataFrame(
+        {
+            "representative_id": ["PRAD__rep1", "PRAD__rep2", "BRCA__rep1"],
+            "source_group_id": ["TCGA:p1", "TCGA:p2", "TCGA:b1"],
+            "source_cohort": ["TCGA_PRAD", "TCGA_PRAD", "TCGA_BRCA"],
+            "source_project": ["TCGA", "TCGA", "TCGA"],
+            "source_sample": ["p1", "p2", "b1"],
+            "representative_role": ["standard", "standard", "standard"],
+            "benchmark_eligible": [True, True, True],
+            "partition_role": ["train", "validation", "train"],
+            "partition_reason": [
+                "stable_source_group_training",
+                "stable_source_group_validation",
+                "stable_source_group_training",
+            ],
+            "partition_policy_version": [expression.REPRESENTATIVE_PARTITION_POLICY_VERSION] * 3,
+            "partition_validation_target": [1, 1, 0],
+            "partition_status": [
+                "available",
+                "available",
+                "insufficient_independent_groups",
+            ],
+            "n_partition_train": [1, 1, 1],
+            "n_partition_validation": [1, 1, 0],
+            "n_partition_validation_external": [0, 0, 0],
+            "n_partition_audit_only": [0, 0, 0],
+        }
+    ).to_csv(shard_dir / "_provenance.csv", index=False)
+
+    manifest = expression.representative_partition_manifest("PRAD")
+
+    assert manifest["representative_id"].tolist() == ["PRAD_rep01", "PRAD_rep02"]
+    assert manifest["partition_role"].tolist() == ["train", "validation"]
+    assert manifest["source_group_id"].is_unique
+    assert (
+        manifest.attrs["partition_policy_version"]
+        == expression.REPRESENTATIVE_PARTITION_POLICY_VERSION
+    )
+
+
+def test_released_representative_partition_is_source_grouped_and_stratified():
+    manifest = expression.representative_partition_manifest()
+    availability = expression.representative_cohort_availability()
+
+    assert not manifest.empty
+    assert set(manifest["partition_role"]) <= {
+        "train",
+        "validation",
+        "validation_external",
+        "audit_only",
+    }
+    assert manifest.groupby("source_group_id")["partition_role"].nunique().max() == 1
+    assert set(manifest["partition_policy_version"]) == {
+        expression.REPRESENTATIVE_PARTITION_POLICY_VERSION
+    }
+
+    ordinary = availability[
+        (availability["n_representatives"] == 5) & (availability["n_partition_audit_only"] == 0)
+    ]
+    assert not ordinary.empty
+    assert set(ordinary["n_partition_train"]) == {3}
+    assert set(ordinary["n_partition_validation"]) == {2}
+    assert set(ordinary["partition_status"]) == {"available"}
+    partition_totals = (
+        availability["n_partition_train"]
+        + availability["n_partition_validation"]
+        + availability["n_partition_audit_only"]
+    )
+    assert partition_totals.equals(availability["n_representatives"])
+
+    by_code = availability.set_index("cancer_code")
+    assert by_code.loc["SARC_EHE", "partition_status"] == ("insufficient_independent_groups")
+    assert by_code.loc["SARC_EHE", "n_partition_train"] == 1
+    for code in ("RB", "SARC_CHOR"):
+        assert by_code.loc[code, "partition_status"] == ("no_benchmark_eligible_groups")
+        assert by_code.loc[code, "n_partition_audit_only"] == 5
+
+    build_summary = expression.expression_artifact_build_summary(on_missing="raise")
+    assert build_summary["representative_partition"]["grouping_key"] == ("source_group_id")
+    assert build_summary["representative_partition"]["policy_version"] == (
+        expression.REPRESENTATIVE_PARTITION_POLICY_VERSION
+    )
 
 
 def test_representative_availability_routes_proxy_and_qc_fallback_cohorts(monkeypatch, tmp_path):
@@ -1043,6 +1144,15 @@ def test_representative_empty_long_schema_includes_requested_provenance(monkeypa
         "selection_scale_class",
         "representative_role",
         "benchmark_eligible",
+        "partition_role",
+        "partition_reason",
+        "partition_policy_version",
+        "partition_validation_target",
+        "partition_status",
+        "n_partition_train",
+        "n_partition_validation",
+        "n_partition_validation_external",
+        "n_partition_audit_only",
         "review_source",
         "review_note",
         "selection_rank",

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,3 +1,6 @@
+import json
+import os
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -7,6 +10,8 @@ from scripts.pypi_release_gate import (
     should_publish_to_pypi,
     write_github_output,
 )
+
+from oncoref.data_bundle import DOWNLOADABLE_PATHS
 
 
 def test_build_backend_supports_declared_pep_639_license_metadata():
@@ -83,3 +88,33 @@ def test_deploy_uses_one_virtualenv_python_interpreter():
 
     command_lines = [line.strip() for line in script.splitlines()]
     assert not any(line.startswith(("python ", "python3 ")) for line in command_lines)
+
+
+def test_data_tarball_can_target_an_unreleased_version(tmp_path):
+    source = tmp_path / "source"
+    output = tmp_path / "output"
+    source.mkdir()
+    output.mkdir()
+    for relative_path in DOWNLOADABLE_PATHS:
+        path = source / relative_path
+        if path.suffix:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("{}" if path.suffix == ".json" else "fixture\n")
+        else:
+            path.mkdir(parents=True)
+            (path / "fixture.txt").write_text("fixture\n")
+
+    env = os.environ.copy()
+    env["ONCOREF_DATA_RELEASE_VERSION"] = "9.8.7"
+    subprocess.run(
+        ["bash", "scripts/build_data_tarball.sh", str(source), str(output)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    manifest = json.loads((output / "oncoref-data-v9.8.7.manifest.json").read_text())
+    assert manifest["data_version"] == "9.8.7"
+    assert manifest["tarball"]["filename"] == "oncoref-data-v9.8.7.tar.gz"
+    assert (output / "oncoref-data-v9.8.7.tar.gz.sha256").exists()

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -113,8 +113,17 @@ def test_data_tarball_can_target_an_unreleased_version(tmp_path):
         text=True,
         env=env,
     )
+    first_tarball = (output / "oncoref-data-v9.8.7.tar.gz").read_bytes()
+    subprocess.run(
+        ["bash", "scripts/build_data_tarball.sh", str(source), str(output)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
 
     manifest = json.loads((output / "oncoref-data-v9.8.7.manifest.json").read_text())
     assert manifest["data_version"] == "9.8.7"
     assert manifest["tarball"]["filename"] == "oncoref-data-v9.8.7.tar.gz"
+    assert (output / "oncoref-data-v9.8.7.tar.gz").read_bytes() == first_tarball
     assert (output / "oncoref-data-v9.8.7.tar.gz.sha256").exists()

--- a/tests/test_representative_partitions.py
+++ b/tests/test_representative_partitions.py
@@ -1,0 +1,114 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+import pytest
+
+from oncoref.representative_partitions import (
+    REPRESENTATIVE_PARTITION_POLICY_VERSION,
+    assign_representative_partitions,
+)
+
+
+def _rows(cancer_code, groups, *, eligible=True):
+    return [
+        {
+            "cancer_code": cancer_code,
+            "representative_id": f"{cancer_code}__rep{rank}",
+            "source_group_id": group_id,
+            "benchmark_eligible": eligible,
+        }
+        for rank, group_id in enumerate(groups, start=1)
+    ]
+
+
+def test_five_group_cohort_gets_deterministic_three_two_split():
+    provenance = pd.DataFrame(_rows("A", [f"P:s{i}" for i in range(5)]))
+
+    first = assign_representative_partitions(provenance)
+    second = assign_representative_partitions(provenance.sample(frac=1, random_state=3))
+
+    first_roles = first.set_index("source_group_id")["partition_role"].to_dict()
+    second_roles = second.set_index("source_group_id")["partition_role"].to_dict()
+    assert first_roles == second_roles
+    assert pd.Series(first_roles).value_counts().to_dict() == {
+        "train": 3,
+        "validation": 2,
+    }
+    assert set(first["partition_policy_version"]) == {REPRESENTATIVE_PARTITION_POLICY_VERSION}
+    assert set(first["partition_status"]) == {"available"}
+    assert set(first["partition_validation_target"]) == {2}
+
+
+def test_shared_source_group_never_crosses_partition_roles():
+    rows = _rows("PARENT", ["P:shared", "P:p2", "P:p3", "P:p4", "P:p5"])
+    rows += _rows("SUBTYPE", ["P:shared", "P:s2"])
+
+    partitioned = assign_representative_partitions(pd.DataFrame(rows))
+
+    assert partitioned.groupby("source_group_id")["partition_role"].nunique().max() == 1
+    subtype = partitioned[partitioned["cancer_code"] == "SUBTYPE"]
+    assert set(subtype["partition_status"]) == {"available"}
+    assert set(subtype["n_partition_train"]) == {1}
+    assert set(subtype["n_partition_validation"]) == {1}
+
+
+def test_single_group_cohort_is_explicitly_train_only():
+    partitioned = assign_representative_partitions(pd.DataFrame(_rows("SPARSE", ["P:only"])))
+
+    assert partitioned.loc[0, "partition_role"] == "train"
+    assert partitioned.loc[0, "partition_status"] == "insufficient_independent_groups"
+    assert partitioned.loc[0, "partition_validation_target"] == 0
+
+
+def test_benchmark_ineligible_group_is_audit_only_for_every_alias():
+    rows = _rows("A", ["P:shared"], eligible=True)
+    rows += _rows("B", ["P:shared"], eligible=False)
+
+    partitioned = assign_representative_partitions(pd.DataFrame(rows))
+
+    assert set(partitioned["partition_role"]) == {"audit_only"}
+    assert set(partitioned["partition_reason"]) == {"benchmark_ineligible_source_group"}
+    assert set(partitioned["partition_status"]) == {"no_benchmark_eligible_groups"}
+
+
+def test_independent_source_project_is_held_out_as_a_whole():
+    rows = _rows("A", ["PRIMARY:p1", "PRIMARY:p2", "PRIMARY:p3"])
+    rows += _rows("A", ["EXTERNAL:e1", "EXTERNAL:e2"])
+
+    partitioned = assign_representative_partitions(pd.DataFrame(rows))
+    external = partitioned[partitioned["source_group_id"].str.startswith("EXTERNAL:")]
+    primary = partitioned[partitioned["source_group_id"].str.startswith("PRIMARY:")]
+
+    assert len(set(external["partition_role"])) == 1
+    held_out = external if external.iloc[0]["partition_role"] == "validation_external" else primary
+    training = primary if held_out is external else external
+    assert set(held_out["partition_role"]) == {"validation_external"}
+    assert set(training["partition_role"]) == {"train"}
+    assert set(partitioned["n_partition_validation_external"]) == {len(held_out)}
+
+
+def test_partition_input_rejects_missing_source_namespace():
+    provenance = pd.DataFrame(_rows("A", ["sample_without_namespace"]))
+
+    with pytest.raises(ValueError, match="<source-namespace>:<source-sample>"):
+        assign_representative_partitions(provenance)
+
+
+def test_empty_partition_input_returns_stable_schema():
+    provenance = pd.DataFrame(columns=["cancer_code", "source_group_id", "benchmark_eligible"])
+
+    partitioned = assign_representative_partitions(provenance)
+
+    assert partitioned.empty
+    assert "partition_role" in partitioned
+    assert "partition_status" in partitioned


### PR DESCRIPTION
## Summary

- assign every physical representative `source_group_id` to one deterministic `train`, `validation`, `validation_external`, or `audit_only` role
- keep parent, subtype, and alias rows for the same source group in one partition and publish per-cohort validation coverage
- add the compact `representative_partition_manifest()` API plus long-form provenance, availability, build metadata, and overview-first documentation
- publish data bundle 5.23.13 and bump oncoref to 1.8.158; expression shards are byte-identical to 5.23.12
- make the tarball builder safely target an unreleased data version before `DATA_VERSION` is bumped and produce reproducible timestamp-free gzip output

## Policy

A standard five-representative cohort gets three train and two validation groups. Cohorts with one eligible group are explicitly train-only. Benchmark-ineligible source groups are audit-only. When a cohort spans independent source namespaces, the smallest viable project is held out whole as `validation_external`.

The released bundle contains 608 physical groups: 355 train, 242 validation, and 11 audit-only. All 131 cohorts have explicit status; 128 have validation coverage, SARC_EHE is train-only because it has one eligible group, and RB/SARC_CHOR are audit-only because they have no benchmark-eligible representatives.

## Data release

- https://github.com/pirl-unc/oncoref/releases/tag/v5.23.13
- tarball SHA256: `59585c1632137c09460391cebb1f962c441f51308a27c4626fbb41a37a841878`
- all 738 non-metadata bundle files match 5.23.12 byte-for-byte
- all 741 files extracted from the release tarball match staging

## Verification

- `pytest -q` against the extracted 5.23.13 tarball and released LUAD source matrix: **885 passed, 0 skipped**
- `./lint.sh`
- `mkdocs build --strict`
- public release manifest and checksum sidecar match the reviewed local artifacts byte-for-byte

Closes #369
