### PR TITLE
Own every published expression source regeneration route

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@
 # [tool.setuptools.exclude-package-data] — without this the sdist auto-includes
 # every git-tracked file and the heavy per-cohort expression data (added in a
 # later milestone) would balloon the .tar.gz past PyPI's 100 MiB limit.
+recursive-include scripts *.py
 recursive-exclude oncoref/data/cancer-reference-expression *
 recursive-exclude oncoref/data/cancer-reference-expression-percentiles *
 recursive-exclude oncoref/data/cancer-reference-expression-representatives *

--- a/docs/api.md
+++ b/docs/api.md
@@ -396,11 +396,22 @@ processing plan.
 
 ### Builder APIs
 
+Every published source matrix has one regeneration path owned by oncoref. The
+path may use a generic builder or a small source-specific adapter, but it always
+ends at the same canonical matrix, mapping-audit, parse-diagnostic, sample-QC,
+and summary-row contract. Source-scale caveats remain data: microarray TPM
+proxies and CTCL single-cell pseudobulk nTPM are retained for within-sample rank
+uses while explicitly marked unsuitable for absolute comparison with bulk
+RNA-seq TPM.
+
 - `oncoref.expression_builders` — build-time ingestion and artifact cores used by
   data-bundle generation scripts. `GeoMatrixSource` /
   `build_source_matrices` own the generic supplementary-matrix path from raw
   source file to canonical per-code per-sample TPM parquet, mapping audit, parse
   diagnostics, sample-QC sidecars, and `SourceMatrixBuildResult.summary_rows`.
+  Raw-count inputs are canonicalized first and use Ensembl gene lengths from
+  the requested pyensembl release in an `oncoref[genome]` build environment;
+  `--gene-lengths-kb` remains available as an explicit build-input override.
   `summarize_source_matrix` is the standalone producer for those
   per-gene-per-cohort reference-expression rows: raw TPM stats, clean-TPM
   16/9/75 stats, `n_samples`, `n_detected`, and source provenance in one schema.
@@ -457,6 +468,13 @@ processing plan.
   builds retain curated cohorts that have no strict QC-pass samples only through
   explicit source-aware fallbacks recorded in the build metadata, and clip
   invalid negative source expression values to zero with per-cohort counts.
+- `oncoref.expression_source_adapters` — narrow parsers and routers for public
+  sources whose sample labels live outside the primary expression matrix. These
+  adapters cover TARGET ALL phase-matrix B/T lineage, TARGET NBL cBioPortal MYCN
+  status, GSE75885 histology titles, DRMetrics histology attributes, audited GEO
+  microarrays, and GSE171811 CTCL TCR-beta-selected case pseudobulks. They
+  delegate normalization, canonicalization, QC, summaries, and artifact writing
+  to `expression_builders` rather than defining parallel data contracts.
 
 ### Registry and low-level APIs
 
@@ -465,7 +483,9 @@ processing plan.
   for the full raw YAML dictionaries, `expression_source_registry_entries(source_type="geo-matrix")`
   for generic GEO build configs, or `expression_source_registry_path()` only when
   a subprocess needs the packaged registry path. Downstream packages should use
-  these helpers instead of shipping a second copy of the registry.
+  these helpers instead of shipping a second copy of the registry. GEO
+  accessions named anywhere in a source's citation or file metadata are also
+  stored in the structured `accession` field.
 - `oncoref.expression_engine` — reusable low-level builder primitives for
   expression tables: identity/value column detection, transcript-to-gene
   aggregation, source row ID-type detection, source gene-row mapping audits,
@@ -482,6 +502,14 @@ processing plan.
   `source_expression_nonzero_samples`, and
   `source_expression_sample_with_max`.
 - `oncoref.source_matrices` — raw per-cohort source-matrix cache/fetch helpers.
+  `source_matrix_regeneration_audit()` matches each selected matrix by the exact
+  `(cancer_code, source_cohort)` physical-source pair. A pair must have exactly
+  one registry owner declaring either an existing repository-relative builder
+  script or an `external_build_exemption`; `validate_source_matrix_regeneration()`
+  raises for missing, ambiguous, invalid, or nonexistent builder ownership. The
+  sole current exemption is the controlled UNC NUTM1 case series. This audit is
+  a source-checkout/release-build check because builder scripts are not installed
+  in the runtime wheel.
   Use `source_matrices.sample_qc(code)` for the live source-matrix QC audit and
   `source_matrices.sample_qc_manifest(...)` for the optional generated-bundle QC
   manifest that records which samples fed derived artifacts.

--- a/oncoref/cancer_types.py
+++ b/oncoref/cancer_types.py
@@ -2383,7 +2383,18 @@ def _expression_source_cohort_counts() -> dict[str, dict[str, int]]:
                 f"expression source {source['id']!r} routed counts must match cancer_codes"
             )
         physical_samples = int(source["expected_source_samples"])
-        if sum(routed_counts.values()) > physical_samples:
+        routed_samples_may_overlap = source.get("routed_samples_may_overlap", False)
+        if not isinstance(routed_samples_may_overlap, bool):
+            raise ValueError(
+                f"expression source {source['id']!r} "
+                "routed_samples_may_overlap must be a YAML boolean"
+            )
+        routed_total = (
+            max(routed_counts.values(), default=0)
+            if routed_samples_may_overlap
+            else sum(routed_counts.values())
+        )
+        if routed_total > physical_samples:
             raise ValueError(
                 f"expression source {source['id']!r} routes more samples than it contains"
             )

--- a/oncoref/data/expression_sources.yaml
+++ b/oncoref/data/expression_sources.yaml
@@ -11,6 +11,12 @@
 #   source_type        — builder/loader contract, such as gdc, geo-matrix,
 #                        recount3, sra-ncbi-counts, or treehouse-compendium.
 #   builder            — build-time script that emits canonical source matrices.
+#   external_build_exemption
+#                      — nonempty reason a selected matrix cannot be rebuilt from
+#                        public inputs. Mutually exclusive with builder.
+#   routed_samples_may_overlap
+#                      — true only when parent and child matrices intentionally
+#                        reuse physical samples; otherwise routes are disjoint.
 #   project_id         — GDC project, when source_type == gdc.
 #   accession          — repository accession (GEO, BioProject, etc.).
 #   url                — Direct download URL for single-file sources.
@@ -78,25 +84,43 @@ sources:
     category: expression
     cancer_codes: [B_ALL, T_ALL]
     source_type: gdc
-    project_id: TARGET-ALL-P1+P2+P3
+    project_ids: [TARGET-ALL-P1, TARGET-ALL-P2, TARGET-ALL-P3]
+    source_cohort: TARGET_ALL_2018
+    source_project: TARGET ALL
     builder: scripts/build_target_all_reference_expression.py
+    expected_samples_by_code: {B_ALL: 154, T_ALL: 264}
+    gdc_sample_types:
+      [Primary Blood Derived Cancer - Bone Marrow,
+       Primary Blood Derived Cancer - Peripheral Blood]
+    gdc_primary_diagnosis_contains: [acute lymphocytic leukemia]
     unit: TPM
     library_prep: polyA RNA-seq   # TARGET Illumina TruSeq mRNA (polyA)
     expected_size_gb: 6
     citation: https://portal.gdc.cancer.gov/projects/TARGET-ALL-P2
     special_handling: >
-      Three TARGET ALL phases merged; split B-cell vs T-cell ALL by
-      diagnosis fields.
+      Three TARGET ALL phases merged. GDC diagnoses do not encode B/T
+      lineage; the builder routes cases from the public Phase 1/2
+      sample-matrix "Cell of origin" comments.
 
   # ---- existing non-GDC builders ----
 
   - id: cllmap
     category: expression
     cancer_codes: [CLL]
-    source_type: broad-cllmap
+    source_type: geo-matrix
+    source_cohort: CLLMAP_2022
+    source_project: CLL-map
     url: https://data.broadinstitute.org/cllmap/data/downloads/cllmap_rnaseq_tpms_full.tsv.gz
-    builder: scripts/build_cllmap_reference_expression.py
+    file_url: https://data.broadinstitute.org/cllmap/data/downloads/cllmap_rnaseq_tpms_full.tsv.gz
+    file_name: cllmap_rnaseq_tpms_full.tsv.gz
+    builder: scripts/build_geo_matrix.py
     unit: TPM
+    gene_id_col: Name
+    symbol_col: Description
+    sample_filter:
+      exclude_match: "^(CRC-0007|CRC-0011|CRC-0028|CRC-0033|DFCI-5053|JB-0010|GCLL-0136)$"
+    expected_source_samples: 715
+    expected_samples_by_code: {CLL: 708}
     library_prep: polyA RNA-seq   # CLL-map Broad Illumina TruSeq mRNA (polyA)
     expected_size_gb: 1
     citation: https://data.broadinstitute.org/cllmap/downloads.html
@@ -106,10 +130,19 @@ sources:
   - id: gse100026-cml
     category: expression
     cancer_codes: [CML]
-    source_type: geo
+    source_type: geo-matrix
     accession: GSE100026
     source_cohort: GSE100026_DING_2017
-    builder: scripts/build_geo_heme_reference_expression.py
+    source_project: GEO
+    builder: scripts/build_geo_matrix.py
+    file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE100nnn/GSE100026/suppl/GSE100026_expressed_gene_RPKM.txt.gz
+    file_name: GSE100026_expressed_gene_RPKM.txt.gz
+    gene_id_col: Gene
+    drop_cols: [Gene_len]
+    sample_filter:
+      include_match: "^CML-CP"
+    expected_source_samples: 15
+    expected_samples_by_code: {CML: 5}
     unit: RPKM
     expected_size_gb: 0.1
     citation: GSE100026 (Ding 2017)
@@ -141,11 +174,18 @@ sources:
   - id: gse271664-mcl
     category: expression
     cancer_codes: [MCL]
-    source_type: geo
+    source_type: geo-matrix
     accession: GSE271664
     source_cohort: GSE271664_BODOR_2025
-    builder: scripts/build_geo_heme_reference_expression.py
-    unit: HTSeq counts
+    source_project: GEO
+    builder: scripts/build_geo_matrix.py
+    file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE271nnn/GSE271664/suppl/GSE271664_HTSeq_counts.csv.gz
+    file_name: GSE271664_HTSeq_counts.csv.gz
+    unit: raw_counts
+    gene_id_col: Gene
+    sep: ","
+    expected_source_samples: 51
+    expected_samples_by_code: {MCL: 51}
     expected_size_gb: 0.1
     citation: GSE271664 (Bodor 2025)
     special_handling: >
@@ -155,10 +195,19 @@ sources:
   - id: gse283710-mpn
     category: expression
     cancer_codes: [MPN]
-    source_type: geo
+    source_type: geo-matrix
     accession: GSE283710
     source_cohort: GSE283710_WASHU_2024
-    builder: scripts/build_geo_heme_reference_expression.py
+    source_project: GEO
+    builder: scripts/build_geo_matrix.py
+    file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE283nnn/GSE283710/suppl/GSE283710_CD34_rawcounts.csv.gz
+    file_name: GSE283710_CD34_rawcounts.csv.gz
+    gene_id_col: external_gene_name
+    sep: ","
+    sample_filter:
+      include_match: "^(ET|MF|PV)[0-9]+_CD34$"
+    expected_source_samples: 90
+    expected_samples_by_code: {MPN: 45}
     unit: raw counts
     expected_size_gb: 0.1
     citation: GSE283710 (WashU 2024)
@@ -171,8 +220,15 @@ sources:
     cancer_codes: [CTCL]
     source_type: geo
     accession: GSE171811
+    source_cohort: GSE171811_ECCITE_CTCL
+    source_project: GEO
     builder: scripts/build_ctcl_scrna_reference_expression.py
     unit: nTPM (pseudobulk)
+    expected_samples_by_code: {CTCL: 7}
+    source_scale_class: scrna_tcr_pseudobulk_ntpm
+    linear_tpm_comparable: false
+    tpm_proxy: true
+    tumor_origin: primary
     expected_size_gb: 1
     citation: GSE171811 (ECCITE-seq CTCL)
     special_handling: >
@@ -193,6 +249,7 @@ sources:
        SARC_ANGIO, SARC_ASPS, SARC_DSRCT, SARC_EPITH, SARC_IMT, SARC_IFS,
        SARC_MPNST, SARC_EHE, SARC_LGFMS, NPC, SARC_GIST]
     source_type: treehouse-compendium
+    accession: GSE294351
     source_cohort: TREEHOUSE_POLYA_25_01
     source_project: Treehouse
     url: https://public.gi.ucsc.edu/~ekephart/public-data/#tumor_25.01_polya
@@ -259,6 +316,7 @@ sources:
     category: expression
     cancer_codes: [MBL_WNT, MBL_SHH, MBL_G3, MBL_G4]
     source_type: treehouse-derived
+    accession: GSE294351
     source_cohort: TREEHOUSE_POLYA_25_01_MBL_SUBGROUP_MARKERS
     source_project: Treehouse
     source_version: "25.01"
@@ -284,6 +342,7 @@ sources:
        KIRC, KIRP, LAML, LIHC, LUAD, LUSC, MESO, OV, PAAD, PCPG,
        PRAD, READ, SKCM, STAD, TGCT, THCA, THYM, UCEC, UCS, UVM]
     source_type: treehouse-compendium
+    accession: GSE294351
     source_cohort: TREEHOUSE_POLYA_25_01_TCGA_SAMPLES
     source_project: Treehouse (TCGA samples)
     url: https://public.gi.ucsc.edu/~ekephart/public-data/#tumor_25.01_polya
@@ -599,6 +658,7 @@ sources:
     category: expression
     cancer_codes: [GBM, LGG]
     source_type: treehouse-compendium
+    accession: GSE294351
     source_cohort: TREEHOUSE_POLYA_25_01_TCGA_SAMPLES
     source_project: Treehouse (TCGA samples)
     url: https://public.gi.ucsc.edu/~ekephart/public-data/#tumor_25.01_polya
@@ -634,6 +694,7 @@ sources:
     category: expression
     cancer_codes: [SARC_CHOR, RB]
     source_type: treehouse-compendium
+    accession: GSE294353
     source_cohort: TREEHOUSE_RIBOD_25_01
     source_project: Treehouse
     url: https://public.gi.ucsc.edu/~ekephart/public-data/#tumor_25.01_ribodeplete
@@ -668,9 +729,38 @@ sources:
   - id: beataml-ohsu-2022
     category: expression
     cancer_codes: [LAML_APL, LAML_ELNadv, LAML_ELNfav, LAML_ELNint]
-    source_type: summary-only-import
+    source_type: gdc
+    source_cohort: BEATAML_OHSU_2022
+    source_project: BeatAML 1.0
+    project_id: BEATAML1.0-COHORT
     url: https://biodev.github.io/BeatAML2/
-    builder: scripts/build_beataml_reference_expression.py
+    builder: scripts/build_gdc_source.py
+    expected_samples_by_code:
+      {LAML_APL: 20, LAML_ELNadv: 189, LAML_ELNfav: 238, LAML_ELNint: 154}
+    gdc_primary_diagnosis_routes:
+      LAML_APL:
+        - Acute promyelocytic leukaemia, PML-RAR-alpha
+      LAML_ELNfav:
+        - Acute myeloid leukemia with mutated CEBPA
+        - Acute myeloid leukemia, CBF-beta/MYH11
+        - Acute myeloid leukemia with t(8;21)(q22;q22); RUNX1-RUNX1T1
+        - Acute myeloid leukemia with mutated NPM1
+      LAML_ELNadv:
+        - Acute myeloid leukemia with myelodysplasia-related changes
+        - Therapy related myeloid neoplasm
+        - Acute myeloid leukemia with inv(3)(q21q26.2) or t(3;3)(q21;q26.2); RPN1-EVI1
+        - Acute myeloid leukemia with t(6;9)(p23;q34); DEK-NUP214
+        - Acute erythroid leukaemia
+      LAML_ELNint:
+        - Acute myeloid leukemia, NOS
+        - Acute myelomonocytic leukemia
+        - Acute monoblastic and monocytic leukemia
+        - Acute myeloid leukemia, minimal differentiation
+        - Acute myeloid leukemia without maturation
+        - Acute myeloid leukemia with maturation
+        - Acute myeloid leukemia with t(9;11)(p22;q23); MLLT3-MLL
+        - Acute megakaryoblastic leukaemia
+        - Myeloid sarcoma
     unit: TPM
     library_prep: polyA RNA-seq   # OHSU BeatAML Illumina TruSeq stranded mRNA (polyA)
     expected_size_gb: 0
@@ -703,10 +793,17 @@ sources:
   - id: gse299759-chon
     category: expression
     cancer_codes: [SARC_CHON]
-    source_type: summary-only-import
+    source_type: geo-matrix
     accession: GSE299759
-    builder: scripts/build_chon_reference_expression.py
-    unit: raw counts   # builder is raw_counts→TPM (GEO supplementary counts)
+    source_cohort: GSE299759_MEIJER_2026
+    source_project: GEO
+    builder: scripts/build_geo_matrix.py
+    file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE299nnn/GSE299759/suppl/GSE299759_raw_counts.tsv.gz
+    file_name: GSE299759_raw_counts.tsv.gz
+    gene_id_col: ""
+    unit: raw_counts
+    expected_source_samples: 54
+    expected_samples_by_code: {SARC_CHON: 54}
     expected_size_gb: 0
     citation: GSE299759 (Meijer 2026)
     special_handling: Chondrosarcoma.
@@ -714,10 +811,17 @@ sources:
   - id: gse239531-chordoma
     category: expression
     cancer_codes: [SARC_CHOR]
-    source_type: summary-only-import
+    source_type: geo-matrix
     accession: GSE239531
-    builder: scripts/build_chordoma_gse239531_reference_expression.py
-    unit: raw counts   # builder is raw_counts→TPM (GEO supplementary counts)
+    source_cohort: GSE239531_VANOOST_2024
+    source_project: GEO
+    builder: scripts/build_geo_matrix.py
+    file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE239nnn/GSE239531/suppl/GSE239531_raw_counts.tsv.gz
+    file_name: GSE239531_raw_counts.tsv.gz
+    gene_id_col: ""
+    unit: raw_counts
+    expected_source_samples: 20
+    expected_samples_by_code: {SARC_CHOR: 20}
     expected_size_gb: 0
     citation: GSE239531 (van Oost 2024, PMID 38272563)
     special_handling: >
@@ -730,6 +834,8 @@ sources:
     cancer_codes: [SARC_DDLPS, SARC_LGFMS, SARC_PLEOLPS]
     source_type: geo-rnaseq
     accession: GSE75885
+    source_cohort: GSE75885_DELESPAUL_2017
+    source_project: GEO
     builder: scripts/build_gse75885_sarc_reference_expression.py
     unit: RPKM   # processed matrix is RPKM-like; builder renormalizes to TPM
     expected_size_gb: 0.02
@@ -744,35 +850,60 @@ sources:
 
   - id: sclc-ucologne-2015
     category: expression
-    cancer_codes: [SCLC]
-    source_type: summary-only-import
+    cancer_codes: [SCLC, SCLC_ASCL1, SCLC_NEUROD1, SCLC_POU2F3, SCLC_YAP1]
+    source_type: geo-matrix
+    source_cohort: SCLC_UCOLOGNE_2015
+    source_project: University of Cologne
     url: https://www.nature.com/articles/nature14664
     builder: scripts/build_sclc_reference_expression.py
-    unit: FPKM   # George 2015 published FPKM; our builder is fpkm_to_tpm
+    file_url: https://media.githubusercontent.com/media/cBioPortal/datahub/master/public/sclc_ucologne_2015/data_mrna_seq_fpkm.txt
+    file_name: data_mrna_seq_fpkm.txt
+    unit: FPKM
+    gene_id_col: Hugo_Symbol
+    drop_cols: [Entrez_Gene_Id]
+    expected_source_samples: 81
+    expected_samples_by_code:
+      {SCLC: 81, SCLC_ASCL1: 61, SCLC_NEUROD1: 8, SCLC_POU2F3: 10, SCLC_YAP1: 2}
+    routed_samples_may_overlap: true
     expected_size_gb: 0
     citation: SCLC U.Cologne 2015 (George 2015, PMID 26168399)
     special_handling: Small-cell lung cancer summary import.
 
   - id: target-nbl
     category: expression
-    cancer_codes: [NBL_MYCNamp, NBL_MYCNnonamp]
-    source_type: summary-only-import
+    cancer_codes: [NBL, NBL_MYCNamp, NBL_MYCNnonamp]
+    source_type: gdc
     project_id: TARGET-NBL
+    source_cohort: TARGET_NBL_2018
+    source_project: TARGET Neuroblastoma
     builder: scripts/build_target_subprojects.py
+    expected_samples_by_code: {NBL: 155, NBL_MYCNamp: 33, NBL_MYCNnonamp: 122}
+    expected_source_samples: 155
+    routed_samples_may_overlap: true
+    gdc_primary_diagnosis_contains: [neuroblastoma, ganglioneuroblastoma]
+    tumor_origin: mixed
     unit: TPM
     library_prep: polyA RNA-seq   # TARGET Illumina TruSeq mRNA (polyA)
     expected_size_gb: 0
     citation: TARGET Neuroblastoma 2018
     special_handling: >
-      Neuroblastoma split by MYCN amplification status. Per-sample
-      data is on GDC — backfill candidate.
+      One deterministic GDC sample per case: 153 primary tumors plus
+      two recurrent samples required to reproduce the published
+      155-sample matrix. MYCN status comes from cBioPortal
+      nbl_target_2018_pub; the one explicit Unknown call stays in the
+      non-amplified child to preserve the published 33/122 split.
 
   - id: target-rt
     category: expression
     cancer_codes: [RT]
-    source_type: summary-only-import
+    source_type: gdc
     project_id: TARGET-RT
-    builder: scripts/build_target_subprojects.py
+    source_cohort: TARGET_RT_2017
+    source_project: TARGET Rhabdoid Tumor
+    builder: scripts/build_gdc_source.py
+    expected_samples_by_code: {RT: 63}
+    gdc_sample_types: [Primary Tumor]
+    gdc_primary_diagnosis_contains: [rhabdoid]
     unit: TPM
     library_prep: polyA RNA-seq   # TARGET Illumina TruSeq mRNA (polyA)
     expected_size_gb: 0
@@ -782,9 +913,14 @@ sources:
   - id: target-wt
     category: expression
     cancer_codes: [WILMS]
-    source_type: summary-only-import
+    source_type: gdc
     project_id: TARGET-WT
-    builder: scripts/build_target_subprojects.py
+    source_cohort: TARGET_WT_2015
+    source_project: TARGET Wilms Tumor
+    builder: scripts/build_gdc_source.py
+    expected_samples_by_code: {WILMS: 125}
+    gdc_sample_types: [Primary Tumor]
+    gdc_primary_diagnosis_contains: [nephroblastoma, wilms]
     unit: TPM
     library_prep: polyA RNA-seq   # TARGET Illumina TruSeq mRNA (polyA)
     expected_size_gb: 0
@@ -1159,6 +1295,7 @@ sources:
     category: expression
     cancer_codes: [FL]
     source_type: geo-matrix
+    accession: GSE142334
     builder: scripts/build_geo_matrix.py
     file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE142nnn/GSE142334/suppl/GSE142334_Proj_3970_htseq_all_samples.txt.gz
     file_name: GSE142334_Proj_3970_htseq_all_samples.txt.gz
@@ -1181,6 +1318,7 @@ sources:
     category: expression
     cancer_codes: [SARC_CCS]
     source_type: geo-matrix
+    accession: GSE248751
     builder: scripts/build_geo_matrix.py
     file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE248nnn/GSE248751/suppl/GSE248751_human_CCS_counts.txt.gz
     file_name: GSE248751_human_CCS_counts.txt.gz
@@ -1289,6 +1427,7 @@ sources:
     category: expression
     cancer_codes: [SARC_PEC]
     source_type: geo-matrix
+    accession: GSE328026
     builder: scripts/build_geo_matrix.py
     file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE328nnn/GSE328026/suppl/GSE328026_TPMs_all_Samples.txt.gz
     file_name: GSE328026_TPMs_all_Samples.txt.gz
@@ -1309,6 +1448,7 @@ sources:
     category: expression
     cancer_codes: [SARC_KS]
     source_type: geo-matrix
+    accession: GSE241095
     builder: scripts/build_geo_matrix.py
     file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE241nnn/GSE241095/suppl/GSE241095_Final_skin_asperpapersamplecode.csv.gz
     file_name: GSE241095_Final_skin_asperpapersamplecode.csv.gz
@@ -1369,6 +1509,7 @@ sources:
     category: expression
     cancer_codes: [NEC_MERKEL]
     source_type: geo-matrix
+    accession: GSE235092
     builder: scripts/build_geo_matrix.py
     file_url: https://ftp.ncbi.nlm.nih.gov/geo/series/GSE235nnn/GSE235092/suppl/GSE235092_all_bulk_counts.csv.gz
     file_name: GSE235092_all_bulk_counts.csv.gz
@@ -1488,6 +1629,8 @@ sources:
     category: expression
     cancer_codes: [SARC_ESS_LG, SARC_ESS_HG]
     source_type: geo-microarray
+    builder: scripts/build_v5_5_microarray_cohorts.py
+    builder_args: ["--only", "ess"]
     accession: GSE85383
     source_project: GEO
     source_cohort: GSE85383_YOSHIDA_2017_ESS
@@ -1513,6 +1656,11 @@ sources:
     unit: TPM
     tumor_origin: primary
     processing_pipeline: Whole-transcriptome RNA-seq gene-level TPM renormalized to 1e6; Ensembl 112
+    external_build_exemption: >
+      The three-case matrix was generated from controlled UNC case-series
+      RNA-seq files that are not publicly downloadable. The released matrix
+      remains auditable by its sample manifest and checksums, but a public
+      registry-backed downloader cannot reproduce it.
     special_handling: >
       Three primary NUT carcinoma cases. This is the only per-sample NUTM
       expression cohort; public NUT data are otherwise cell-line or

--- a/oncoref/expression_builders.py
+++ b/oncoref/expression_builders.py
@@ -243,6 +243,7 @@ class GdcSource:
     primary_diagnosis_contains: tuple[str, ...] = ()
     sample_id_include_match: str | None = None
     sample_to_cancer_code: Callable[[Mapping], str | None] | None = None
+    sample_lineage_evidence: Callable[[Mapping], str | None] | None = None
     expected_n: Mapping[str, int] | None = None
     notes: str = ""
     pipeline_stem: str = ""
@@ -263,7 +264,10 @@ class GeoMatrixSource:
     source download, raw parse diagnostics, unit-to-TPM conversion, canonical gene
     mapping, per-code routing, per-sample QC, and oncoref-style per-sample parquet
     output. Source-specific wrappers should supply the routing/filter functions;
-    the identity/QC contract remains here.
+    the identity/QC contract remains here. ``unit`` is the generic parser's raw
+    normalization input; adapters that supply an already-canonical matrix use
+    ``native_unit`` to retain a more specific provenance label such as
+    ``TPM proxy`` or ``nTPM (pseudobulk)``.
     """
 
     cancer_code: str | list[str]
@@ -285,6 +289,7 @@ class GeoMatrixSource:
     source_scale_class: str | None = None
     linear_tpm_comparable: bool | None = None
     tpm_proxy: bool | None = None
+    native_unit: str | None = None
     notes: str = ""
     pipeline_stem: str = ""
     source_version: str | None = None
@@ -741,6 +746,43 @@ def gdc_source_entries(registry_path: str | Path | None = None) -> list[dict]:
     ]
 
 
+def _compile_gdc_primary_diagnosis_router(
+    entry: Mapping,
+    *,
+    allowed_codes: Iterable[str],
+) -> Callable[[Mapping], str | None] | None:
+    """Compile exact GDC diagnosis labels into one deterministic code router."""
+    routes = entry.get("gdc_primary_diagnosis_routes") or {}
+    if not routes:
+        return None
+    allowed = {str(code) for code in allowed_codes}
+    unexpected = sorted({str(code) for code in routes} - allowed)
+    if unexpected:
+        raise ValueError(
+            f"source {entry.get('id')!r} routes diagnoses to undeclared cancer codes: {unexpected}"
+        )
+
+    diagnosis_to_code: dict[str, str] = {}
+    for code, diagnoses in routes.items():
+        for diagnosis in _coerce_string_tuple(diagnoses):
+            diagnosis = diagnosis.strip()
+            if not diagnosis:
+                raise ValueError(
+                    f"source {entry.get('id')!r} has a blank GDC primary diagnosis route"
+                )
+            previous = diagnosis_to_code.setdefault(diagnosis, str(code))
+            if previous != str(code):
+                raise ValueError(
+                    f"source {entry.get('id')!r} routes GDC diagnosis {diagnosis!r} "
+                    f"to both {previous!r} and {str(code)!r}"
+                )
+
+    def _route(row: Mapping) -> str | None:
+        return diagnosis_to_code.get(str(row.get("primary_diagnosis") or ""))
+
+    return _route
+
+
 def gdc_source_from_entry(entry: Mapping) -> GdcSource:
     """Convert one registry YAML entry into an executable :class:`GdcSource`."""
     if entry.get("source_type") != GDC_SOURCE_TYPE:
@@ -775,6 +817,11 @@ def gdc_source_from_entry(entry: Mapping) -> GdcSource:
             entry.get("gdc_primary_diagnosis_contains")
         ),
         sample_id_include_match=_coerce_optional_text(entry.get("gdc_sample_id_include_match")),
+        sample_to_cancer_code=_compile_gdc_primary_diagnosis_router(
+            entry,
+            allowed_codes=cancer_codes,
+        ),
+        sample_lineage_evidence=None,
         expected_n=expected,
         notes=str(entry.get("notes") or entry.get("special_handling") or ""),
         pipeline_stem=str(entry.get("pipeline_stem") or ""),
@@ -1700,9 +1747,23 @@ def read_source_expression_matrix(
         df = df.rename(columns={"index": row_id_col})
         symbol_col = None
     else:
-        row_id_col = gene_id_col or str(df.columns[0])
-        if row_id_col not in df.columns:
-            raise ValueError(f"gene_id_col={row_id_col!r} is not in columns: {list(df.columns)}")
+        if isinstance(df.index, pd.RangeIndex):
+            row_id_col = gene_id_col or str(df.columns[0])
+            if row_id_col not in df.columns:
+                raise ValueError(
+                    f"gene_id_col={row_id_col!r} is not in columns: {list(df.columns)}"
+                )
+        else:
+            # Some GEO matrices omit the gene-ID header while every data row
+            # still begins with a gene ID. Pandas preserves that leading field
+            # as the index.
+            row_id_col = gene_id_col or "source_row_id"
+            if row_id_col in df.columns:
+                raise ValueError(
+                    f"source matrix has both an implicit gene index and a {row_id_col!r} column"
+                )
+            df.insert(0, row_id_col, df.index)
+            df = df.reset_index(drop=True)
         df, row_id_col = _rename_unnamed_row_id(df, row_id_col)
         symbol_col = _detect_symbol_col(df, row_id_col, symbol_col)
 
@@ -1786,6 +1847,46 @@ def normalize_source_matrix_to_tpm(
     out.attrs["symbol_col"] = symbol_col
     out.attrs["source_expression_unit"] = unit
     return out
+
+
+def ensembl_gene_lengths_kb(
+    gene_ids: Iterable[str],
+    *,
+    release: int = 112,
+) -> pd.Series:
+    """Resolve canonical Ensembl gene IDs to genomic lengths in kilobases.
+
+    This build-time helper loads pyensembl lazily. Runtime accessors do not
+    require the optional genome dependency.
+    """
+    try:
+        from pyensembl import EnsemblRelease
+    except ImportError as error:
+        raise RuntimeError(
+            "raw-count source builds require pyensembl; install oncoref[genome]"
+        ) from error
+
+    genome = EnsemblRelease(release)
+    lengths: dict[str, float] = {}
+    last_error: Exception | None = None
+    for raw_id in gene_ids:
+        gene_id = unversioned(str(raw_id).strip())
+        if not gene_id:
+            continue
+        try:
+            length_kb = float(genome.gene_by_id(gene_id).length) / 1000.0
+        except Exception as error:
+            last_error = error
+            continue
+        if np.isfinite(length_kb) and length_kb > 0:
+            lengths[gene_id] = length_kb
+    if not lengths:
+        detail = f": {last_error}" if last_error is not None else ""
+        raise RuntimeError(
+            f"Ensembl release {release} has no usable gene lengths; "
+            f"install its pyensembl data first{detail}"
+        )
+    return pd.Series(lengths, dtype=float, name="gene_length_kb")
 
 
 def source_metadata(
@@ -2552,9 +2653,15 @@ def build_gdc_sample_manifest(source: GdcSource, hits: Iterable[Mapping]) -> pd.
     row_codes = manifest.apply(lambda row: _gdc_default_cancer_code(source, row.to_dict()), axis=1)
     manifest["cancer_code"] = row_codes.fillna("").astype(str)
     manifest["lineage_label"] = manifest["cancer_code"]
-    manifest["lineage_evidence_source"] = (
-        "GDC STAR-counts project/sample metadata routed by oncoref.expression_builders"
-    )
+    if source.sample_lineage_evidence is None:
+        manifest["lineage_evidence_source"] = (
+            "GDC STAR-counts project/sample metadata routed by oncoref.expression_builders"
+        )
+    else:
+        manifest["lineage_evidence_source"] = manifest.apply(
+            lambda row: str(source.sample_lineage_evidence(row.to_dict()) or ""),
+            axis=1,
+        )
 
     eligible = row_codes.notna() & row_codes.astype(str).ne("")
     if source.primary_sample_types:
@@ -3978,6 +4085,123 @@ def medulloblastoma_subgroup_matrices(matrix: pd.DataFrame) -> dict[str, pd.Data
     return {code: matrix[[*identifiers, *samples]].copy() for code, samples in groups.items()}
 
 
+SCLC_SUBTYPE_MARKERS = {
+    "SCLC_ASCL1": "ASCL1",
+    "SCLC_NEUROD1": "NEUROD1",
+    "SCLC_POU2F3": "POU2F3",
+    "SCLC_YAP1": "YAP1",
+}
+
+
+def sclc_subtype_sample_ids(matrix: pd.DataFrame) -> dict[str, list[str]]:
+    """Route SCLC samples by the largest source-row value for four markers.
+
+    The UCologne source contains duplicate rows for some HUGO symbols. Its
+    historical TF-dominance contract first takes the maximum row per symbol,
+    then selects the largest marker per sample. Classification must therefore
+    happen before duplicate rows are summed during canonical gene mapping.
+    """
+    marker_col = "Symbol" if "Symbol" in matrix.columns else matrix.attrs.get("row_id_col")
+    if marker_col is None or marker_col not in matrix.columns:
+        raise ValueError("SCLC source matrix lacks a marker-symbol column")
+    samples = (
+        sample_columns(matrix)
+        if "Symbol" in matrix.columns
+        else source_expression_value_columns(
+            matrix,
+            row_id_col=str(marker_col),
+            symbol_col=matrix.attrs.get("symbol_col"),
+        )
+    )
+    if not samples:
+        raise ValueError("SCLC source matrix has no sample columns")
+
+    marker_rows = matrix.loc[
+        matrix[marker_col].astype(str).isin(SCLC_SUBTYPE_MARKERS.values()),
+        [marker_col, *samples],
+    ]
+    marker_counts = marker_rows[marker_col].astype(str).value_counts()
+    invalid = sorted(
+        marker for marker in SCLC_SUBTYPE_MARKERS.values() if marker_counts.get(marker, 0) == 0
+    )
+    if invalid:
+        raise ValueError(
+            "SCLC source matrix must contain each subtype marker; missing: " + ", ".join(invalid)
+        )
+
+    expression = (
+        marker_rows.set_index(marker_col)[samples]
+        .apply(
+            pd.to_numeric,
+            errors="coerce",
+        )
+        .groupby(level=0)
+        .max()
+        .T
+    )
+    finite = np.isfinite(expression.to_numpy(dtype=float))
+    if not finite.all():
+        invalid_samples = expression.index[~finite.all(axis=1)].tolist()
+        raise ValueError(
+            "SCLC subtype-marker expression is missing, nonnumeric, or non-finite "
+            "for sample(s): " + ", ".join(invalid_samples[:5])
+        )
+    winners = expression.eq(expression.max(axis=1), axis=0)
+    tied = winners.index[winners.sum(axis=1) != 1].tolist()
+    if tied:
+        raise ValueError(
+            "SCLC subtype-marker maximum is tied for sample(s): " + ", ".join(tied[:5])
+        )
+
+    winning_symbol = winners.idxmax(axis=1)
+    groups = {"SCLC": samples}
+    groups.update(
+        {
+            code: winning_symbol.index[winning_symbol.eq(marker)].tolist()
+            for code, marker in SCLC_SUBTYPE_MARKERS.items()
+        }
+    )
+    return groups
+
+
+def build_sclc_source_matrices(
+    source: GeoMatrixSource,
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    source_path: str | Path | None = None,
+    force_download: bool = False,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build the parent SCLC matrix and its four TF-dominance views."""
+    cache = Path(cache_dir)
+    out_dir = Path(output_dir) if output_dir is not None else cache / "derived"
+    matrix, audit, diagnostics = prepare_source_matrix(
+        source,
+        cache_dir=cache,
+        source_path=source_path,
+        force_download=force_download,
+        high_expression_threshold=high_expression_threshold,
+    )
+    source_file = Path(source_path) if source_path is not None else cache / source.file_name
+    source_rows = read_source_expression_matrix(
+        source_file,
+        sep=source.sep,
+        gene_id_col=source.gene_id_col,
+        symbol_col=source.symbol_col,
+        drop_cols=source.drop_cols,
+        transposed=source.transposed,
+    )
+    return build_canonical_source_matrices(
+        source,
+        matrix,
+        routed_samples=sclc_subtype_sample_ids(source_rows),
+        output_dir=out_dir,
+        mapping_audit=audit,
+        parse_diagnostics=diagnostics,
+    )
+
+
 def _reconcile_per_code_artifacts(out_dir: Path, current_codes: Iterable[str]) -> None:
     """Remove stale per-code matrix/QC sidecars from a per-source output directory."""
     current_stems = {_artifact_stem(code) for code in current_codes}
@@ -4032,31 +4256,149 @@ def _validate_source_sample_count(source: GeoMatrixSource, actual_count: int) ->
         )
 
 
-def build_source_matrices(
+def build_canonical_source_matrices(
+    source: GeoMatrixSource,
+    matrix: pd.DataFrame,
+    *,
+    routed_samples: Mapping[str, Iterable[str]],
+    output_dir: str | Path,
+    mapping_audit: pd.DataFrame | None = None,
+    parse_diagnostics: pd.DataFrame | None = None,
+) -> SourceMatrixBuildResult:
+    """Write the standard artifacts for an already-canonical TPM matrix.
+
+    Source-specific adapters use this after their raw-source parsing and sample
+    routing. ``routed_samples`` may intentionally place one physical sample in
+    both a parent and a molecular-subtype cohort; every listed code must be
+    declared by ``source.cancer_code`` and every listed sample must be a matrix
+    column.
+    """
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    identifiers = id_columns(matrix)
+    if not identifiers:
+        raise ValueError("canonical source matrix has no identifier columns")
+    available_samples = set(sample_columns(matrix))
+    routed = {
+        str(code): [str(sample) for sample in samples] for code, samples in routed_samples.items()
+    }
+    declared_codes = (
+        {str(source.cancer_code)}
+        if isinstance(source.cancer_code, str)
+        else {str(code) for code in source.cancer_code}
+    )
+    unexpected_codes = sorted(set(routed) - declared_codes)
+    if unexpected_codes:
+        raise ValueError(f"samples routed to undeclared cancer codes: {unexpected_codes}")
+    missing_samples = sorted(
+        {
+            sample
+            for samples in routed.values()
+            for sample in samples
+            if sample not in available_samples
+        }
+    )
+    if missing_samples:
+        raise ValueError(f"routed samples are absent from the canonical matrix: {missing_samples}")
+    for code, samples in routed.items():
+        duplicates = sorted(
+            sample
+            for sample, count in pd.Series(samples, dtype=str).value_counts().items()
+            if count > 1
+        )
+        if duplicates:
+            raise ValueError(f"{code} contains duplicate routed samples: {duplicates}")
+    _validate_routed_sample_counts(
+        source.source_cohort,
+        routed,
+        source.expected_samples_by_code,
+    )
+
+    audit = mapping_audit.copy() if mapping_audit is not None else pd.DataFrame()
+    diagnostics = parse_diagnostics.copy() if parse_diagnostics is not None else pd.DataFrame()
+    stem = _artifact_stem(source.source_cohort)
+    sidecar_paths: dict[str, Path] = {}
+    audit_path = out_dir / f"{stem}_mapping_audit.csv"
+    parse_path = out_dir / f"{stem}_parse_diagnostics.csv"
+    _write_csv_atomic(audit, audit_path)
+    _write_csv_atomic(diagnostics, parse_path)
+    sidecar_paths["mapping_audit"] = audit_path
+    sidecar_paths["parse_diagnostics"] = parse_path
+
+    provenance_unit = source.native_unit or source.unit
+    meta = source_metadata(
+        source_cohort=source.source_cohort,
+        source_type=source.source_type or source.source_project,
+        unit=provenance_unit,
+        source_scale_class=source.source_scale_class,
+        linear_tpm_comparable=source.linear_tpm_comparable,
+        tpm_proxy=source.tpm_proxy,
+    )
+    from .expression import sample_expression_qc_from_matrix
+
+    matrices: dict[str, pd.DataFrame] = {}
+    matrix_paths: dict[str, Path] = {}
+    qc_frames: list[pd.DataFrame] = []
+    summary_frames: list[pd.DataFrame] = []
+    for code, samples in routed.items():
+        if not samples:
+            continue
+        sub = matrix[[*identifiers, *samples]].copy()
+        sub.attrs = {}
+        path = out_dir / f"{_artifact_stem(code)}_per_sample_tpm.parquet"
+        _write_parquet_atomic(sub, path)
+        qc = sample_expression_qc_from_matrix(sub, cancer_type=code, source_metadata=meta)
+        qc_path = out_dir / f"{_artifact_stem(code)}_sample_qc.csv"
+        _write_csv_atomic(qc, qc_path)
+        matrices[code] = sub
+        matrix_paths[code] = path
+        sidecar_paths[f"{code}_sample_qc"] = qc_path
+        qc_frames.append(qc)
+        summary_frames.append(
+            summarize_source_matrix(
+                sub,
+                cancer_code=code,
+                source=source,
+                native_unit=provenance_unit,
+            )
+        )
+
+    if not matrices:
+        raise ValueError("no samples were routed to a cancer code")
+    sample_qc = pd.concat(qc_frames, ignore_index=True) if qc_frames else pd.DataFrame()
+    summary_rows = (
+        pd.concat(summary_frames, ignore_index=True)
+        if summary_frames
+        else pd.DataFrame(columns=list(REFERENCE_EXPRESSION_COLUMNS))
+    )
+    summary_path = out_dir / f"{stem}_summary_rows.csv"
+    _write_csv_atomic(summary_rows, summary_path)
+    _reconcile_per_code_artifacts(out_dir, matrices)
+    sidecar_paths["summary_rows"] = summary_path
+    return SourceMatrixBuildResult(
+        source=source,
+        matrices=matrices,
+        matrix_paths=matrix_paths,
+        summary_rows=summary_rows,
+        mapping_audit=audit,
+        parse_diagnostics=diagnostics,
+        sample_qc=sample_qc,
+        sidecar_paths=sidecar_paths,
+    )
+
+
+def prepare_source_matrix(
     source: GeoMatrixSource,
     *,
     cache_dir: str | Path,
-    output_dir: str | Path | None = None,
     source_path: str | Path | None = None,
     force_download: bool = False,
     gene_lengths_kb: pd.Series | Mapping[str, float] | None = None,
+    ensembl_release: int = 112,
     high_expression_threshold: float = 1.0,
-) -> SourceMatrixBuildResult:
-    """Build oncoref source-matrix artifacts for one generic expression source.
-
-    Output matrices are written as ``<CODE>_per_sample_tpm.parquet`` under
-    ``output_dir`` (default ``cache_dir / "derived"``), matching the layout that
-    :mod:`scripts.stage_source_matrices` consumes before release upload. Sidecars
-    include source-row mapping audit, source-value parse diagnostics, and per-sample
-    QC manifests. Samples are not dropped here; read/build-time consumers choose
-    ``all``/``pass``/``pass_or_warn`` filtering from the QC manifest.
-    ``output_dir`` is treated as this source's derived-artifact directory; after a
-    successful build, stale per-code matrix/QC sidecars in it are removed.
-    """
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Download, parse, normalize, and canonicalize one generic source matrix."""
     cache = Path(cache_dir)
-    out_dir = Path(output_dir) if output_dir is not None else cache / "derived"
-    out_dir.mkdir(parents=True, exist_ok=True)
-
     file_path = Path(source_path) if source_path is not None else cache / source.file_name
     if not file_path.exists() or force_download:
         if not source.file_url:
@@ -4092,6 +4434,31 @@ def build_source_matrices(
     _, parse_diagnostics = coerce_source_expression_values(
         raw, value_cols=raw_value_cols, row_id_col=row_id_col, symbol_col=symbol_col
     )
+    if source.unit == "raw_counts" and gene_lengths_kb is None:
+        canonical_counts, audit = canonicalize_source_gene_matrix(
+            raw,
+            row_id_col=row_id_col,
+            symbol_col=symbol_col,
+            value_cols=raw_value_cols,
+            high_expression_threshold=high_expression_threshold,
+        )
+        canonical_lengths = ensembl_gene_lengths_kb(
+            canonical_counts["Ensembl_Gene_ID"],
+            release=ensembl_release,
+        )
+        has_length = canonical_counts["Ensembl_Gene_ID"].isin(canonical_lengths.index)
+        canonical_counts = canonical_counts.loc[has_length].reset_index(drop=True)
+        matrix = normalize_source_matrix_to_tpm(
+            canonical_counts,
+            unit="raw_counts",
+            row_id_col="Ensembl_Gene_ID",
+            symbol_col="Symbol",
+            value_cols=raw_value_cols,
+            gene_lengths_kb=canonical_lengths,
+        )
+        matrix.attrs["source_value_parse_diagnostics"] = parse_diagnostics
+        return matrix, audit, parse_diagnostics
+
     tpm = normalize_source_matrix_to_tpm(
         raw,
         unit=source.unit,
@@ -4108,94 +4475,56 @@ def build_source_matrices(
         high_expression_threshold=high_expression_threshold,
     )
     matrix.attrs["source_value_parse_diagnostics"] = parse_diagnostics
+    return matrix, audit, parse_diagnostics
 
-    meta = source_metadata(
-        source_cohort=source.source_cohort,
-        source_type=source.source_type or source.source_project,
-        unit=source.unit,
-        source_scale_class=source.source_scale_class,
-        linear_tpm_comparable=source.linear_tpm_comparable,
-        tpm_proxy=source.tpm_proxy,
+
+def build_source_matrices(
+    source: GeoMatrixSource,
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    source_path: str | Path | None = None,
+    force_download: bool = False,
+    gene_lengths_kb: pd.Series | Mapping[str, float] | None = None,
+    ensembl_release: int = 112,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build oncoref source-matrix artifacts for one generic expression source.
+
+    Output matrices are written as ``<CODE>_per_sample_tpm.parquet`` under
+    ``output_dir`` (default ``cache_dir / "derived"``), matching the layout that
+    :mod:`scripts.stage_source_matrices` consumes before release upload. Sidecars
+    include source-row mapping audit, source-value parse diagnostics, and per-sample
+    QC manifests. Samples are not dropped here; read/build-time consumers choose
+    ``all``/``pass``/``pass_or_warn`` filtering from the QC manifest.
+    ``output_dir`` is treated as this source's derived-artifact directory; after a
+    successful build, stale per-code matrix/QC sidecars in it are removed.
+    """
+    cache = Path(cache_dir)
+    out_dir = Path(output_dir) if output_dir is not None else cache / "derived"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    matrix, audit, parse_diagnostics = prepare_source_matrix(
+        source,
+        cache_dir=cache,
+        source_path=source_path,
+        force_download=force_download,
+        gene_lengths_kb=gene_lengths_kb,
+        ensembl_release=ensembl_release,
+        high_expression_threshold=high_expression_threshold,
     )
-
-    from .expression import sample_expression_qc_from_matrix
 
     routed = split_source_matrix_by_code(
         matrix,
         source.cancer_code,
         sample_to_cancer_code=source.sample_to_cancer_code,
     )
-    declared_codes = (
-        {str(source.cancer_code)}
-        if isinstance(source.cancer_code, str)
-        else {str(code) for code in source.cancer_code}
-    )
-    unexpected_codes = sorted(set(routed) - declared_codes)
-    if unexpected_codes:
-        raise ValueError(f"samples routed to undeclared cancer codes: {unexpected_codes}")
-    _validate_routed_sample_counts(
-        source.source_cohort,
-        routed,
-        source.expected_samples_by_code,
-    )
-
-    stem = _artifact_stem(source.source_cohort)
-    sidecar_paths: dict[str, Path] = {}
-    audit_path = out_dir / f"{stem}_mapping_audit.csv"
-    parse_path = out_dir / f"{stem}_parse_diagnostics.csv"
-    _write_csv_atomic(audit, audit_path)
-    _write_csv_atomic(parse_diagnostics, parse_path)
-    sidecar_paths["mapping_audit"] = audit_path
-    sidecar_paths["parse_diagnostics"] = parse_path
-
-    matrices: dict[str, pd.DataFrame] = {}
-    matrix_paths: dict[str, Path] = {}
-    qc_frames: list[pd.DataFrame] = []
-    summary_frames: list[pd.DataFrame] = []
-    for code, cols in routed.items():
-        if not cols:
-            continue
-        sub = matrix[[*id_columns(matrix), *cols]].copy()
-        sub.attrs = {}
-        path = out_dir / f"{_artifact_stem(code)}_per_sample_tpm.parquet"
-        _write_parquet_atomic(sub, path)
-        qc = sample_expression_qc_from_matrix(sub, cancer_type=code, source_metadata=meta)
-        qc_path = out_dir / f"{_artifact_stem(code)}_sample_qc.csv"
-        _write_csv_atomic(qc, qc_path)
-        matrices[code] = sub
-        matrix_paths[code] = path
-        sidecar_paths[f"{code}_sample_qc"] = qc_path
-        qc_frames.append(qc)
-        summary_frames.append(
-            summarize_source_matrix(
-                sub,
-                cancer_code=code,
-                source=source,
-                native_unit=source.unit,
-            )
-        )
-
-    if not matrices:
-        raise ValueError("no samples were routed to a cancer code")
-    sample_qc = pd.concat(qc_frames, ignore_index=True) if qc_frames else pd.DataFrame()
-    summary_rows = (
-        pd.concat(summary_frames, ignore_index=True)
-        if summary_frames
-        else pd.DataFrame(columns=list(REFERENCE_EXPRESSION_COLUMNS))
-    )
-    summary_path = out_dir / f"{stem}_summary_rows.csv"
-    _write_csv_atomic(summary_rows, summary_path)
-    _reconcile_per_code_artifacts(out_dir, matrices)
-    sidecar_paths["summary_rows"] = summary_path
-    return SourceMatrixBuildResult(
-        source=source,
-        matrices=matrices,
-        matrix_paths=matrix_paths,
-        summary_rows=summary_rows,
+    return build_canonical_source_matrices(
+        source,
+        matrix,
+        routed_samples=routed,
+        output_dir=out_dir,
         mapping_audit=audit,
         parse_diagnostics=parse_diagnostics,
-        sample_qc=sample_qc,
-        sidecar_paths=sidecar_paths,
     )
 
 

--- a/oncoref/expression_registry.py
+++ b/oncoref/expression_registry.py
@@ -43,7 +43,10 @@ class ExpressionSource:
     source_type: str
     builder: str | None = None
     builder_args: tuple[str, ...] = ()
+    external_build_exemption: str | None = None
+    routed_samples_may_overlap: bool = False
     project_id: str | None = None
+    project_ids: tuple[str, ...] = ()
     accession: str | None = None
     url: str | None = None
     unit: str | None = None
@@ -76,6 +79,14 @@ def _coerce_float(value) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _coerce_bool(value, *, field: str) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    raise ValueError(f"{field} must be a YAML boolean")
 
 
 def _clean(value):
@@ -134,7 +145,13 @@ def load_registry() -> tuple[ExpressionSource, ...]:
                 source_type=str(entry.get("source_type", "")),
                 builder=_clean(entry.get("builder")),
                 builder_args=_coerce_tuple(entry.get("builder_args")),
+                external_build_exemption=_clean(entry.get("external_build_exemption")),
+                routed_samples_may_overlap=_coerce_bool(
+                    entry.get("routed_samples_may_overlap"),
+                    field=f"{entry['id']}.routed_samples_may_overlap",
+                ),
                 project_id=_clean(entry.get("project_id")),
+                project_ids=_coerce_tuple(entry.get("project_ids")),
                 accession=_clean(entry.get("accession")),
                 url=_clean(entry.get("url")),
                 unit=_clean(entry.get("unit")),
@@ -186,13 +203,17 @@ def expression_sources_df() -> pd.DataFrame:
             "source_version": s.source_version,
             "unit": s.unit,
             "library_prep": s.library_prep,
-            "project_id": s.project_id or s.accession or s.recount3_srp,
+            "project_id": ";".join(s.project_ids) or s.project_id or s.accession or s.recount3_srp,
             "tumor_origin": s.tumor_origin,
             "metastasis_site": s.metastasis_site,
             "processing_pipeline": s.processing_pipeline,
             "notes": s.notes,
             "expected_size_gb": s.expected_size_gb,
             "citation": s.citation,
+            "builder": s.builder,
+            "builder_args": " ".join(s.builder_args),
+            "external_build_exemption": s.external_build_exemption,
+            "routed_samples_may_overlap": s.routed_samples_may_overlap,
         }
         for s in load_registry()
     )

--- a/oncoref/expression_source_adapters.py
+++ b/oncoref/expression_source_adapters.py
@@ -1,0 +1,1463 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Small adapters for public expression sources with nonstandard metadata.
+
+Each adapter is responsible only for extracting the source-specific sample
+labels or file layout. Normalization, canonical gene mapping, sample QC, summary
+statistics, and artifact naming remain in :mod:`oncoref.expression_builders`.
+"""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import io
+import json
+import re
+import shutil
+import tarfile
+import urllib.request
+import zipfile
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from .expression_builders import (
+    GeoMatrixSource,
+    SourceMatrixBuildResult,
+    build_canonical_source_matrices,
+    build_gdc_source_matrices,
+    ensembl_gene_lengths_kb,
+    gdc_source_from_registry,
+    prepare_source_matrix,
+)
+from .expression_engine import (
+    canonicalize_source_gene_matrix,
+    coerce_source_expression_values,
+    sample_columns,
+)
+from .expression_registry import expression_source_registry_entries
+
+GSE75885_EXPRESSION_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE75nnn/GSE75885/suppl/"
+    "GSE75885_Expression_117_sarcomas.tsv.gz"
+)
+GSE75885_SERIES_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE75nnn/GSE75885/matrix/GSE75885_series_matrix.txt.gz"
+)
+GSE75885_LABEL_TO_CODE = {
+    "Liposarcoma - dedifferentiated": "SARC_DDLPS",
+    "Liposarcoma - pleomorphic": "SARC_PLEOLPS",
+    "Low grade fibromyxoid sarcoma": "SARC_LGFMS",
+}
+
+DRMETRICS_COUNTS_URL = (
+    "https://raw.githubusercontent.com/IARCbioinfo/DRMetrics/NextJournalH/"
+    "data/read_counts_all.txt.zip"
+)
+DRMETRICS_ATTRIBUTES_URL = (
+    "https://raw.githubusercontent.com/IARCbioinfo/DRMetrics/NextJournalH/data/Attributes.txt.zip"
+)
+DRMETRICS_HISTOLOGY_TO_CODE = {
+    "Typical": "NET_LUNG",
+    "Atypical": "NET_LUNG",
+    "Carcinoid": "NET_LUNG",
+    "Supra_carcinoid": "NET_LUNG",
+    "LCNEC": "NEC_LUNG_LARGECELL",
+}
+
+TARGET_ALL_SAMPLE_MATRICES = {
+    "TARGET_ALL_P1": {
+        "file_id": "c5b8499d-8777-4ad5-bb6b-48cfeca68aed",
+        "members": ("TARGET_ALL_SampleMatrix_Phase1_20190606.xlsx",),
+    },
+    "TARGET_ALL_P2": {
+        "file_id": "313fd46b-8111-45dd-88df-4e637a4d2249",
+        "members": (
+            "TARGET_ALL_SampleMatrix_Phase2_Discovery_20190606.xlsx",
+            "TARGET_ALL_SampleMatrix_Phase2_Validation_20190606.xlsx",
+        ),
+    },
+}
+CBIOPORTAL_NBL_MYCN_URL = (
+    "https://www.cbioportal.org/api/studies/nbl_target_2018_pub/"
+    "clinical-data?clinicalDataType=SAMPLE&attributeId=MYCN"
+)
+CTCL_RAW_URL = "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE171nnn/GSE171811/suppl/GSE171811_RAW.tar"
+CTCL_SOFT_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE171nnn/GSE171811/soft/GSE171811_family.soft.gz"
+)
+CTCL_SAMPLE_NAME = re.compile(r"^(GSM\d+)_(.+)_(Blood|Skin)_GEX\.tsv\.gz$")
+
+
+@dataclass(frozen=True)
+class GeoMicroarrayGroup:
+    """One GEO series/platform combination and its cancer-code filters."""
+
+    source_id: str
+    accession: str
+    platform_id: str
+    platform_name: str
+    sample_patterns: Mapping[str, str | None]
+    expected_samples: Mapping[str, int]
+    log2_transformed: bool = True
+    symbol_platform_id: str | None = None
+
+
+MICROARRAY_GROUPS = {
+    "mtc": GeoMicroarrayGroup(
+        source_id="gse32662-mtc",
+        accession="GSE32662",
+        platform_id="GPL6480",
+        platform_name="Agilent Human Genome 4x44K v1",
+        sample_patterns={"MTC": None},
+        expected_samples={"MTC": 52},
+    ),
+    "ess": GeoMicroarrayGroup(
+        source_id="gse85383-ess",
+        accession="GSE85383",
+        platform_id="GPL22303",
+        platform_name="Agilent SurePrint G3 Human Gene Expression v3",
+        sample_patterns={
+            "SARC_ESS_LG": r"(?i)low.?grade",
+            "SARC_ESS_HG": r"(?i)high.?grade",
+        },
+        expected_samples={"SARC_ESS_LG": 9, "SARC_ESS_HG": 4},
+        symbol_platform_id="GPL13497",
+    ),
+    "lps": GeoMicroarrayGroup(
+        source_id="gse30929-lps",
+        accession="GSE30929",
+        platform_id="GPL96",
+        platform_name="Affymetrix HG-U133A",
+        sample_patterns={
+            "SARC_WDLPS": r"(?i)well-differentiated",
+            "SARC_DDLPS": r"(?i)dedifferentiated",
+            "SARC_PLEOLPS": r"(?i)pleomorphic",
+            "SARC_MYXLPS": r"(?i)myxoid",
+        },
+        expected_samples={
+            "SARC_WDLPS": 52,
+            "SARC_DDLPS": 40,
+            "SARC_PLEOLPS": 20,
+            "SARC_MYXLPS": 28,
+        },
+    ),
+}
+
+
+def _registry_entry(source_id: str) -> dict:
+    matches = [
+        entry for entry in expression_source_registry_entries() if str(entry.get("id")) == source_id
+    ]
+    if len(matches) != 1:
+        raise KeyError(f"expected one expression source {source_id!r}; found {len(matches)}")
+    return matches[0]
+
+
+def _download(url: str, path: Path, *, force: bool = False) -> Path:
+    """Download one cacheable public source file atomically."""
+    if path.exists() and path.stat().st_size > 0 and not force:
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with urllib.request.urlopen(url, timeout=180) as response, temporary.open("wb") as handle:
+        shutil.copyfileobj(response, handle)
+    temporary.replace(path)
+    return path
+
+
+def _extract_single_file(archive: Path, output_dir: Path) -> Path:
+    """Extract the sole regular file in a ZIP without accepting unsafe paths."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive) as zipped:
+        members = [info for info in zipped.infolist() if not info.is_dir()]
+        if len(members) != 1:
+            raise ValueError(f"{archive} contains {len(members)} files; expected exactly one")
+        member = members[0]
+        name = Path(member.filename)
+        if name.is_absolute() or ".." in name.parts:
+            raise ValueError(f"{archive} contains unsafe path {member.filename!r}")
+        path = output_dir / name.name
+        if not path.exists() or path.stat().st_size != member.file_size:
+            temporary = path.with_suffix(path.suffix + ".tmp")
+            with zipped.open(member) as source, temporary.open("wb") as destination:
+                shutil.copyfileobj(source, destination)
+            temporary.replace(path)
+    return path
+
+
+def geo_sample_titles(series_matrix_path: str | Path) -> dict[str, str]:
+    """Return ``sample_id -> title suffix`` from one GEO series matrix.
+
+    The supported title format is ``<sample-id> - <label>``. Malformed or
+    duplicate sample IDs fail explicitly instead of silently changing routing.
+    """
+    title_line = ""
+    with gzip.open(Path(series_matrix_path), "rt", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if line.startswith("!Sample_title"):
+                title_line = line
+                break
+    if not title_line:
+        raise ValueError(f"{series_matrix_path} has no !Sample_title row")
+
+    titles: dict[str, str] = {}
+    for title in re.findall(r'"([^"]+)"', title_line):
+        if " - " not in title:
+            raise ValueError(f"unsupported GEO sample title {title!r}")
+        sample_id, label = (part.strip() for part in title.split(" - ", 1))
+        if not sample_id or not label:
+            raise ValueError(f"unsupported GEO sample title {title!r}")
+        if sample_id in titles:
+            raise ValueError(f"duplicate GEO sample title for {sample_id!r}")
+        titles[sample_id] = label
+    if not titles:
+        raise ValueError(f"{series_matrix_path} has no quoted sample titles")
+    return titles
+
+
+def gse75885_routed_samples(
+    samples: Iterable[str],
+    sample_titles: Mapping[str, str],
+) -> dict[str, list[str]]:
+    """Route only the three GSE75885 histologies owned by this source."""
+    routed = {code: [] for code in GSE75885_LABEL_TO_CODE.values()}
+    for sample in samples:
+        sample_id = str(sample)
+        if sample_id not in sample_titles:
+            raise ValueError(f"GSE75885 expression sample {sample_id!r} has no GEO title")
+        code = GSE75885_LABEL_TO_CODE.get(str(sample_titles[sample_id]))
+        if code is not None:
+            routed[code].append(sample_id)
+    return routed
+
+
+def build_gse75885_source_matrices(
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    expression_path: str | Path | None = None,
+    series_matrix_path: str | Path | None = None,
+    force_download: bool = False,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build the three registry-owned GSE75885 sarcoma matrices."""
+    entry = _registry_entry("gse75885-sarc")
+    cache = Path(cache_dir)
+    source = GeoMatrixSource(
+        cancer_code=[str(code) for code in entry["cancer_codes"]],
+        source_cohort=str(entry["source_cohort"]),
+        source_project=str(entry.get("source_project") or "GEO"),
+        citation=str(entry.get("citation") or ""),
+        file_url=GSE75885_EXPRESSION_URL,
+        file_name="GSE75885_Expression_117_sarcomas.tsv.gz",
+        unit="RPKM",
+        expected_source_samples=117,
+        expected_samples_by_code={"SARC_DDLPS": 19, "SARC_LGFMS": 2, "SARC_PLEOLPS": 4},
+        notes=str(entry.get("special_handling") or ""),
+        tumor_origin="mixed",
+        source_type=str(entry.get("source_type") or "geo-rnaseq"),
+    )
+    matrix, audit, diagnostics = prepare_source_matrix(
+        source,
+        cache_dir=cache,
+        source_path=expression_path,
+        force_download=force_download,
+        high_expression_threshold=high_expression_threshold,
+    )
+    series_path = (
+        Path(series_matrix_path)
+        if series_matrix_path is not None
+        else _download(
+            GSE75885_SERIES_URL,
+            cache / "GSE75885_series_matrix.txt.gz",
+            force=force_download,
+        )
+    )
+    routed = gse75885_routed_samples(sample_columns(matrix), geo_sample_titles(series_path))
+    return build_canonical_source_matrices(
+        source,
+        matrix,
+        routed_samples=routed,
+        output_dir=Path(output_dir) if output_dir is not None else cache / "derived",
+        mapping_audit=audit,
+        parse_diagnostics=diagnostics,
+    )
+
+
+def drmetrics_routed_samples(
+    samples: Iterable[str],
+    attributes: pd.DataFrame,
+) -> dict[str, list[str]]:
+    """Route DRMetrics samples by its published simplified histology."""
+    required = {"Sample_ID", "Histopathology_simplified"}
+    missing = sorted(required - set(attributes.columns))
+    if missing:
+        raise ValueError(f"DRMetrics attributes lack columns: {missing}")
+    if attributes["Sample_ID"].astype(str).duplicated().any():
+        raise ValueError("DRMetrics attributes contain duplicate Sample_ID values")
+    sample_to_histology = dict(
+        zip(
+            attributes["Sample_ID"].astype(str),
+            attributes["Histopathology_simplified"].astype(str),
+        )
+    )
+    routed = {code: [] for code in set(DRMETRICS_HISTOLOGY_TO_CODE.values())}
+    for sample in samples:
+        sample_id = str(sample)
+        if sample_id not in sample_to_histology:
+            raise ValueError(f"DRMetrics expression sample {sample_id!r} has no attributes row")
+        code = DRMETRICS_HISTOLOGY_TO_CODE.get(sample_to_histology[sample_id])
+        if code is not None:
+            routed[code].append(sample_id)
+    return routed
+
+
+def build_drmetrics_source_matrices(
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    counts_path: str | Path | None = None,
+    attributes_path: str | Path | None = None,
+    force_download: bool = False,
+    ensembl_release: int = 112,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build lung carcinoid and LCNEC matrices from the DRMetrics release."""
+    entry = _registry_entry("drmetrics-lnen-2020")
+    cache = Path(cache_dir)
+    if counts_path is None:
+        archive = _download(
+            DRMETRICS_COUNTS_URL,
+            cache / "read_counts_all.txt.zip",
+            force=force_download,
+        )
+        counts = _extract_single_file(archive, cache)
+    else:
+        counts = Path(counts_path)
+    if attributes_path is None:
+        archive = _download(
+            DRMETRICS_ATTRIBUTES_URL,
+            cache / "Attributes.txt.zip",
+            force=force_download,
+        )
+        attributes = _extract_single_file(archive, cache)
+    else:
+        attributes = Path(attributes_path)
+
+    gene_ids = pd.read_csv(counts, sep=r"\s+", usecols=[0], dtype=str).iloc[:, 0]
+    lengths = ensembl_gene_lengths_kb(gene_ids, release=ensembl_release)
+    source = GeoMatrixSource(
+        cancer_code=[str(code) for code in entry["cancer_codes"]],
+        source_cohort=str(entry["source_cohort"]),
+        source_project="IARC pan-LNEN",
+        citation=str(entry.get("citation") or ""),
+        file_name=counts.name,
+        unit="raw_counts",
+        gene_id_col="gene_id",
+        sep=r"\s+",
+        expected_source_samples=238,
+        expected_samples_by_code={"NET_LUNG": 118, "NEC_LUNG_LARGECELL": 69},
+        notes=str(entry.get("special_handling") or ""),
+        tumor_origin="primary",
+        source_type=str(entry.get("source_type") or "github-release"),
+    )
+    matrix, audit, diagnostics = prepare_source_matrix(
+        source,
+        cache_dir=cache,
+        source_path=counts,
+        gene_lengths_kb=lengths,
+        high_expression_threshold=high_expression_threshold,
+    )
+    attrs = pd.read_csv(
+        attributes,
+        sep="\t",
+        usecols=["Sample_ID", "Histopathology_simplified"],
+        dtype=str,
+    )
+    routed = drmetrics_routed_samples(sample_columns(matrix), attrs)
+    return build_canonical_source_matrices(
+        source,
+        matrix,
+        routed_samples=routed,
+        output_dir=Path(output_dir) if output_dir is not None else cache / "derived",
+        mapping_audit=audit,
+        parse_diagnostics=diagnostics,
+    )
+
+
+@dataclass(frozen=True)
+class TargetAllLineageAssignment:
+    """One TARGET ALL case's explicit B/T lineage evidence."""
+
+    cancer_code: str
+    raw_label: str
+    evidence_source: str
+
+
+def parse_target_all_lineage_label(comment: object) -> tuple[str, str]:
+    """Return the raw ``Cell of origin`` value and its canonical ALL code."""
+    text = "" if comment is None else str(comment)
+    match = re.search(r"Cell of origin:\s*([^;\n\r]+)", text)
+    if match is None:
+        return "", ""
+    raw_label = match.group(1).strip()
+    if raw_label.lower().startswith("indeterminate"):
+        return raw_label, ""
+    if re.match(r"^B(\b|-|\s+precursor|\s+cell)", raw_label, flags=re.IGNORECASE):
+        return raw_label, "B_ALL"
+    if re.match(r"^T(\b|-|\s+cell)", raw_label, flags=re.IGNORECASE):
+        return raw_label, "T_ALL"
+    return raw_label, ""
+
+
+def _extract_named_tar_members(
+    archive: Path,
+    member_names: Iterable[str],
+    output_dir: Path,
+) -> list[Path]:
+    """Extract an explicit member allowlist without trusting archive paths."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths = []
+    with tarfile.open(archive, "r:gz") as tar:
+        available = {member.name: member for member in tar.getmembers() if member.isfile()}
+        for name in member_names:
+            if name not in available:
+                raise ValueError(f"{archive} lacks required member {name!r}")
+            path = output_dir / Path(name).name
+            member = available[name]
+            if not path.exists() or path.stat().st_size != member.size:
+                extracted = tar.extractfile(member)
+                if extracted is None:
+                    raise ValueError(f"{archive} member {name!r} cannot be read")
+                temporary = path.with_suffix(path.suffix + ".tmp")
+                with extracted, temporary.open("wb") as destination:
+                    shutil.copyfileobj(extracted, destination)
+                temporary.replace(path)
+            paths.append(path)
+    return paths
+
+
+def target_all_lineage_assignments(
+    sample_matrices: Iterable[tuple[str, str | Path]],
+) -> dict[str, TargetAllLineageAssignment]:
+    """Resolve case-level B/T assignments from the public TARGET matrices."""
+    rows = []
+    for evidence_name, path in sample_matrices:
+        matrix = pd.read_excel(Path(path), sheet_name="Sample Names")
+        required = {"Case USI", "Comments"}
+        missing = sorted(required - set(matrix.columns))
+        if missing:
+            raise ValueError(f"{path} lacks TARGET lineage columns: {missing}")
+        for _index, row in matrix.loc[matrix["Case USI"].notna()].iterrows():
+            case_id = str(row["Case USI"])
+            raw_label, cancer_code = parse_target_all_lineage_label(row["Comments"])
+            if cancer_code:
+                rows.append(
+                    {
+                        "case_id": case_id,
+                        "raw_label": raw_label,
+                        "cancer_code": cancer_code,
+                        "evidence_source": str(evidence_name),
+                    }
+                )
+
+    if not rows:
+        raise ValueError("TARGET ALL sample matrices contain no explicit B/T lineage assignments")
+    assignments: dict[str, TargetAllLineageAssignment] = {}
+    for case_id, group in pd.DataFrame(rows).groupby("case_id", sort=False):
+        codes = sorted(set(group["cancer_code"].astype(str)))
+        if len(codes) != 1:
+            raise ValueError(f"TARGET ALL case {case_id!r} has conflicting lineages: {codes}")
+        labels = sorted(set(group["raw_label"].astype(str)))
+        evidence = sorted(set(group["evidence_source"].astype(str)))
+        assignments[str(case_id)] = TargetAllLineageAssignment(
+            cancer_code=codes[0],
+            raw_label="; ".join(labels),
+            evidence_source=(f"{'; '.join(evidence)}; Cell of origin: {'; '.join(labels)}"),
+        )
+    return assignments
+
+
+def fetch_target_all_lineages(
+    cache_dir: str | Path,
+    *,
+    force_download: bool = False,
+) -> dict[str, TargetAllLineageAssignment]:
+    """Download the public TARGET phase sample matrices and resolve lineage."""
+    cache = Path(cache_dir) / "sample_matrices"
+    matrices = []
+    for archive_name, record in TARGET_ALL_SAMPLE_MATRICES.items():
+        archive = _download(
+            f"https://api.gdc.cancer.gov/data/{record['file_id']}",
+            cache / f"{archive_name}.tar.gz",
+            force=force_download,
+        )
+        paths = _extract_named_tar_members(
+            archive,
+            record["members"],
+            cache / archive_name,
+        )
+        matrices.extend((f"{archive_name} {path.stem} sample matrix", path) for path in paths)
+    return target_all_lineage_assignments(matrices)
+
+
+def build_target_all_source_matrices(
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    lineage_assignments: Mapping[str, TargetAllLineageAssignment] | None = None,
+    manifest: pd.DataFrame | None = None,
+    file_paths: Mapping[str, str | Path] | None = None,
+    force_download: bool = False,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build TARGET ALL matrices using its authoritative phase lineage tables."""
+    cache = Path(cache_dir)
+    assignments = (
+        dict(lineage_assignments)
+        if lineage_assignments is not None
+        else fetch_target_all_lineages(cache, force_download=force_download)
+    )
+    base = gdc_source_from_registry("target-all")
+
+    def route(row: Mapping) -> str | None:
+        assignment = assignments.get(str(row.get("case_id") or ""))
+        return assignment.cancer_code if assignment is not None else None
+
+    def evidence(row: Mapping) -> str | None:
+        assignment = assignments.get(str(row.get("case_id") or ""))
+        return assignment.evidence_source if assignment is not None else None
+
+    source = replace(
+        base,
+        primary_sample_types=(
+            "Primary Blood Derived Cancer - Bone Marrow",
+            "Primary Blood Derived Cancer - Peripheral Blood",
+        ),
+        primary_diagnosis_contains=("acute lymphocytic leukemia",),
+        sample_to_cancer_code=route,
+        sample_lineage_evidence=evidence,
+        expected_n={"B_ALL": 154, "T_ALL": 264},
+    )
+    return build_gdc_source_matrices(
+        source,
+        cache_dir=cache,
+        output_dir=output_dir,
+        manifest=manifest,
+        file_paths=file_paths,
+        force_download=force_download,
+        high_expression_threshold=high_expression_threshold,
+    )
+
+
+def fetch_nbl_mycn_status(
+    cache_path: str | Path,
+    *,
+    force_download: bool = False,
+) -> dict[str, str]:
+    """Return case-level ``amp``, ``nonamp``, or ``unknown`` MYCN calls."""
+    cache = Path(cache_path)
+    if cache.exists() and cache.stat().st_size > 0 and not force_download:
+        rows = pd.read_csv(cache, dtype=str)
+    else:
+        with urllib.request.urlopen(CBIOPORTAL_NBL_MYCN_URL, timeout=120) as response:
+            payload = json.load(response)
+        rows = pd.DataFrame(
+            {
+                "case_id": str(item.get("patientId") or ""),
+                "raw_mycn_status": str(item.get("value") or ""),
+            }
+            for item in payload
+        )
+
+    required = {"case_id", "raw_mycn_status"}
+    missing = sorted(required - set(rows.columns))
+    if missing:
+        raise ValueError(f"NBL MYCN table lacks columns: {missing}")
+
+    normalized = {"Amplified": "amp", "Not Amplified": "nonamp", "Unknown": "unknown"}
+    rows = rows.copy()
+    rows["mycn_status"] = rows["raw_mycn_status"].map(normalized)
+    if rows["mycn_status"].isna().any():
+        unexpected = sorted(set(rows.loc[rows["mycn_status"].isna(), "raw_mycn_status"]))
+        raise ValueError(f"unsupported cBioPortal MYCN values: {unexpected}")
+    conflicts = {
+        case_id: sorted(set(group["mycn_status"]))
+        for case_id, group in rows.groupby("case_id")
+        if group["mycn_status"].nunique() != 1
+    }
+    if conflicts:
+        raise ValueError(f"conflicting cBioPortal MYCN values: {conflicts}")
+    unique = rows.drop_duplicates("case_id")[["case_id", "raw_mycn_status", "mycn_status"]]
+    if not cache.exists() or force_download:
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        temporary = cache.with_suffix(cache.suffix + ".tmp")
+        unique.to_csv(temporary, index=False)
+        temporary.replace(cache)
+    return dict(zip(unique["case_id"].astype(str), unique["mycn_status"].astype(str)))
+
+
+def nbl_mycn_routed_samples(
+    samples: Iterable[str],
+    case_status: Mapping[str, str],
+) -> dict[str, list[str]]:
+    """Route every NBL sample to the parent and exactly one MYCN child."""
+    routed = {"NBL": [], "NBL_MYCNamp": [], "NBL_MYCNnonamp": []}
+    for sample in samples:
+        sample_id = str(sample)
+        case_id = "-".join(sample_id.split("-")[:3])
+        status = case_status.get(case_id)
+        if status not in {"amp", "nonamp", "unknown"}:
+            raise ValueError(f"NBL sample {sample_id!r} lacks a supported MYCN call")
+        routed["NBL"].append(sample_id)
+        child = "NBL_MYCNamp" if status == "amp" else "NBL_MYCNnonamp"
+        routed[child].append(sample_id)
+    return routed
+
+
+def build_target_nbl_source_matrices(
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    manifest: pd.DataFrame | None = None,
+    file_paths: Mapping[str, str | Path] | None = None,
+    mycn_status: Mapping[str, str] | None = None,
+    force_download: bool = False,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build the TARGET NBL parent and its mutually exclusive MYCN children."""
+    cache = Path(cache_dir)
+    out_dir = Path(output_dir) if output_dir is not None else cache / "derived"
+    base = gdc_source_from_registry("target-nbl")
+    parent_source = replace(
+        base,
+        cancer_code="NBL",
+        primary_sample_types=(),
+        primary_diagnosis_contains=("neuroblastoma", "ganglioneuroblastoma"),
+        sample_to_cancer_code=None,
+        expected_n={"NBL": 155},
+        tumor_origin="mixed",
+    )
+    parent = build_gdc_source_matrices(
+        parent_source,
+        cache_dir=cache,
+        output_dir=out_dir,
+        manifest=manifest,
+        file_paths=file_paths,
+        force_download=force_download,
+        high_expression_threshold=high_expression_threshold,
+    )
+    statuses = (
+        dict(mycn_status)
+        if mycn_status is not None
+        else fetch_nbl_mycn_status(
+            cache / "cbioportal_nbl_mycn.csv",
+            force_download=force_download,
+        )
+    )
+    matrix = parent.matrices["NBL"]
+    routed = nbl_mycn_routed_samples(sample_columns(matrix), statuses)
+    source = GeoMatrixSource(
+        cancer_code=["NBL", "NBL_MYCNamp", "NBL_MYCNnonamp"],
+        source_cohort=base.source_cohort,
+        source_project=base.source_project,
+        citation=base.citation,
+        file_name="GDC TARGET-NBL STAR-counts files",
+        unit="TPM",
+        expected_source_samples=155,
+        expected_samples_by_code={"NBL": 155, "NBL_MYCNamp": 33, "NBL_MYCNnonamp": 122},
+        source_scale_class="linear_rnaseq_tpm",
+        linear_tpm_comparable=True,
+        tpm_proxy=False,
+        notes=(
+            "One deterministic GDC sample per TARGET-NBL case. The released cohort "
+            "contains 153 primary and two recurrent samples. MYCN children use "
+            "cBioPortal nbl_target_2018_pub; its one explicit Unknown call is retained "
+            "in the non-amplified child to preserve the published 33/122 split."
+        ),
+        tumor_origin="mixed",
+        source_type="gdc",
+    )
+    result = build_canonical_source_matrices(
+        source,
+        matrix,
+        routed_samples=routed,
+        output_dir=out_dir,
+        mapping_audit=parent.mapping_audit,
+        parse_diagnostics=parent.parse_diagnostics,
+    )
+
+    evidence_rows = []
+    for sample in sample_columns(matrix):
+        case_id = "-".join(str(sample).split("-")[:3])
+        status = statuses[case_id]
+        evidence_rows.append(
+            {
+                "sample_id": str(sample),
+                "case_id": case_id,
+                "mycn_status": status,
+                "child_cancer_code": ("NBL_MYCNamp" if status == "amp" else "NBL_MYCNnonamp"),
+                "evidence_source": (
+                    "cBioPortal nbl_target_2018_pub sample clinical attribute MYCN"
+                ),
+            }
+        )
+    evidence_path = out_dir / "target_nbl_2018_mycn_routing.csv"
+    temporary = evidence_path.with_suffix(evidence_path.suffix + ".tmp")
+    pd.DataFrame(evidence_rows).to_csv(temporary, index=False)
+    temporary.replace(evidence_path)
+    return SourceMatrixBuildResult(
+        source=result.source,
+        matrices=result.matrices,
+        matrix_paths=result.matrix_paths,
+        summary_rows=result.summary_rows,
+        mapping_audit=result.mapping_audit,
+        parse_diagnostics=result.parse_diagnostics,
+        sample_qc=result.sample_qc,
+        sidecar_paths={
+            **result.sidecar_paths,
+            "gdc_sample_manifest": parent.sidecar_paths["gdc_sample_manifest"],
+            "mycn_routing": evidence_path,
+        },
+    )
+
+
+@dataclass(frozen=True)
+class CtclSampleRecord:
+    """Paired GEX/TCR-beta matrices for one CTCL study specimen."""
+
+    gsm_id: str
+    case_id: str
+    compartment: str
+    gex_name: str
+    tcrb_name: str
+
+    @property
+    def is_healthy_control(self) -> bool:
+        return self.case_id.upper().startswith("HC")
+
+
+def parse_geo_soft_samples(path: str | Path) -> dict[str, dict[str, str]]:
+    """Parse the small sample-metadata subset needed from a GEO family SOFT."""
+    samples: dict[str, dict[str, str]] = {}
+    current: dict[str, str] | None = None
+    with gzip.open(Path(path), "rt", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.rstrip("\n")
+            if line.startswith("^SAMPLE = "):
+                current = {"geo_accession": line.split(" = ", 1)[1]}
+                samples[current["geo_accession"]] = current
+                continue
+            if current is None:
+                continue
+            if line.startswith("!Sample_title = "):
+                current["title"] = line.split(" = ", 1)[1]
+            elif line.startswith("!Sample_characteristics_ch1 = "):
+                value = line.split(" = ", 1)[1]
+                key, separator, field_value = value.partition(":")
+                if separator:
+                    current[key.strip().lower()] = field_value.strip()
+    if not samples:
+        raise ValueError(f"{path} contains no GEO samples")
+    return samples
+
+
+def ctcl_sample_records(tar_names: Iterable[str]) -> list[CtclSampleRecord]:
+    """Pair each CTCL GEX member with its matching TCR-beta member."""
+    names = {str(name) for name in tar_names}
+    records = []
+    for gex_name in sorted(name for name in names if name.endswith("_GEX.tsv.gz")):
+        match = CTCL_SAMPLE_NAME.fullmatch(gex_name)
+        if match is None:
+            raise ValueError(f"unsupported CTCL GEX member name {gex_name!r}")
+        tcrb_name = gex_name.replace("_GEX.tsv.gz", "_TCRb.tsv.gz")
+        if tcrb_name not in names:
+            raise ValueError(f"CTCL GEX member {gex_name!r} has no matching TCR-beta matrix")
+        records.append(
+            CtclSampleRecord(
+                gsm_id=match.group(1),
+                case_id=match.group(2),
+                compartment=match.group(3),
+                gex_name=gex_name,
+                tcrb_name=tcrb_name,
+            )
+        )
+    if not records:
+        raise ValueError("CTCL archive contains no paired GEX/TCR-beta samples")
+    return records
+
+
+@contextmanager
+def _tar_gzip_rows(tar: tarfile.TarFile, member_name: str):
+    """Yield tab-separated rows from one gzip-compressed TAR member."""
+    member = tar.extractfile(member_name)
+    if member is None:
+        raise ValueError(f"CTCL archive member {member_name!r} cannot be read")
+    with (
+        member,
+        gzip.GzipFile(fileobj=member) as compressed,
+        io.TextIOWrapper(compressed) as text,
+    ):
+        yield csv.reader(text, delimiter="\t")
+
+
+def _ctcl_top_clone(tar: tarfile.TarFile, member_name: str) -> tuple[str, int, tuple[str, ...]]:
+    with _tar_gzip_rows(tar, member_name) as reader:
+        header = next(reader)
+        ranked = []
+        for row in reader:
+            if len(row) != len(header):
+                raise ValueError(f"{member_name} contains a malformed clone row")
+            try:
+                count = sum(int(value) for value in row[1:] if value)
+            except ValueError as error:
+                raise ValueError(f"{member_name} has a non-integer TCR count") from error
+            ranked.append((count, row[0]))
+    if not ranked:
+        raise ValueError(f"{member_name} has no TCR clones")
+    ranked.sort(reverse=True)
+    if len(ranked) > 1 and ranked[0][0] == ranked[1][0]:
+        raise ValueError(f"{member_name} has a tied dominant TCR-beta clone")
+    return ranked[0][1], ranked[0][0], tuple(header[1:])
+
+
+def _ctcl_selected_cells(
+    tar: tarfile.TarFile,
+    member_name: str,
+    clone: str,
+) -> tuple[list[int], tuple[str, ...]]:
+    with _tar_gzip_rows(tar, member_name) as reader:
+        header = next(reader)
+        for row in reader:
+            if len(row) != len(header):
+                raise ValueError(f"{member_name} contains a malformed clone row")
+            if row[0] != clone:
+                continue
+            indices = [
+                index for index, value in enumerate(row[1:], start=1) if value and value != "0"
+            ]
+            return indices, tuple(header[1:])
+    return [], tuple(header[1:])
+
+
+def _add_ctcl_gex_counts(
+    tar: tarfile.TarFile,
+    record: CtclSampleRecord,
+    selected_indices: list[int],
+    tcr_cell_ids: tuple[str, ...],
+    counts_by_symbol: dict[str, defaultdict[str, float]],
+) -> None:
+    with _tar_gzip_rows(tar, record.gex_name) as reader:
+        header = next(reader)
+        if tuple(header[1:]) != tcr_cell_ids:
+            raise ValueError(
+                f"{record.gex_name} and {record.tcrb_name} have different cell columns"
+            )
+        for row in reader:
+            if len(row) != len(header):
+                raise ValueError(f"{record.gex_name} contains a malformed gene row")
+            count = sum(float(row[index]) for index in selected_indices)
+            if count > 0:
+                counts_by_symbol[row[0]][record.case_id] += count
+
+
+def ctcl_case_pseudobulk(
+    raw_tar_path: str | Path,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Select dominant-clone cells and return case counts plus provenance."""
+    with tarfile.open(Path(raw_tar_path)) as tar:
+        records = ctcl_sample_records(tar.getnames())
+        blood_clones: dict[str, set[str]] = defaultdict(set)
+        for record in records:
+            if record.is_healthy_control or record.compartment != "Blood":
+                continue
+            clone, _count, _cell_ids = _ctcl_top_clone(tar, record.tcrb_name)
+            blood_clones[record.case_id].add(clone)
+        conflicts = {
+            case_id: sorted(clones) for case_id, clones in blood_clones.items() if len(clones) != 1
+        }
+        if conflicts:
+            raise ValueError(f"CTCL cases lack one unambiguous blood TCR-beta clone: {conflicts}")
+        case_clone = {case_id: next(iter(clones)) for case_id, clones in blood_clones.items()}
+
+        counts_by_symbol: dict[str, defaultdict[str, float]] = defaultdict(
+            lambda: defaultdict(float)
+        )
+        manifest_rows = []
+        for record in records:
+            clone = case_clone.get(record.case_id, "")
+            selected_indices: list[int] = []
+            cell_ids: tuple[str, ...] = ()
+            if not record.is_healthy_control:
+                if not clone:
+                    raise ValueError(f"CTCL case {record.case_id!r} has no blood clone")
+                selected_indices, cell_ids = _ctcl_selected_cells(
+                    tar,
+                    record.tcrb_name,
+                    clone,
+                )
+                _add_ctcl_gex_counts(
+                    tar,
+                    record,
+                    selected_indices,
+                    cell_ids,
+                    counts_by_symbol,
+                )
+            else:
+                _clone, _count, cell_ids = _ctcl_top_clone(tar, record.tcrb_name)
+            manifest_rows.append(
+                {
+                    "cancer_code": "CTCL",
+                    "source_cohort": "GSE171811_ECCITE_CTCL",
+                    "case_id": record.case_id,
+                    "sample_id": f"{record.gsm_id}_{record.case_id}_{record.compartment}",
+                    "source_file_id": record.gsm_id,
+                    "source_file_name": f"GSE171811_RAW.tar:{record.gex_name}",
+                    "sample_type": record.compartment,
+                    "raw_unit": "scRNA UMI counts",
+                    "lineage_evidence_source": (
+                        f"dominant blood TCR-beta clone {clone}; "
+                        f"{len(selected_indices)} of {len(cell_ids)} cells selected"
+                        if not record.is_healthy_control
+                        else "healthy-control specimen excluded"
+                    ),
+                    "included": not record.is_healthy_control and bool(selected_indices),
+                    "exclusion_reason": ("healthy_control" if record.is_healthy_control else ""),
+                    "lineage_label": "CTCL" if not record.is_healthy_control else "",
+                }
+            )
+
+    cases = sorted(case_clone)
+    counts = pd.DataFrame(
+        (
+            {
+                "source_symbol": symbol,
+                **{case: values.get(case, 0.0) for case in cases},
+            }
+            for symbol, values in counts_by_symbol.items()
+        )
+    )
+    if counts.empty or len(cases) != 7:
+        raise ValueError(f"CTCL pseudobulk produced {len(cases)} cases and {len(counts)} genes")
+    return counts, pd.DataFrame(manifest_rows)
+
+
+def build_ctcl_source_matrices(
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    raw_tar_path: str | Path | None = None,
+    soft_path: str | Path | None = None,
+    force_download: bool = False,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build seven CTCL case pseudobulks from GSE171811 GEX/TCR-beta data."""
+    entry = _registry_entry("gse171811-ctcl")
+    cache = Path(cache_dir)
+    raw_tar = (
+        Path(raw_tar_path)
+        if raw_tar_path is not None
+        else _download(
+            CTCL_RAW_URL,
+            cache / "GSE171811_RAW.tar",
+            force=force_download,
+        )
+    )
+    soft = (
+        Path(soft_path)
+        if soft_path is not None
+        else _download(
+            CTCL_SOFT_URL,
+            cache / "GSE171811_family.soft.gz",
+            force=force_download,
+        )
+    )
+    counts, manifest = ctcl_case_pseudobulk(raw_tar)
+    sample_metadata = parse_geo_soft_samples(soft)
+    manifest["primary_diagnosis"] = manifest["source_file_id"].map(
+        lambda gsm: sample_metadata.get(str(gsm), {}).get("disease state", "")
+    )
+    manifest["sample_type"] = manifest.apply(
+        lambda row: sample_metadata.get(str(row["source_file_id"]), {}).get(
+            "tissue",
+            row["sample_type"],
+        ),
+        axis=1,
+    )
+
+    value_cols = [column for column in counts.columns if column != "source_symbol"]
+    values = counts[value_cols].apply(pd.to_numeric, errors="raise")
+    totals = values.sum(axis=0)
+    if (totals <= 0).any():
+        raise ValueError("CTCL pseudobulk contains a case with no selected UMI counts")
+    ntpm = values.div(totals, axis=1) * 1_000_000.0
+    raw = pd.concat([counts[["source_symbol"]], ntpm], axis=1)
+    _, diagnostics = coerce_source_expression_values(
+        raw,
+        value_cols=value_cols,
+        row_id_col="source_symbol",
+    )
+    matrix, audit = canonicalize_source_gene_matrix(
+        raw,
+        row_id_col="source_symbol",
+        value_cols=value_cols,
+        high_expression_threshold=high_expression_threshold,
+    )
+    source = GeoMatrixSource(
+        cancer_code="CTCL",
+        source_cohort=str(entry["source_cohort"]),
+        source_project="GEO",
+        citation=str(entry.get("citation") or ""),
+        file_name=raw_tar.name,
+        unit="TPM",
+        expected_source_samples=7,
+        expected_samples_by_code={"CTCL": 7},
+        source_scale_class="scrna_tcr_pseudobulk_ntpm",
+        linear_tpm_comparable=False,
+        tpm_proxy=True,
+        native_unit=str(entry.get("unit") or "nTPM (pseudobulk)"),
+        notes=(
+            "GSE171811 CTCL ECCITE-seq. Each disease patient's dominant blood "
+            "TCR-beta clonotype selects cells from available blood/skin specimens; "
+            "UMIs are pseudobulked per case and scaled to nTPM. This rank-preserving "
+            "single-cell pseudobulk is not directly comparable to bulk RNA-seq TPM."
+        ),
+        processing_pipeline=(
+            "gse171811_ctcl_scrna_tcrb_pseudobulk_ntpm_ensembl112_clean_tpm_16_9_75"
+        ),
+        tumor_origin="primary",
+        source_type="geo-scrna-pseudobulk",
+    )
+    out_dir = Path(output_dir) if output_dir is not None else cache / "derived"
+    result = build_canonical_source_matrices(
+        source,
+        matrix,
+        routed_samples={"CTCL": sample_columns(matrix)},
+        output_dir=out_dir,
+        mapping_audit=audit,
+        parse_diagnostics=diagnostics,
+    )
+    manifest_path = out_dir / "gse171811_eccite_ctcl_sample_manifest.csv"
+    temporary = manifest_path.with_suffix(manifest_path.suffix + ".tmp")
+    manifest.to_csv(temporary, index=False)
+    temporary.replace(manifest_path)
+    return SourceMatrixBuildResult(
+        source=result.source,
+        matrices=result.matrices,
+        matrix_paths=result.matrix_paths,
+        summary_rows=result.summary_rows,
+        mapping_audit=result.mapping_audit,
+        parse_diagnostics=result.parse_diagnostics,
+        sample_qc=result.sample_qc,
+        sidecar_paths={**result.sidecar_paths, "sample_manifest": manifest_path},
+    )
+
+
+def geo_platform_url(platform_id: str) -> str:
+    """GEO text view containing one platform's probe annotations."""
+    return (
+        "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi"
+        f"?targ=self&form=text&view=full&acc={platform_id}"
+    )
+
+
+def geo_series_matrix_url(accession: str) -> str:
+    """FTP URL for an accession's primary GEO series matrix."""
+    prefix = f"{accession[:-3]}nnn"
+    return (
+        f"https://ftp.ncbi.nlm.nih.gov/geo/series/{prefix}/{accession}/matrix/"
+        f"{accession}_series_matrix.txt.gz"
+    )
+
+
+def _open_text(path: Path):
+    if path.suffix == ".gz":
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return path.open("r", encoding="utf-8", errors="replace")
+
+
+def _read_geo_platform_table(path: str | Path) -> pd.DataFrame:
+    """Read the delimited table inside a GEO platform text response."""
+    table_started = False
+    header: list[str] = []
+    rows: list[list[str]] = []
+    with _open_text(Path(path)) as handle:
+        for line in handle:
+            if line.startswith("!platform_table_begin"):
+                table_started = True
+                header = handle.readline().rstrip("\n").split("\t")
+                continue
+            if not table_started:
+                continue
+            if line.startswith("!platform_table_end"):
+                break
+            values = line.rstrip("\n").split("\t")
+            rows.append((values + [""] * len(header))[: len(header)])
+    if not table_started or not header:
+        raise ValueError(f"{path} has no GEO platform table")
+    return pd.DataFrame(rows, columns=header, dtype=str)
+
+
+def _parallel_symbol_entrez_pairs(symbols: str, entrez_ids: str) -> list[tuple[str, str]]:
+    symbol_values = [value.strip() for value in str(symbols).split("///")]
+    entrez_values = [value.strip() for value in str(entrez_ids).split("///")]
+    entrez_values.extend([""] * (len(symbol_values) - len(entrez_values)))
+    return list(zip(symbol_values, entrez_values[: len(symbol_values)]))
+
+
+def parse_geo_platform_annotations(path: str | Path) -> pd.DataFrame:
+    """Return probe, symbol, and optional Entrez assignments from GEO."""
+    table = _read_geo_platform_table(path)
+    probe_col = next(
+        (
+            column
+            for column in ("ID", "ID_REF", "Probe Set ID", "ProbeName", "ProbeID")
+            if column in table.columns
+        ),
+        None,
+    )
+    symbol_col = next(
+        (
+            column
+            for column in (
+                "Gene symbol",
+                "Gene Symbol",
+                "GeneSymbol",
+                "Symbol",
+                "GENE_SYMBOL",
+                "ILMN_Gene",
+            )
+            if column in table.columns
+        ),
+        None,
+    )
+    entrez_col = next(
+        (
+            column
+            for column in (
+                "ENTREZ_GENE_ID",
+                "Entrez Gene ID",
+                "Entrez_Gene_ID",
+                "EntrezGeneID",
+                "ENTREZID",
+                "GENE",
+            )
+            if column in table.columns
+        ),
+        None,
+    )
+    if probe_col is None:
+        raise ValueError(f"{path} has no recognized GEO probe column")
+
+    out = pd.DataFrame({"probe_id": table[probe_col].astype(str)})
+    out["gene_symbol"] = (
+        table[symbol_col].astype(str) if symbol_col is not None else out["probe_id"]
+    )
+    out["entrez_id"] = table[entrez_col].astype(str) if entrez_col is not None else ""
+    out["symbol_entrez_pairs"] = out.apply(
+        lambda row: _parallel_symbol_entrez_pairs(row["gene_symbol"], row["entrez_id"]),
+        axis=1,
+    )
+    out = out.explode("symbol_entrez_pairs")
+    out[["gene_symbol", "entrez_id"]] = pd.DataFrame(
+        out["symbol_entrez_pairs"].tolist(),
+        index=out.index,
+    )
+    out = out.drop(columns="symbol_entrez_pairs")
+    valid = (
+        out["probe_id"].str.strip().ne("")
+        & out["gene_symbol"].str.strip().ne("")
+        & out["gene_symbol"].str.strip().ne("---")
+    )
+    return out.loc[valid].reset_index(drop=True)
+
+
+def _unversioned_accession(value: str) -> str:
+    return str(value).split(".", 1)[0].strip()
+
+
+def parse_geo_platform_annotation_bridge(
+    primary_path: str | Path,
+    symbol_path: str | Path,
+) -> pd.DataFrame:
+    """Join a symbol-less platform to a same-design symbol platform by GB_ACC."""
+    primary = _read_geo_platform_table(primary_path)
+    symbol_table = _read_geo_platform_table(symbol_path)
+    probe_col = next(
+        (column for column in ("ID", "ID_REF", "ProbeName") if column in primary.columns),
+        None,
+    )
+    primary_accession_col = next(
+        (column for column in ("GB_ACC", "SystematicName", "ID") if column in primary.columns),
+        None,
+    )
+    symbol_accession_col = next(
+        (column for column in ("GB_ACC", "SystematicName") if column in symbol_table.columns),
+        None,
+    )
+    symbol_col = next(
+        (
+            column
+            for column in ("GENE_SYMBOL", "Gene Symbol", "GeneSymbol")
+            if column in symbol_table.columns
+        ),
+        None,
+    )
+    if not all((probe_col, primary_accession_col, symbol_accession_col, symbol_col)):
+        raise ValueError("GEO platform bridge lacks probe, accession, or symbol columns")
+    entrez_col = next(
+        (
+            column
+            for column in ("GENE", "ENTREZ_GENE_ID", "Entrez Gene ID")
+            if column in symbol_table.columns
+        ),
+        None,
+    )
+
+    lookup = pd.DataFrame(
+        {
+            "join_key": symbol_table[symbol_accession_col].map(_unversioned_accession),
+            "gene_symbol": symbol_table[symbol_col].astype(str).str.strip(),
+            "entrez_id": (
+                symbol_table[entrez_col].astype(str).str.strip() if entrez_col is not None else ""
+            ),
+        }
+    )
+    lookup = lookup.loc[lookup["gene_symbol"].ne("")].drop_duplicates("join_key")
+    primary_rows = pd.DataFrame(
+        {
+            "probe_id": primary[probe_col].astype(str),
+            "join_key": primary[primary_accession_col].map(_unversioned_accession),
+        }
+    )
+    out = primary_rows.merge(lookup, on="join_key", how="inner").drop(columns="join_key")
+    return out.loc[out["probe_id"].str.strip().ne("")].reset_index(drop=True)
+
+
+def parse_geo_series_matrix(
+    path: str | Path,
+) -> tuple[pd.DataFrame, dict[str, dict[str, str]]]:
+    """Parse probe intensities and per-sample metadata from a GEO series matrix."""
+    metadata_rows: dict[str, list[str]] = {}
+    characteristic_rows: list[list[str]] = []
+    table_started = False
+    with gzip.open(Path(path), "rt", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.rstrip("\n")
+            if line == "!series_matrix_table_begin":
+                table_started = True
+                break
+            if not line.startswith("!Sample_"):
+                continue
+            key, *values = line.split("\t")
+            cleaned = [value.strip().strip('"') for value in values]
+            if key == "!Sample_characteristics_ch1":
+                characteristic_rows.append(cleaned)
+            else:
+                metadata_rows[key.removeprefix("!")] = cleaned
+        if not table_started:
+            raise ValueError(f"{path} has no series-matrix table")
+        header = [value.strip().strip('"') for value in next(handle).rstrip("\n").split("\t")]
+        sample_ids = header[1:]
+        if not sample_ids or len(sample_ids) != len(set(sample_ids)):
+            raise ValueError(f"{path} has empty or duplicate sample columns")
+        probe_ids: list[str] = []
+        values: list[list[float]] = []
+        for line in handle:
+            if line.startswith("!series_matrix_table_end"):
+                break
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) != len(header):
+                raise ValueError(f"{path} contains a malformed expression row")
+            probe_ids.append(fields[0].strip().strip('"'))
+            values.append(
+                [pd.to_numeric(field.strip().strip('"'), errors="coerce") for field in fields[1:]]
+            )
+
+    matrix = pd.DataFrame(values, index=probe_ids, columns=sample_ids, dtype=float)
+    matrix.index.name = "probe_id"
+    sample_metadata = {sample: {} for sample in sample_ids}
+    for key, row in metadata_rows.items():
+        if len(row) == len(sample_ids):
+            for sample, value in zip(sample_ids, row):
+                sample_metadata[sample][key] = value
+    for row in characteristic_rows:
+        if len(row) != len(sample_ids):
+            raise ValueError(f"{path} has a malformed sample-characteristics row")
+        for sample, value in zip(sample_ids, row):
+            if not value:
+                continue
+            key, separator, field_value = value.partition(":")
+            metadata_key = f"char_{key.strip().lower().replace(' ', '_')}" if separator else "char"
+            sample_metadata[sample][metadata_key] = (
+                field_value.strip() if separator else key.strip()
+            )
+    return matrix, sample_metadata
+
+
+def microarray_tpm_proxy(
+    intensities: pd.DataFrame,
+    annotations: pd.DataFrame,
+    *,
+    log2_transformed: bool,
+) -> pd.DataFrame:
+    """Collapse probes by symbol and scale each sample to a TPM-like proxy."""
+    required = {"probe_id", "gene_symbol"}
+    missing = sorted(required - set(annotations.columns))
+    if missing:
+        raise ValueError(f"microarray annotations lack columns: {missing}")
+    if intensities.empty or intensities.shape[1] == 0:
+        raise ValueError("microarray intensity matrix is empty")
+    if not np.isfinite(intensities.to_numpy(dtype=float)).all():
+        raise ValueError("microarray intensity matrix contains non-finite values")
+
+    joined = intensities.join(
+        annotations[["probe_id", "gene_symbol"]].set_index("probe_id"),
+        how="inner",
+    )
+    if joined.empty:
+        raise ValueError("microarray probes do not overlap the platform annotations")
+    by_symbol = joined.groupby("gene_symbol", sort=False).max()
+    linear = np.power(2.0, by_symbol) if log2_transformed else by_symbol.clip(lower=0.0)
+    totals = linear.sum(axis=0)
+    if (totals <= 0).any():
+        failed = totals.index[totals <= 0].astype(str).tolist()
+        raise ValueError(f"microarray samples have no positive signal: {failed}")
+    return linear.div(totals, axis=1) * 1_000_000.0
+
+
+def microarray_routed_samples(
+    sample_metadata: Mapping[str, Mapping[str, str]],
+    sample_patterns: Mapping[str, str | None],
+) -> dict[str, list[str]]:
+    """Apply mutually exclusive cancer-code regexes to sample metadata."""
+    routed = {str(code): [] for code in sample_patterns}
+    for sample_id, fields in sample_metadata.items():
+        matched_codes = [
+            str(code)
+            for code, pattern in sample_patterns.items()
+            if pattern is None or any(re.search(pattern, str(value)) for value in fields.values())
+        ]
+        if len(matched_codes) > 1:
+            raise ValueError(
+                f"microarray sample {sample_id!r} matches multiple codes: {matched_codes}"
+            )
+        if matched_codes:
+            routed[matched_codes[0]].append(str(sample_id))
+    return routed
+
+
+def build_geo_microarray_group(
+    group: GeoMicroarrayGroup,
+    *,
+    cache_dir: str | Path,
+    output_dir: str | Path | None = None,
+    series_matrix_path: str | Path | None = None,
+    platform_path: str | Path | None = None,
+    symbol_platform_path: str | Path | None = None,
+    force_download: bool = False,
+    ensembl_release: int = 112,
+    high_expression_threshold: float = 1.0,
+) -> SourceMatrixBuildResult:
+    """Build one GEO microarray group through the shared canonical pipeline."""
+    entry = _registry_entry(group.source_id)
+    cache = Path(cache_dir)
+    series = (
+        Path(series_matrix_path)
+        if series_matrix_path is not None
+        else _download(
+            geo_series_matrix_url(group.accession),
+            cache / f"{group.accession}_series_matrix.txt.gz",
+            force=force_download,
+        )
+    )
+    platform = (
+        Path(platform_path)
+        if platform_path is not None
+        else _download(
+            geo_platform_url(group.platform_id),
+            cache / f"{group.platform_id}.platform_table.txt",
+            force=force_download,
+        )
+    )
+    symbol_platform = None
+    if group.symbol_platform_id is not None:
+        symbol_platform = (
+            Path(symbol_platform_path)
+            if symbol_platform_path is not None
+            else _download(
+                geo_platform_url(group.symbol_platform_id),
+                cache / f"{group.symbol_platform_id}.platform_table.txt",
+                force=force_download,
+            )
+        )
+
+    intensities, metadata = parse_geo_series_matrix(series)
+    annotations = (
+        parse_geo_platform_annotation_bridge(platform, symbol_platform)
+        if symbol_platform is not None
+        else parse_geo_platform_annotations(platform)
+    )
+    proxy = microarray_tpm_proxy(
+        intensities,
+        annotations,
+        log2_transformed=group.log2_transformed,
+    )
+    raw = proxy.reset_index().rename(columns={"gene_symbol": "source_symbol"})
+    value_cols = [str(column) for column in proxy.columns]
+    _, diagnostics = coerce_source_expression_values(
+        raw,
+        value_cols=value_cols,
+        row_id_col="source_symbol",
+    )
+    matrix, audit = canonicalize_source_gene_matrix(
+        raw,
+        row_id_col="source_symbol",
+        value_cols=value_cols,
+        high_expression_threshold=high_expression_threshold,
+    )
+    routed = microarray_routed_samples(metadata, group.sample_patterns)
+    source = GeoMatrixSource(
+        cancer_code=list(group.sample_patterns),
+        source_cohort=str(entry["source_cohort"]),
+        source_project=str(entry.get("source_project") or "GEO"),
+        citation=str(entry.get("citation") or ""),
+        file_name=series.name,
+        unit="TPM",
+        expected_source_samples=len(intensities.columns),
+        expected_samples_by_code=group.expected_samples,
+        source_scale_class="microarray_tpm_proxy",
+        linear_tpm_comparable=False,
+        tpm_proxy=True,
+        native_unit=str(entry.get("unit") or "TPM proxy"),
+        notes=(
+            f"{group.platform_name} ({group.platform_id}) microarray-derived TPM proxy. "
+            "Preserves within-sample gene rank but is not directly comparable to RNA-seq TPM. "
+            f"{entry.get('special_handling') or ''}"
+        ).strip(),
+        processing_pipeline=(
+            f"{group.platform_id.lower()}_microarray_tpm_proxy_ensembl"
+            f"{ensembl_release}_clean_tpm_16_9_75"
+        ),
+        tumor_origin=str(entry.get("tumor_origin") or "primary"),
+        source_type=str(entry.get("source_type") or "geo-microarray"),
+    )
+    return build_canonical_source_matrices(
+        source,
+        matrix,
+        routed_samples=routed,
+        output_dir=Path(output_dir) if output_dir is not None else cache / "derived",
+        mapping_audit=audit,
+        parse_diagnostics=diagnostics,
+    )

--- a/oncoref/source_matrices.py
+++ b/oncoref/source_matrices.py
@@ -88,6 +88,17 @@ class SourceMatrixResolution:
         return tuple(matrix.cancer_code for matrix in self.matrices)
 
 
+REGENERATION_AUDIT_COLUMNS = (
+    "cancer_code",
+    "source_cohort",
+    "source_id",
+    "builder",
+    "builder_args",
+    "external_build_exemption",
+    "status",
+)
+
+
 @lru_cache(maxsize=1)
 def registry() -> pd.DataFrame:
     """The per-cohort registry (``cancer_code``, ``source_cohort``, ``n_samples``)
@@ -186,6 +197,114 @@ def codes_for_source(source_id: str) -> list[str]:
     physical-source match from routing through the source's declared codes.
     """
     return list(resolution_for_source(source_id).codes)
+
+
+def source_matrix_regeneration_audit(
+    project_root: str | Path | None = None,
+) -> pd.DataFrame:
+    """Audit exact build ownership for every published source matrix.
+
+    Ownership is physical-source specific: both ``cancer_code`` and
+    ``source_cohort`` must match one expression-registry entry. An owner must
+    declare exactly one of:
+
+    - an existing repository-relative ``builder`` script; or
+    - a nonempty ``external_build_exemption`` explaining why public
+      regeneration is impossible.
+
+    ``project_root`` defaults to the source checkout root containing
+    ``oncoref/`` and ``scripts/``. Passing it explicitly is useful when auditing
+    an unpacked source distribution.
+    """
+    from .expression_registry import expression_source_registry_entries
+
+    root = (
+        Path(project_root).expanduser().resolve()
+        if project_root is not None
+        else Path(__file__).resolve().parents[1]
+    )
+    entries = expression_source_registry_entries()
+    rows = []
+    for matrix in registry().itertuples(index=False):
+        cancer_code = str(matrix.cancer_code)
+        source_cohort = str(matrix.source_cohort)
+        candidates = [
+            entry
+            for entry in entries
+            if cancer_code in {str(code) for code in entry.get("cancer_codes", ())}
+            and str(entry.get("source_cohort") or "") == source_cohort
+        ]
+        owners = [
+            entry
+            for entry in candidates
+            if str(entry.get("builder") or "").strip()
+            or str(entry.get("external_build_exemption") or "").strip()
+        ]
+
+        source_id = ""
+        builder = ""
+        builder_args = ""
+        exemption = ""
+        if not owners:
+            status = "missing_owner"
+        elif len(owners) > 1:
+            source_id = ";".join(sorted(str(entry["id"]) for entry in owners))
+            status = "ambiguous_owner"
+        else:
+            owner = owners[0]
+            source_id = str(owner["id"])
+            builder = str(owner.get("builder") or "").strip()
+            raw_builder_args = owner.get("builder_args") or ()
+            if isinstance(raw_builder_args, str):
+                builder_args = raw_builder_args
+            else:
+                builder_args = " ".join(str(arg) for arg in raw_builder_args)
+            exemption = str(owner.get("external_build_exemption") or "").strip()
+            if builder and exemption:
+                status = "invalid_owner"
+            elif exemption:
+                status = "external_build_exemption"
+            elif not builder:
+                status = "missing_owner"
+            else:
+                builder_path = (root / builder).resolve()
+                try:
+                    builder_path.relative_to(root)
+                except ValueError:
+                    status = "invalid_builder_path"
+                else:
+                    status = (
+                        "executable_builder" if builder_path.is_file() else "missing_builder_script"
+                    )
+
+        rows.append(
+            {
+                "cancer_code": cancer_code,
+                "source_cohort": source_cohort,
+                "source_id": source_id,
+                "builder": builder,
+                "builder_args": builder_args,
+                "external_build_exemption": exemption,
+                "status": status,
+            }
+        )
+    return pd.DataFrame(rows, columns=REGENERATION_AUDIT_COLUMNS)
+
+
+def validate_source_matrix_regeneration(
+    project_root: str | Path | None = None,
+) -> pd.DataFrame:
+    """Return the regeneration audit or raise for missing/ambiguous ownership."""
+    audit = source_matrix_regeneration_audit(project_root)
+    acceptable = {"executable_builder", "external_build_exemption"}
+    invalid = audit.loc[~audit["status"].isin(acceptable)]
+    if not invalid.empty:
+        details = ", ".join(
+            f"{row.cancer_code}/{row.source_cohort}: {row.status}"
+            for row in invalid.itertuples(index=False)
+        )
+        raise SourceMatrixError(f"source-matrix regeneration ownership is incomplete: {details}")
+    return audit
 
 
 def source_sample_namespace(source_cohort: str) -> str:

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.162"
+__version__ = "1.8.163"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/scripts/build_ctcl_scrna_reference_expression.py
+++ b/scripts/build_ctcl_scrna_reference_expression.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""Build seven CTCL case pseudobulks from public GSE171811 matrices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oncoref.expression_engine import sample_columns
+from oncoref.expression_source_adapters import build_ctcl_source_matrices
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-dir", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--raw-tar-path", type=Path, default=None)
+    parser.add_argument("--soft-path", type=Path, default=None)
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    cache = args.cache_dir or (Path.home() / ".cache" / "oncoref" / "expression" / "gse171811-ctcl")
+    result = build_ctcl_source_matrices(
+        cache_dir=cache,
+        output_dir=args.output_dir,
+        raw_tar_path=args.raw_tar_path,
+        soft_path=args.soft_path,
+        force_download=args.force_download,
+        high_expression_threshold=args.high_expression_threshold,
+    )
+    print(
+        json.dumps(
+            {
+                "source_id": "gse171811-ctcl",
+                "matrix_paths": {code: str(path) for code, path in result.matrix_paths.items()},
+                "sample_counts": {
+                    code: len(sample_columns(matrix)) for code, matrix in result.matrices.items()
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_geo_matrix.py
+++ b/scripts/build_geo_matrix.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from oncoref.expression_builders import build_source_matrices, geo_matrix_source_from_registry
 
@@ -80,10 +83,11 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=None,
         help=(
-            "CSV mapping source row ids to positive gene lengths in kb. Required for "
-            "unit=raw_counts sources."
+            "Optional CSV mapping source row ids to positive gene lengths in kb. "
+            "Raw-count builds otherwise derive Ensembl gene lengths with pyensembl."
         ),
     )
+    parser.add_argument("--ensembl-release", type=int, default=112)
     parser.add_argument("--force-download", action="store_true")
     parser.add_argument("--high-expression-threshold", type=float, default=1.0)
     args = parser.parse_args(argv)
@@ -93,9 +97,6 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("provide --source-id <id>")
 
     source = geo_matrix_source_from_registry(source_id, registry_path=args.registry)
-    if source.unit == "raw_counts" and args.gene_lengths_kb is None:
-        raise SystemExit("unit='raw_counts' sources require --gene-lengths-kb")
-
     cache_dir = args.cache_dir or Path.home() / ".cache" / "oncoref" / "expression" / source_id
     result = build_source_matrices(
         source,
@@ -104,6 +105,7 @@ def main(argv: list[str] | None = None) -> int:
         source_path=args.source_path,
         force_download=args.force_download,
         gene_lengths_kb=_load_gene_lengths_kb(args.gene_lengths_kb),
+        ensembl_release=args.ensembl_release,
         high_expression_threshold=args.high_expression_threshold,
     )
     summary = {

--- a/scripts/build_gse75885_sarc_reference_expression.py
+++ b/scripts/build_gse75885_sarc_reference_expression.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+"""Build the three GSE75885 sarcoma source matrices from public GEO files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oncoref.expression_engine import sample_columns
+from oncoref.expression_source_adapters import build_gse75885_source_matrices
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-dir", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--expression-path", type=Path, default=None)
+    parser.add_argument("--series-matrix-path", type=Path, default=None)
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    cache = args.cache_dir or (Path.home() / ".cache" / "oncoref" / "expression" / "gse75885-sarc")
+    result = build_gse75885_source_matrices(
+        cache_dir=cache,
+        output_dir=args.output_dir,
+        expression_path=args.expression_path,
+        series_matrix_path=args.series_matrix_path,
+        force_download=args.force_download,
+        high_expression_threshold=args.high_expression_threshold,
+    )
+    print(
+        json.dumps(
+            {
+                "source_id": "gse75885-sarc",
+                "matrix_paths": {code: str(path) for code, path in result.matrix_paths.items()},
+                "sample_counts": {
+                    code: len(sample_columns(matrix)) for code, matrix in result.matrices.items()
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_lnen_drmetrics_reference_expression.py
+++ b/scripts/build_lnen_drmetrics_reference_expression.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+"""Build DRMetrics lung carcinoid and LCNEC matrices from public files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oncoref.expression_engine import sample_columns
+from oncoref.expression_source_adapters import build_drmetrics_source_matrices
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-dir", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--counts-path", type=Path, default=None)
+    parser.add_argument("--attributes-path", type=Path, default=None)
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--ensembl-release", type=int, default=112)
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    cache = args.cache_dir or (
+        Path.home() / ".cache" / "oncoref" / "expression" / "drmetrics-lnen-2020"
+    )
+    result = build_drmetrics_source_matrices(
+        cache_dir=cache,
+        output_dir=args.output_dir,
+        counts_path=args.counts_path,
+        attributes_path=args.attributes_path,
+        force_download=args.force_download,
+        ensembl_release=args.ensembl_release,
+        high_expression_threshold=args.high_expression_threshold,
+    )
+    print(
+        json.dumps(
+            {
+                "source_id": "drmetrics-lnen-2020",
+                "matrix_paths": {code: str(path) for code, path in result.matrix_paths.items()},
+                "sample_counts": {
+                    code: len(sample_columns(matrix)) for code, matrix in result.matrices.items()
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_sclc_reference_expression.py
+++ b/scripts/build_sclc_reference_expression.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""Build SCLC UCologne and its four marker-dominance subtype matrices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oncoref.expression_builders import (
+    build_sclc_source_matrices,
+    geo_matrix_source_from_registry,
+)
+from oncoref.expression_engine import sample_columns
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-id", default="sclc-ucologne-2015")
+    parser.add_argument("--registry", type=Path, default=None)
+    parser.add_argument("--cache-dir", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--source-path", type=Path, default=None)
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    source = geo_matrix_source_from_registry(args.source_id, registry_path=args.registry)
+    cache_dir = args.cache_dir or (
+        Path.home() / ".cache" / "oncoref" / "expression" / args.source_id
+    )
+    result = build_sclc_source_matrices(
+        source,
+        cache_dir=cache_dir,
+        output_dir=args.output_dir,
+        source_path=args.source_path,
+        force_download=args.force_download,
+        high_expression_threshold=args.high_expression_threshold,
+    )
+    print(
+        json.dumps(
+            {
+                "source_id": args.source_id,
+                "source_cohort": source.source_cohort,
+                "matrix_paths": {
+                    code: str(path) for code, path in result.matrix_paths.items()
+                },
+                "sample_counts": {
+                    code: len(sample_columns(matrix))
+                    for code, matrix in result.matrices.items()
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_target_all_reference_expression.py
+++ b/scripts/build_target_all_reference_expression.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Build TARGET B-ALL and T-ALL matrices with public lineage evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oncoref.expression_engine import sample_columns
+from oncoref.expression_source_adapters import build_target_all_source_matrices
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-dir", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--manifest", type=Path, default=None)
+    parser.add_argument(
+        "--file-dir",
+        type=Path,
+        default=None,
+        help="Directory containing manifest source_file_name values for offline builds.",
+    )
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    cache = args.cache_dir or (Path.home() / ".cache" / "oncoref" / "expression" / "target-all")
+    manifest = pd.read_csv(args.manifest) if args.manifest is not None else None
+    file_paths = None
+    if args.file_dir is not None:
+        if manifest is None:
+            parser.error("--file-dir requires --manifest")
+        file_paths = {
+            str(name): args.file_dir / str(name)
+            for name in manifest["source_file_name"].astype(str)
+        }
+    result = build_target_all_source_matrices(
+        cache_dir=cache,
+        output_dir=args.output_dir,
+        manifest=manifest,
+        file_paths=file_paths,
+        force_download=args.force_download,
+        high_expression_threshold=args.high_expression_threshold,
+    )
+    print(
+        json.dumps(
+            {
+                "source_id": "target-all",
+                "matrix_paths": {code: str(path) for code, path in result.matrix_paths.items()},
+                "sample_counts": {
+                    code: len(sample_columns(matrix)) for code, matrix in result.matrices.items()
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_target_subprojects.py
+++ b/scripts/build_target_subprojects.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Build TARGET NBL and its MYCN-amplified/non-amplified child matrices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oncoref.expression_engine import sample_columns
+from oncoref.expression_source_adapters import build_target_nbl_source_matrices
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-dir", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--manifest", type=Path, default=None)
+    parser.add_argument(
+        "--file-dir",
+        type=Path,
+        default=None,
+        help="Directory containing manifest source_file_name values for offline builds.",
+    )
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    cache = args.cache_dir or (Path.home() / ".cache" / "oncoref" / "expression" / "target-nbl")
+    manifest = pd.read_csv(args.manifest) if args.manifest is not None else None
+    file_paths = None
+    if args.file_dir is not None:
+        if manifest is None:
+            parser.error("--file-dir requires --manifest")
+        file_paths = {
+            str(name): args.file_dir / str(name)
+            for name in manifest["source_file_name"].astype(str)
+        }
+    result = build_target_nbl_source_matrices(
+        cache_dir=cache,
+        output_dir=args.output_dir,
+        manifest=manifest,
+        file_paths=file_paths,
+        force_download=args.force_download,
+        high_expression_threshold=args.high_expression_threshold,
+    )
+    print(
+        json.dumps(
+            {
+                "source_id": "target-nbl",
+                "matrix_paths": {code: str(path) for code, path in result.matrix_paths.items()},
+                "sample_counts": {
+                    code: len(sample_columns(matrix)) for code, matrix in result.matrices.items()
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_v5_5_microarray_cohorts.py
+++ b/scripts/build_v5_5_microarray_cohorts.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Build audited GEO microarray cohorts as explicitly tagged TPM proxies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oncoref.expression_engine import sample_columns
+from oncoref.expression_source_adapters import (
+    MICROARRAY_GROUPS,
+    build_geo_microarray_group,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-root", type=Path, default=None)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Explicit source-specific output directory; valid with one --only group.",
+    )
+    parser.add_argument(
+        "--only",
+        choices=tuple(MICROARRAY_GROUPS),
+        action="append",
+        help="Build only the named physical source group. Defaults to all groups.",
+    )
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--ensembl-release", type=int, default=112)
+    parser.add_argument("--high-expression-threshold", type=float, default=1.0)
+    args = parser.parse_args(argv)
+
+    selected = list(dict.fromkeys(args.only or MICROARRAY_GROUPS))
+    if args.output_dir is not None and len(selected) != 1:
+        parser.error("--output-dir requires exactly one --only group")
+    cache_root = args.cache_root or Path.home() / ".cache" / "oncoref" / "expression"
+
+    summary = {}
+    for name in selected:
+        group = MICROARRAY_GROUPS[name]
+        result = build_geo_microarray_group(
+            group,
+            cache_dir=cache_root / group.source_id,
+            output_dir=args.output_dir,
+            force_download=args.force_download,
+            ensembl_release=args.ensembl_release,
+            high_expression_threshold=args.high_expression_threshold,
+        )
+        summary[name] = {
+            "source_id": group.source_id,
+            "matrix_paths": {code: str(path) for code, path in result.matrix_paths.items()},
+            "sample_counts": {
+                code: len(sample_columns(matrix)) for code, matrix in result.matrices.items()
+            },
+        }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_generators.py
+++ b/tests/test_build_generators.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+import tarfile
 from copy import deepcopy
 from dataclasses import replace
 from pathlib import Path
@@ -21,7 +22,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from oncoref import expression_builders
+from oncoref import expression_builders, expression_source_adapters
 from oncoref.cancer_types import cohort_registry
 
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
@@ -420,6 +421,38 @@ def test_geo_matrix_builder_writes_canonical_per_sample_matrix_and_sidecars(tmp_
     )
 
 
+def test_canonical_source_builder_preserves_nonstandard_native_unit(tmp_path):
+    matrix = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG00000141510", "ENSG00000146648"],
+            "Symbol": ["TP53", "EGFR"],
+            "sample_1": [600_000.0, 400_000.0],
+        }
+    )
+    source = expression_builders.GeoMatrixSource(
+        cancer_code="X",
+        source_cohort="TEST_PROXY",
+        source_project="GEO",
+        file_name="already_canonical.parquet",
+        unit="TPM",
+        native_unit="TPM proxy",
+        source_scale_class="microarray_tpm_proxy",
+        linear_tpm_comparable=False,
+        tpm_proxy=True,
+    )
+
+    result = expression_builders.build_canonical_source_matrices(
+        source,
+        matrix,
+        routed_samples={"X": ["sample_1"]},
+        output_dir=tmp_path,
+    )
+
+    assert set(result.sample_qc["unit"]) == {"TPM proxy"}
+    assert result.summary_rows["source_version"].str.contains("unit=TPM proxy").all()
+    assert result.summary_rows["processing_pipeline"].str.contains("tpm_proxy_to_tpm").all()
+
+
 def test_geo_matrix_builder_reconciles_stale_per_code_artifacts(tmp_path):
     out_dir = tmp_path / "derived"
     out_dir.mkdir()
@@ -543,6 +576,21 @@ def test_transposed_matrix_uses_implicit_sample_index_and_uniquifies_duplicates(
     assert matrix[["P-1", "P-1.2", "P-1.1"]].astype(float).to_numpy().tolist() == [
         [1.0, 3.0, 5.0],
         [2.0, 4.0, 6.0],
+    ]
+
+
+def test_nontransposed_matrix_preserves_implicit_gene_index(tmp_path):
+    path = tmp_path / "implicit_gene_ids.tsv"
+    path.write_text("sample_a\tsample_b\nENSG1\t1\t2\nENSG2\t3\t4\n")
+
+    matrix = expression_builders.read_source_expression_matrix(path)
+
+    assert matrix.attrs["row_id_col"] == "source_row_id"
+    assert list(matrix.columns) == ["source_row_id", "sample_a", "sample_b"]
+    assert matrix["source_row_id"].tolist() == ["ENSG1", "ENSG2"]
+    assert matrix[["sample_a", "sample_b"]].astype(float).to_numpy().tolist() == [
+        [1.0, 2.0],
+        [3.0, 4.0],
     ]
 
 
@@ -1030,6 +1078,7 @@ def test_build_gdc_source_matrices_writes_canonical_artifacts(tmp_path):
         source_project="GDC synthetic",
         primary_sample_types=("Primary Tumor",),
         primary_diagnosis_contains=("Synthetic",),
+        sample_lineage_evidence=lambda row: f"synthetic evidence for {row['case_id']}",
         pipeline_stem="synthetic_gdc",
         notes="synthetic GDC source notes",
     )
@@ -1061,6 +1110,11 @@ def test_build_gdc_source_matrices_writes_canonical_artifacts(tmp_path):
         "sample-b",
     }
     assert "duplicate_sample_for_case_code" in set(selected_manifest["exclusion_reason"])
+    assert set(selected_manifest["lineage_evidence_source"]) == {
+        "synthetic evidence for case-a",
+        "synthetic evidence for case-b",
+        "synthetic evidence for case-normal",
+    }
     assert result.sidecar_paths["mapping_audit"].exists()
     assert result.sidecar_paths["parse_diagnostics"].exists()
     assert result.sidecar_paths["summary_rows"].exists()
@@ -1274,6 +1328,301 @@ def test_medulloblastoma_subgroup_assignment_rejects_ties_and_missing_markers():
     non_finite.loc[non_finite["Symbol"].eq("MYC"), "g3_sample"] = np.inf
     with pytest.raises(ValueError, match=r"non-finite.*g3_sample"):
         expression_builders.medulloblastoma_subgroup_sample_ids(non_finite)
+
+
+def test_sclc_subtype_assignment_keeps_parent_and_routes_one_marker_winner():
+    matrix = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG1", "ENSG2", "ENSG3", "ENSG4"],
+            "Symbol": ["ASCL1", "NEUROD1", "POU2F3", "YAP1"],
+            "S1": [9.0, 2.0, 1.0, 0.0],
+            "S2": [0.0, 8.0, 2.0, 1.0],
+            "S3": [1.0, 0.0, 7.0, 2.0],
+            "S4": [1.0, 2.0, 0.0, 6.0],
+        }
+    )
+
+    assert expression_builders.sclc_subtype_sample_ids(matrix) == {
+        "SCLC": ["S1", "S2", "S3", "S4"],
+        "SCLC_ASCL1": ["S1"],
+        "SCLC_NEUROD1": ["S2"],
+        "SCLC_POU2F3": ["S3"],
+        "SCLC_YAP1": ["S4"],
+    }
+
+
+def test_sclc_subtype_assignment_rejects_ties():
+    matrix = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG1", "ENSG2", "ENSG3", "ENSG4"],
+            "Symbol": ["ASCL1", "NEUROD1", "POU2F3", "YAP1"],
+            "S1": [9.0, 9.0, 1.0, 0.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="maximum is tied"):
+        expression_builders.sclc_subtype_sample_ids(matrix)
+
+
+def test_sclc_subtype_assignment_takes_maximum_duplicate_source_row():
+    matrix = pd.DataFrame(
+        {
+            "Hugo_Symbol": ["ASCL1", "NEUROD1", "POU2F3", "POU2F3", "YAP1"],
+            "S1": [1.0, 10.0, 6.0, 6.0, 0.0],
+        }
+    )
+    matrix.attrs["row_id_col"] = "Hugo_Symbol"
+    matrix.attrs["symbol_col"] = None
+
+    routed = expression_builders.sclc_subtype_sample_ids(matrix)
+
+    assert routed["SCLC_NEUROD1"] == ["S1"]
+    assert routed["SCLC_POU2F3"] == []
+
+
+def test_gse75885_titles_route_only_owned_histologies(tmp_path):
+    series_matrix = tmp_path / "series.txt.gz"
+    with gzip.open(series_matrix, "wt") as handle:
+        handle.write(
+            '!Sample_title\t"S1 - Liposarcoma - dedifferentiated"'
+            '\t"S2 - Low grade fibromyxoid sarcoma"'
+            '\t"S3 - Liposarcoma - pleomorphic"'
+            '\t"S4 - Leiomyosarcoma"\n'
+        )
+
+    titles = expression_source_adapters.geo_sample_titles(series_matrix)
+
+    assert expression_source_adapters.gse75885_routed_samples(
+        ["S1", "S2", "S3", "S4"],
+        titles,
+    ) == {
+        "SARC_DDLPS": ["S1"],
+        "SARC_PLEOLPS": ["S3"],
+        "SARC_LGFMS": ["S2"],
+    }
+
+
+def test_gse75885_routing_requires_metadata_for_every_expression_sample():
+    with pytest.raises(ValueError, match="has no GEO title"):
+        expression_source_adapters.gse75885_routed_samples(
+            ["S1", "S2"],
+            {"S1": "Liposarcoma - pleomorphic"},
+        )
+
+
+def test_drmetrics_histology_routing_excludes_sclc():
+    attributes = pd.DataFrame(
+        {
+            "Sample_ID": ["T1", "T2", "T3", "T4", "T5", "SCLC1"],
+            "Histopathology_simplified": [
+                "Typical",
+                "Atypical",
+                "Carcinoid",
+                "Supra_carcinoid",
+                "LCNEC",
+                "SCLC",
+            ],
+        }
+    )
+
+    assert expression_source_adapters.drmetrics_routed_samples(
+        attributes["Sample_ID"],
+        attributes,
+    ) == {
+        "NET_LUNG": ["T1", "T2", "T3", "T4"],
+        "NEC_LUNG_LARGECELL": ["T5"],
+    }
+
+
+def test_drmetrics_histology_routing_rejects_missing_or_duplicate_metadata():
+    duplicate = pd.DataFrame(
+        {
+            "Sample_ID": ["T1", "T1"],
+            "Histopathology_simplified": ["Typical", "Atypical"],
+        }
+    )
+    with pytest.raises(ValueError, match="duplicate Sample_ID"):
+        expression_source_adapters.drmetrics_routed_samples(["T1"], duplicate)
+
+    attributes = duplicate.drop_duplicates("Sample_ID")
+    with pytest.raises(ValueError, match="has no attributes row"):
+        expression_source_adapters.drmetrics_routed_samples(["T2"], attributes)
+
+
+def test_geo_microarray_parsers_keep_characteristics_and_multi_gene_probes(tmp_path):
+    series = tmp_path / "series.txt.gz"
+    with gzip.open(series, "wt") as handle:
+        handle.write('!Sample_title\t"T1"\t"T2"\n')
+        handle.write('!Sample_characteristics_ch1\t"subtype: low-grade"\t"subtype: high-grade"\n')
+        handle.write("!series_matrix_table_begin\n")
+        handle.write('"ID_REF"\t"T1"\t"T2"\n')
+        handle.write('"P1"\t"2"\t"3"\n')
+        handle.write('"P2"\t"4"\t"1"\n')
+        handle.write("!series_matrix_table_end\n")
+    platform = tmp_path / "platform.txt"
+    platform.write_text(
+        "!platform_table_begin\n"
+        "ID\tGene Symbol\tENTREZ_GENE_ID\n"
+        "P1\tGENE1\t1\n"
+        "P2\tGENE2 /// GENE3\t2 /// 3\n"
+        "!platform_table_end\n"
+    )
+
+    intensities, metadata = expression_source_adapters.parse_geo_series_matrix(series)
+    annotations = expression_source_adapters.parse_geo_platform_annotations(platform)
+
+    assert metadata["T1"]["char_subtype"] == "low-grade"
+    assert metadata["T2"]["char_subtype"] == "high-grade"
+    assert annotations.loc[annotations["probe_id"].eq("P2"), "gene_symbol"].tolist() == [
+        "GENE2",
+        "GENE3",
+    ]
+    proxy = expression_source_adapters.microarray_tpm_proxy(
+        intensities,
+        annotations,
+        log2_transformed=True,
+    )
+    assert np.allclose(proxy.sum(axis=0), 1_000_000.0)
+    assert proxy.loc["GENE2", "T1"] > proxy.loc["GENE1", "T1"]
+
+
+def test_geo_microarray_routing_is_explicit_and_mutually_exclusive():
+    metadata = {
+        "LG": {"char_subtype": "low-grade endometrial stromal sarcoma"},
+        "HG": {"char_subtype": "high-grade endometrial stromal sarcoma"},
+        "UUS": {"char_subtype": "undifferentiated uterine sarcoma"},
+    }
+    patterns = {
+        "SARC_ESS_LG": r"(?i)low.?grade",
+        "SARC_ESS_HG": r"(?i)high.?grade",
+    }
+
+    assert expression_source_adapters.microarray_routed_samples(metadata, patterns) == {
+        "SARC_ESS_LG": ["LG"],
+        "SARC_ESS_HG": ["HG"],
+    }
+
+    with pytest.raises(ValueError, match="matches multiple codes"):
+        expression_source_adapters.microarray_routed_samples(
+            {"S1": {"subtype": "mixed"}},
+            {"A": "mixed", "B": "mixed"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("comment", "expected"),
+    [
+        ("Cell of origin: B-precursor; Risk: standard", ("B-precursor", "B_ALL")),
+        ("Cell of origin: T cell", ("T cell", "T_ALL")),
+        ("Cell of origin: Indeterminate", ("Indeterminate", "")),
+        ("Risk: standard", ("", "")),
+    ],
+)
+def test_target_all_lineage_labels_are_explicit(comment, expected):
+    assert expression_source_adapters.parse_target_all_lineage_label(comment) == expected
+
+
+def test_target_all_registry_uses_complete_gdc_project_ids():
+    source = expression_builders.gdc_source_from_registry("target-all")
+
+    assert source.project_ids == ("TARGET-ALL-P1", "TARGET-ALL-P2", "TARGET-ALL-P3")
+
+
+def test_target_all_lineage_assignments_preserve_evidence(monkeypatch, tmp_path):
+    matrix = pd.DataFrame(
+        {
+            "Case USI": ["TARGET-10-A", "TARGET-10-B", "TARGET-10-X"],
+            "Comments": [
+                "Cell of origin: B-precursor; other",
+                "Cell of origin: T cell",
+                "Cell of origin: Indeterminate",
+            ],
+        }
+    )
+    monkeypatch.setattr(expression_source_adapters.pd, "read_excel", lambda *_a, **_k: matrix)
+
+    assignments = expression_source_adapters.target_all_lineage_assignments(
+        [("TARGET phase sample matrix", tmp_path / "lineage.xlsx")]
+    )
+
+    assert assignments["TARGET-10-A"].cancer_code == "B_ALL"
+    assert assignments["TARGET-10-B"].cancer_code == "T_ALL"
+    assert "Cell of origin: B-precursor" in assignments["TARGET-10-A"].evidence_source
+    assert "TARGET-10-X" not in assignments
+
+
+def test_nbl_mycn_routing_keeps_parent_and_one_child():
+    routed = expression_source_adapters.nbl_mycn_routed_samples(
+        ["TARGET-30-AMPCASE-01A", "TARGET-30-NONCASE-01A", "TARGET-30-UNKNOWN-02A"],
+        {
+            "TARGET-30-AMPCASE": "amp",
+            "TARGET-30-NONCASE": "nonamp",
+            "TARGET-30-UNKNOWN": "unknown",
+        },
+    )
+
+    assert routed == {
+        "NBL": [
+            "TARGET-30-AMPCASE-01A",
+            "TARGET-30-NONCASE-01A",
+            "TARGET-30-UNKNOWN-02A",
+        ],
+        "NBL_MYCNamp": ["TARGET-30-AMPCASE-01A"],
+        "NBL_MYCNnonamp": ["TARGET-30-NONCASE-01A", "TARGET-30-UNKNOWN-02A"],
+    }
+    with pytest.raises(ValueError, match="lacks a supported MYCN call"):
+        expression_source_adapters.nbl_mycn_routed_samples(["TARGET-30-MISSING-01A"], {})
+
+
+def test_ctcl_pseudobulk_selects_each_cases_dominant_blood_clone(tmp_path):
+    raw_tar = tmp_path / "GSE171811_RAW.tar"
+    with tarfile.open(raw_tar, "w") as tar:
+        for index, case_id in enumerate(["HC1", "SS1", "SS2", "SS3", "SS4", "SS5", "SS6", "MFIV1"]):
+            gsm = f"GSM{index + 1}"
+            prefix = f"{gsm}_{case_id}_Blood"
+            tcr = f"clone\tcell1\tcell2\n{case_id}_dominant\t2\t0\n{case_id}_other\t0\t1\n"
+            gex = "gene\tcell1\tcell2\nGENE1\t10\t0\nGENE2\t2\t8\n"
+            for suffix, content in (("TCRb", tcr), ("GEX", gex)):
+                compressed = gzip.compress(content.encode())
+                info = tarfile.TarInfo(f"{prefix}_{suffix}.tsv.gz")
+                info.size = len(compressed)
+                tar.addfile(info, io.BytesIO(compressed))
+
+    counts, manifest = expression_source_adapters.ctcl_case_pseudobulk(raw_tar)
+
+    assert list(counts.columns) == [
+        "source_symbol",
+        "MFIV1",
+        "SS1",
+        "SS2",
+        "SS3",
+        "SS4",
+        "SS5",
+        "SS6",
+    ]
+    assert set(counts["source_symbol"]) == {"GENE1", "GENE2"}
+    assert set(counts.set_index("source_symbol").loc["GENE1"]) == {10.0}
+    assert manifest["included"].value_counts().to_dict() == {True: 7, False: 1}
+    healthy = manifest.loc[~manifest["included"]].iloc[0]
+    assert healthy["case_id"] == "HC1"
+    assert healthy["exclusion_reason"] == "healthy_control"
+
+
+def test_ctcl_pseudobulk_requires_identical_gex_and_tcr_cell_columns(tmp_path):
+    raw_tar = tmp_path / "GSE171811_RAW.tar"
+    with tarfile.open(raw_tar, "w") as tar:
+        contents = {
+            "GSM1_SS1_Blood_TCRb.tsv.gz": "clone\tcell1\tcell2\ndominant\t1\t0\n",
+            "GSM1_SS1_Blood_GEX.tsv.gz": "gene\tcell2\tcell1\nGENE1\t10\t0\n",
+        }
+        for name, content in contents.items():
+            compressed = gzip.compress(content.encode())
+            info = tarfile.TarInfo(name)
+            info.size = len(compressed)
+            tar.addfile(info, io.BytesIO(compressed))
+
+    with pytest.raises(ValueError, match="different cell columns"):
+        expression_source_adapters.ctcl_case_pseudobulk(raw_tar)
 
 
 def test_derive_mbl_subgroup_source_matrices_writes_cache_and_release_assets(tmp_path):
@@ -3541,7 +3890,17 @@ def test_build_gdc_script_uses_registry_config(tmp_path, monkeypatch, capsys):
     assert '"CODE_A": 1' in stdout
 
 
-def test_build_geo_matrix_script_requires_gene_lengths_for_raw_counts(tmp_path):
+def test_build_geo_matrix_script_derives_gene_lengths_for_raw_counts(
+    tmp_path,
+    monkeypatch,
+):
+    source_path = tmp_path / "source.tsv"
+    pd.DataFrame(
+        {
+            "gene": ["ENSG00000141510", "ENSG00000146648"],
+            "sample_1": [60, 80],
+        }
+    ).to_csv(source_path, sep="\t", index=False)
     registry_path = tmp_path / "expression_sources.yaml"
     registry_path.write_text(
         """
@@ -3557,18 +3916,46 @@ sources:
 """.lstrip()
     )
     mod = _load_script("build_geo_matrix")
+    observed = {}
 
-    with pytest.raises(SystemExit, match="raw_counts"):
-        mod.main(
-            [
-                "--source-id",
-                "synthetic-counts",
-                "--registry",
-                str(registry_path),
-                "--cache-dir",
-                str(tmp_path / "cache"),
-            ]
+    def fake_gene_lengths(gene_ids, *, release):
+        observed["gene_ids"] = list(gene_ids)
+        observed["release"] = release
+        return pd.Series(
+            {
+                "ENSG00000141510": 1.0,
+                "ENSG00000146648": 2.0,
+            }
         )
+
+    monkeypatch.setattr(expression_builders, "ensembl_gene_lengths_kb", fake_gene_lengths)
+
+    status = mod.main(
+        [
+            "--source-id",
+            "synthetic-counts",
+            "--registry",
+            str(registry_path),
+            "--cache-dir",
+            str(tmp_path / "cache"),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--source-path",
+            str(source_path),
+            "--ensembl-release",
+            "112",
+        ]
+    )
+
+    assert status == 0
+    assert observed == {
+        "gene_ids": ["ENSG00000141510", "ENSG00000146648"],
+        "release": 112,
+    }
+    matrix = pd.read_parquet(tmp_path / "out" / "CODE_A_per_sample_tpm.parquet")
+    by_gene = matrix.set_index("Ensembl_Gene_ID")
+    assert by_gene.loc["ENSG00000141510", "sample_1"] == pytest.approx(600_000.0)
+    assert by_gene.loc["ENSG00000146648", "sample_1"] == pytest.approx(400_000.0)
 
 
 # ---------- cohort_percentile_vectors ----------

--- a/tests/test_cancer_types.py
+++ b/tests/test_cancer_types.py
@@ -247,6 +247,37 @@ def test_source_cohort_counts_are_derived_from_expression_registry(monkeypatch):
     assert int(row["n_codes"]) == 2
 
 
+def test_source_cohort_counts_require_explicit_boolean_for_overlapping_routes(monkeypatch):
+    from oncoref import expression_registry
+
+    source = {
+        "id": "overlap-test",
+        "source_cohort": "OVERLAP_TEST",
+        "cancer_codes": ["PARENT", "CHILD"],
+        "expected_source_samples": 5,
+        "expected_samples_by_code": {"PARENT": 5, "CHILD": 5},
+    }
+    monkeypatch.setattr(
+        expression_registry,
+        "expression_source_registry_entries",
+        lambda: (source,),
+    )
+    cancer_types._expression_source_cohort_counts.cache_clear()
+    with pytest.raises(ValueError, match="routes more samples than it contains"):
+        cancer_types._expression_source_cohort_counts()
+
+    source["routed_samples_may_overlap"] = "true"
+    cancer_types._expression_source_cohort_counts.cache_clear()
+    with pytest.raises(ValueError, match="must be a YAML boolean"):
+        cancer_types._expression_source_cohort_counts()
+
+    source["routed_samples_may_overlap"] = True
+    cancer_types._expression_source_cohort_counts.cache_clear()
+    counts = cancer_types._expression_source_cohort_counts()
+    assert counts["OVERLAP_TEST"]["physical_samples"] == 5
+    cancer_types._expression_source_cohort_counts.cache_clear()
+
+
 def test_cohort_source_version_parses_ensembl_release():
     # The per-cohort source_version for auditing the canonical gene-ID space: a code
     # resolves to its source cohort, whose provenance records the harmonized Ensembl

--- a/tests/test_expression_sources.py
+++ b/tests/test_expression_sources.py
@@ -4,6 +4,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import re
 from pathlib import Path
 
 import pandas as pd
@@ -24,8 +25,13 @@ def test_registry_loads_all_sources():
 
 def test_source_types_cover_the_major_providers():
     types = {s.source_type for s in es.expression_sources()}
-    for t in ("gdc", "treehouse-compendium", "recount3", "sra-ncbi-counts", "broad-cllmap"):
+    for t in ("gdc", "treehouse-compendium", "recount3", "sra-ncbi-counts", "geo-matrix"):
         assert t in types
+
+    cllmap = es.expression_source("cllmap")
+    assert cllmap is not None
+    assert cllmap.source_type == "geo-matrix"
+    assert cllmap.source_project == "CLL-map"
 
 
 def test_lookup_by_id_and_code():
@@ -188,6 +194,35 @@ def test_expression_source_registry_raw_helpers_are_public():
     assert es.expression_source_registry_entries(source_type=["not-a-source-type"]) == ()
     assert oncoref.expression_source_registry_entries() == entries
     assert "expression_source_registry_entries" in oncoref.__all__
+
+
+def test_geo_accessions_are_structured_when_source_metadata_names_them():
+    pattern = re.compile(r"\bGSE\d+\b", flags=re.IGNORECASE)
+
+    def nested_strings(value):
+        if isinstance(value, dict):
+            for nested in value.values():
+                yield from nested_strings(nested)
+        elif isinstance(value, (list, tuple)):
+            for nested in value:
+                yield from nested_strings(nested)
+        else:
+            yield str(value)
+
+    def metadata_values(entry):
+        for key, value in entry.items():
+            if key in {"citation", "url"} or "file" in key:
+                yield from nested_strings(value)
+
+    for entry in es.expression_source_registry_entries():
+        named = {
+            match.upper() for value in metadata_values(entry) for match in pattern.findall(value)
+        }
+        structured = {match.upper() for match in pattern.findall(str(entry.get("accession") or ""))}
+        assert named <= structured, (
+            f"{entry['id']} names GEO accession(s) {sorted(named - structured)} "
+            "outside its structured accession field"
+        )
 
 
 def test_sample_manifest_loads():

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -22,6 +22,12 @@ def test_build_backend_supports_declared_pep_639_license_metadata():
     assert 'license-files = ["LICENSE"]' in pyproject
 
 
+def test_source_distribution_includes_regeneration_scripts():
+    manifest = Path("MANIFEST.in").read_text()
+
+    assert "recursive-include scripts *.py" in manifest
+
+
 def test_release_classifier_accepts_only_unpublished_package_tag():
     package_version = "1.2.3"
     cases = [

--- a/tests/test_source_matrices.py
+++ b/tests/test_source_matrices.py
@@ -23,9 +23,24 @@ def test_registry_and_available_cohorts():
     assert info["source_cohort"] and info["n_samples"] > 0
 
 
+def test_every_published_matrix_has_one_executable_or_exempt_owner():
+    audit = sm.validate_source_matrix_regeneration()
+
+    assert len(audit) == len(sm.registry())
+    assert audit[["cancer_code", "source_cohort"]].duplicated().sum() == 0
+    assert audit["status"].value_counts().to_dict() == {
+        "executable_builder": len(audit) - 1,
+        "external_build_exemption": 1,
+    }
+    exemption = audit.loc[audit["status"].eq("external_build_exemption")].iloc[0]
+    assert exemption["cancer_code"] == "NUTM"
+    assert exemption["source_cohort"] == "UNC_NUTM1"
+    assert "controlled" in exemption["external_build_exemption"].lower()
+
+
 def test_source_id_resolver_distinguishes_physical_and_declared_code_routes():
     beataml = sm.resolution_for_source("beataml-ohsu-2022")
-    assert beataml.resolution_method == "declared_cancer_code"
+    assert beataml.resolution_method == "physical_source"
     assert beataml.codes == ("LAML_APL", "LAML_ELNadv", "LAML_ELNfav", "LAML_ELNint")
     assert {matrix.source_cohort for matrix in beataml.matrices} == {"BEATAML_OHSU_2022"}
 


### PR DESCRIPTION
## Summary
- add exact registry-backed regeneration ownership for every published source matrix, with one documented controlled-data exemption
- add source-specific public-data adapters while keeping normalization, QC, provenance, and summaries in the canonical builder core
- populate and enforce structured GEO accessions, package the builders in the sdist, and document the build contract

## Verification
- `./test.sh` (958 passed, 0 skipped)
- `./lint.sh`
- `mkdocs build --strict`
- built and audited `oncoref-1.8.163.tar.gz` (131 executable owners, 1 controlled-data exemption)
- installed and smoke-tested `oncoref-1.8.163-py3-none-any.whl`
- live processed-data builds checked for SCLC, CML, MCL, CHON, and CTCL; no Salmon execution

Closes #450
Closes #451