### PR TITLE
Complete source-aware housekeeping panel policy

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -438,11 +438,12 @@ processing plan.
   `on_missing="raise"` when a downstream migration requires the manifests.
   `housekeeping_cancer_expression_coverage(...)` is the reusable #202 audit
   surface for evaluating clean-TPM biological housekeeping candidates across
-  cancer cohorts: it reports per-gene detection, `>= floor` coverage, p1/p5/
-  median clean TPM, sample-QC mode, and source-scale metadata. Treat absolute TPM
-  floors as hard evidence only where `recommended_for_absolute_tpm_floor` is true;
-  microarray/proxy or otherwise non-linear sources stay visible as warning/rank
-  calibration inputs, not vetoes.
+  cancer cohorts. Pass its result to
+  `housekeeping_cancer_expression_coverage_summary(...)` for one row per candidate
+  with a source-aware linear-floor status and the worst comparable cohort. Treat
+  absolute TPM floors as hard evidence only where
+  `recommended_for_absolute_tpm_floor` is true; microarray/proxy or otherwise
+  non-linear sources stay visible as warning/rank calibration inputs, not vetoes.
 
 ### Builder APIs
 
@@ -838,6 +839,34 @@ gene_families.clean_tpm_censored_gene_ids()
 ```
 
 ### Housekeeping normalization
+
+Housekeeping normalization is an explicit, consumer-specific expression space, not
+the general oncoref default. Prefer clean TPM when additive abundance matters,
+`log1p(clean TPM)` when magnitude needs compression, and percentile ranks when only
+within-sample ordering matters. Use an HK-derived size factor only after the consumer
+has shown that it improves its own calibrated task.
+
+The active 30-gene biological panel is deliberately stable. Cancer-side low-tail
+coverage can identify warnings and candidate replacements, but it does not
+automatically promote genes: changing the panel changes every normalized value and
+requires downstream recalibration. Use the raw and summarized source-aware audits:
+
+```python
+from oncoref import expression
+
+coverage = expression.housekeeping_cancer_expression_coverage(
+    ["LUAD", "SKCM"], auto_fetch=False, on_missing="raise"
+)
+summary = expression.housekeeping_cancer_expression_coverage_summary(coverage)
+summary[["Symbol", "linear_floor_status", "worst_linear_p5_cancer_code"]]
+```
+
+Only rows marked `recommended_for_absolute_tpm_floor` participate in the summary's
+linear TPM pass/fail decision. Proxy or non-linear sources remain counted but cannot
+pass or veto an absolute clean-TPM floor. The raw audit records requested, audited,
+and unavailable cancer codes in DataFrame attributes. The summary rejects a known
+partial audit by default; `require_complete=False` is an explicit exploratory-cache
+opt-out, not a release-quality panel decision.
 
 For clean-TPM housekeeping denominators, use the biological HPA-stable panel:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -864,9 +864,10 @@ summary[["Symbol", "linear_floor_status", "worst_linear_p5_cancer_code"]]
 Only rows marked `recommended_for_absolute_tpm_floor` participate in the summary's
 linear TPM pass/fail decision. Proxy or non-linear sources remain counted but cannot
 pass or veto an absolute clean-TPM floor. The raw audit records requested, audited,
-and unavailable cancer codes in DataFrame attributes. The summary rejects a known
-partial audit by default; `require_complete=False` is an explicit exploratory-cache
-opt-out, not a release-quality panel decision.
+and unavailable cancer codes in DataFrame attributes. The summary rejects a partial
+audit, or one whose completeness is unknown, by default;
+`require_complete=False` is an explicit exploratory-cache opt-out, not a
+release-quality panel decision.
 
 For clean-TPM housekeeping denominators, use the biological HPA-stable panel:
 

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -191,6 +191,7 @@ from .expression import (
     gene_within_sample_top_fraction,
     housekeeping_cancer_expression_coverage,
     housekeeping_cancer_expression_coverage_from_matrix,
+    housekeeping_cancer_expression_coverage_summary,
     pan_cancer_expression,
     per_sample_expression,
     pooled_cohort_stats,
@@ -586,6 +587,7 @@ __all__ = [
     "greedy_coverage",
     "housekeeping_cancer_expression_coverage",
     "housekeeping_cancer_expression_coverage_from_matrix",
+    "housekeeping_cancer_expression_coverage_summary",
     "housekeeping_reference_profile",
     # HPA normal-tissue reference data
     "hpa_cell_type_expression",

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2292,6 +2292,8 @@ def housekeeping_cancer_expression_coverage(
     out.attrs["issue"] = "#202"
     out.attrs["sample_qc"] = sample_qc
     out.attrs["expression_space"] = "tpm_clean"
+    out.attrs["housekeeping_detection_floor_tpm"] = float(housekeeping_detection_floor_tpm)
+    out.attrs["on_missing"] = mode
     out.attrs["requested_cancer_codes"] = tuple(requested_codes)
     out.attrs["audited_cancer_codes"] = tuple(audited_codes)
     out.attrs["missing_cancer_codes"] = tuple(missing_codes)
@@ -2341,16 +2343,25 @@ def housekeeping_cancer_expression_coverage_summary(
     missing = sorted(required - set(coverage.columns))
     if missing:
         raise ValueError(f"coverage missing required columns: {missing}")
+    completeness = coverage.attrs.get("cohort_audit_complete")
     missing_codes = tuple(str(code) for code in coverage.attrs.get("missing_cancer_codes", ()))
-    if require_complete and missing_codes:
+    if require_complete and completeness is not True:
+        if missing_codes:
+            detail = f"missing requested cancer codes: {list(missing_codes)}"
+        else:
+            detail = "input does not declare whether every requested cohort was audited"
         raise ValueError(
-            "housekeeping coverage audit is incomplete; missing requested cancer codes: "
-            f"{list(missing_codes)}. Fetch the missing source matrices or pass "
-            "require_complete=False for an explicitly partial audit."
+            f"housekeeping coverage audit is not confirmed complete; {detail}. "
+            "Use housekeeping_cancer_expression_coverage to produce a complete audit "
+            "or pass require_complete=False for an explicitly partial audit."
         )
     if coverage.empty:
         out = pd.DataFrame(columns=_HOUSEKEEPING_CANCER_COVERAGE_SUMMARY_COLUMNS)
         out.attrs.update(coverage.attrs)
+        out.attrs["issue"] = "#202"
+        out.attrs["panel_selection_policy"] = "consumer_benchmark_required"
+        out.attrs["missing_cancer_codes"] = missing_codes
+        out.attrs["cohort_audit_complete"] = completeness
         return out
 
     work = coverage.loc[:, sorted(required)].copy()
@@ -2474,7 +2485,7 @@ def housekeeping_cancer_expression_coverage_summary(
     out.attrs["requested_cancer_codes"] = coverage.attrs.get("requested_cancer_codes")
     out.attrs["audited_cancer_codes"] = coverage.attrs.get("audited_cancer_codes")
     out.attrs["missing_cancer_codes"] = missing_codes
-    out.attrs["cohort_audit_complete"] = not missing_codes
+    out.attrs["cohort_audit_complete"] = completeness
     return out
 
 

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2067,6 +2067,25 @@ _HOUSEKEEPING_CANCER_COVERAGE_SUMMARY_COLUMNS = [
     "linear_floor_status",
 ]
 
+_HOUSEKEEPING_CANCER_COVERAGE_SUMMARY_REQUIRED = frozenset(
+    {
+        "cancer_code",
+        "source_cohort",
+        "recommended_for_absolute_tpm_floor",
+        "housekeeping_detection_floor_tpm",
+        "Ensembl_Gene_ID",
+        "Symbol",
+        "panel_member_present",
+        "n_samples",
+        "n_measured_samples",
+        "fraction_above_floor",
+        "p5_tpm",
+        "passes_p5_floor",
+        "sample_qc",
+        "expression_space",
+    }
+)
+
 
 def _housekeeping_panel_rows(panel_ids=None) -> pd.DataFrame:
     from .gene_families import clean_tpm_biological_housekeeping_genes
@@ -2301,6 +2320,157 @@ def housekeeping_cancer_expression_coverage(
     return out
 
 
+def _strict_coverage_bool_column(values: pd.Series, *, column: str) -> pd.Series:
+    normalized = values.astype(str).str.strip().str.lower()
+    true_values = {"true", "1", "yes"}
+    false_values = {"false", "0", "no"}
+    invalid = normalized[~normalized.isin(true_values | false_values)]
+    if not invalid.empty:
+        bad = sorted(invalid.unique().tolist())
+        raise ValueError(f"coverage column {column!r} contains non-boolean values: {bad}")
+    return normalized.isin(true_values)
+
+
+def _prepare_housekeeping_coverage_summary_input(
+    coverage: pd.DataFrame,
+) -> tuple[pd.DataFrame, float, dict[str, str]]:
+    work = coverage.loc[:, sorted(_HOUSEKEEPING_CANCER_COVERAGE_SUMMARY_REQUIRED)].copy()
+    raw_ids = work["Ensembl_Gene_ID"]
+    invalid_ids = raw_ids.isna() | raw_ids.astype(str).str.strip().str.lower().isin(
+        {"", "nan", "none"}
+    )
+    if invalid_ids.any():
+        raise ValueError("coverage contains missing Ensembl_Gene_ID values")
+    work["Ensembl_Gene_ID"] = raw_ids.astype(str).map(unversioned)
+
+    for column in (
+        "housekeeping_detection_floor_tpm",
+        "n_samples",
+        "n_measured_samples",
+        "fraction_above_floor",
+        "p5_tpm",
+    ):
+        work[column] = pd.to_numeric(work[column], errors="coerce")
+    for column in (
+        "recommended_for_absolute_tpm_floor",
+        "panel_member_present",
+        "passes_p5_floor",
+    ):
+        work[column] = _strict_coverage_bool_column(work[column], column=column)
+
+    if work["housekeeping_detection_floor_tpm"].isna().any():
+        raise ValueError("coverage has missing housekeeping_detection_floor_tpm values")
+    floors = work["housekeeping_detection_floor_tpm"].unique()
+    if len(floors) != 1:
+        raise ValueError(
+            "coverage must use exactly one housekeeping_detection_floor_tpm; "
+            f"found {sorted(float(value) for value in floors)}"
+        )
+    floor = float(floors[0])
+    if not np.isfinite(floor) or floor < 0:
+        raise ValueError("housekeeping_detection_floor_tpm must be finite and non-negative")
+
+    for column in ("n_samples", "n_measured_samples"):
+        values = work[column]
+        invalid = values.isna() | values.lt(0) | values.mod(1).ne(0)
+        if invalid.any():
+            raise ValueError(f"coverage column {column!r} must contain non-negative integers")
+    if work["n_measured_samples"].gt(work["n_samples"]).any():
+        raise ValueError("coverage n_measured_samples cannot exceed n_samples")
+    invalid_fraction = work["fraction_above_floor"].isna() | ~work["fraction_above_floor"].between(
+        0.0, 1.0
+    )
+    if invalid_fraction.any():
+        raise ValueError("coverage fraction_above_floor values must be between 0 and 1")
+    invalid_p5 = work["p5_tpm"].notna() & ~np.isfinite(work["p5_tpm"])
+    if invalid_p5.any():
+        raise ValueError("coverage p5_tpm values must be finite or missing")
+
+    dimensions: dict[str, str] = {}
+    for column in ("sample_qc", "expression_space"):
+        values = work[column].dropna().astype(str).str.strip().unique()
+        if len(values) != 1 or work[column].isna().any() or not values[0]:
+            raise ValueError(f"coverage must use exactly one non-missing {column}; found {values}")
+        dimensions[column] = str(values[0])
+
+    computed_p5_pass = work["p5_tpm"].notna() & work["p5_tpm"].ge(floor)
+    inconsistent_pass = work["passes_p5_floor"] != computed_p5_pass
+    if inconsistent_pass.any():
+        raise ValueError("coverage passes_p5_floor values disagree with p5_tpm and the floor")
+    measured_without_member = ~work["panel_member_present"] & work["n_measured_samples"].gt(0)
+    if measured_without_member.any():
+        raise ValueError("coverage records measured samples for an absent panel member")
+
+    audit_key = ["Ensembl_Gene_ID", "cancer_code", "source_cohort"]
+    duplicates = work.duplicated(audit_key, keep=False)
+    if duplicates.any():
+        repeated = work.loc[duplicates, audit_key].drop_duplicates().to_dict("records")
+        raise ValueError(f"coverage contains duplicate gene/cohort audit rows: {repeated[:5]}")
+    return work, floor, dimensions
+
+
+def _summarize_housekeeping_gene_coverage(
+    gene_id: str,
+    gene_rows: pd.DataFrame,
+    *,
+    floor: float,
+    dimensions: dict[str, str],
+) -> dict:
+    linear = gene_rows[gene_rows["recommended_for_absolute_tpm_floor"]]
+    noncomparable = gene_rows[~gene_rows["recommended_for_absolute_tpm_floor"]]
+    measured = linear[
+        linear["panel_member_present"]
+        & linear["n_measured_samples"].gt(0)
+        & linear["p5_tpm"].notna()
+    ]
+    missing_measurement = len(linear) - len(measured)
+    passing = int(measured["passes_p5_floor"].sum())
+
+    if linear.empty:
+        status = "not_audited"
+    elif missing_measurement:
+        status = "missing_linear_measurement"
+    elif passing == len(linear):
+        status = "passes_all_linear_cohorts"
+    else:
+        status = "fails_some_linear_cohorts"
+
+    worst = measured.sort_values("p5_tpm", kind="stable", na_position="last").head(1)
+    worst_row = worst.iloc[0] if not worst.empty else None
+    symbols = gene_rows["Symbol"].dropna().astype(str)
+    symbol = symbols.iloc[0] if not symbols.empty else str(gene_id)
+    return {
+        "Ensembl_Gene_ID": gene_id,
+        "Symbol": symbol,
+        "housekeeping_detection_floor_tpm": floor,
+        "sample_qc": dimensions["sample_qc"],
+        "expression_space": dimensions["expression_space"],
+        "linear_cohorts_audited": len(linear),
+        "linear_samples_audited": int(linear["n_samples"].sum()),
+        "noncomparable_cohorts_observed": len(noncomparable),
+        "noncomparable_samples_observed": int(noncomparable["n_samples"].sum()),
+        "linear_cohorts_with_measurement": len(measured),
+        "linear_cohorts_missing_measurement": missing_measurement,
+        "linear_cohorts_passing_p5_floor": passing,
+        "linear_measured_cohort_pass_fraction": (
+            passing / len(measured) if len(measured) else np.nan
+        ),
+        "minimum_linear_p5_tpm": (
+            float(measured["p5_tpm"].min()) if not measured.empty else np.nan
+        ),
+        "minimum_linear_fraction_above_floor": (
+            float(measured["fraction_above_floor"].min()) if not measured.empty else np.nan
+        ),
+        "worst_linear_p5_cancer_code": (
+            worst_row["cancer_code"] if worst_row is not None else None
+        ),
+        "worst_linear_p5_source_cohort": (
+            worst_row["source_cohort"] if worst_row is not None else None
+        ),
+        "linear_floor_status": status,
+    }
+
+
 def housekeeping_cancer_expression_coverage_summary(
     coverage: pd.DataFrame,
     *,
@@ -2308,48 +2478,36 @@ def housekeeping_cancer_expression_coverage_summary(
 ) -> pd.DataFrame:
     """Summarize the cancer-side evidence for each housekeeping candidate.
 
-    This is the policy layer over :func:`housekeeping_cancer_expression_coverage`.
-    It answers one narrow question: across source rows whose scale supports absolute
-    clean-TPM comparison, does each candidate meet the recorded cohort p5 floor?
-    Non-comparable sources remain counted for visibility, but their numeric TPM values
-    never pass or veto the absolute floor.
+    This policy layer asks whether each candidate meets the recorded cohort p5
+    floor across sources whose scale supports absolute clean-TPM comparison.
+    Non-comparable sources remain counted, but their TPM values cannot pass or veto
+    the floor. ``linear_floor_status`` separates complete passes, measured low-tail
+    failures, missing measurements, and candidates with no comparable audit.
 
-    ``linear_floor_status`` distinguishes a complete pass, a measured low-tail failure,
-    missing measurement in at least one comparable cohort, and no comparable audit.
-    These statuses are evidence for panel review, not an automatic promotion rule.
-    Changing a denominator panel still requires a consumer-specific benchmark because
-    it changes every HK-normalized value and any threshold calibrated on that scale.
-
-    Coverage returned by the multi-cohort audit records any unavailable requested
-    cohorts. The summary rejects that known-partial input by default; pass
-    ``require_complete=False`` only for an explicitly exploratory cache-local audit.
+    The statuses are panel-review evidence, not an automatic promotion rule. A panel
+    change alters every HK-normalized value and still requires a consumer-specific
+    benchmark. Results from :func:`housekeeping_cancer_expression_coverage` declare
+    whether every requested cohort was audited. Partial or undeclared inputs are
+    rejected by default; use ``require_complete=False`` only for explicit exploration.
     """
-    required = {
-        "cancer_code",
-        "source_cohort",
-        "recommended_for_absolute_tpm_floor",
-        "housekeeping_detection_floor_tpm",
-        "Ensembl_Gene_ID",
-        "Symbol",
-        "panel_member_present",
-        "n_samples",
-        "n_measured_samples",
-        "fraction_above_floor",
-        "p5_tpm",
-        "passes_p5_floor",
-        "sample_qc",
-        "expression_space",
-    }
-    missing = sorted(required - set(coverage.columns))
+    missing = sorted(_HOUSEKEEPING_CANCER_COVERAGE_SUMMARY_REQUIRED - set(coverage.columns))
     if missing:
         raise ValueError(f"coverage missing required columns: {missing}")
-    completeness = coverage.attrs.get("cohort_audit_complete")
-    missing_codes = tuple(str(code) for code in coverage.attrs.get("missing_cancer_codes", ()))
+
+    completeness = _optional_bool(coverage.attrs.get("cohort_audit_complete"))
+    raw_missing_codes = coverage.attrs.get("missing_cancer_codes", ())
+    if isinstance(raw_missing_codes, str):
+        missing_codes = (raw_missing_codes,)
+    else:
+        missing_codes = tuple(str(code) for code in raw_missing_codes)
+    if completeness is True and missing_codes:
+        raise ValueError("coverage completeness metadata conflicts with missing_cancer_codes")
     if require_complete and completeness is not True:
-        if missing_codes:
-            detail = f"missing requested cancer codes: {list(missing_codes)}"
-        else:
-            detail = "input does not declare whether every requested cohort was audited"
+        detail = (
+            f"missing requested cancer codes: {list(missing_codes)}"
+            if missing_codes
+            else "input does not declare whether every requested cohort was audited"
+        )
         raise ValueError(
             f"housekeeping coverage audit is not confirmed complete; {detail}. "
             "Use housekeeping_cancer_expression_coverage to produce a complete audit "
@@ -2364,117 +2522,13 @@ def housekeeping_cancer_expression_coverage_summary(
         out.attrs["cohort_audit_complete"] = completeness
         return out
 
-    work = coverage.loc[:, sorted(required)].copy()
-    work["Ensembl_Gene_ID"] = work["Ensembl_Gene_ID"].astype(str).map(unversioned)
-    for column in (
-        "housekeeping_detection_floor_tpm",
-        "n_samples",
-        "n_measured_samples",
-        "fraction_above_floor",
-        "p5_tpm",
-    ):
-        work[column] = pd.to_numeric(work[column], errors="coerce")
-    true_values = {"true", "1", "yes"}
-    false_values = {"false", "0", "no"}
-    for column in (
-        "recommended_for_absolute_tpm_floor",
-        "panel_member_present",
-        "passes_p5_floor",
-    ):
-        normalized = work[column].astype(str).str.strip().str.lower()
-        invalid = normalized[~normalized.isin(true_values | false_values)]
-        if not invalid.empty:
-            values = sorted(invalid.unique().tolist())
-            raise ValueError(f"coverage column {column!r} contains non-boolean values: {values}")
-        work[column] = normalized.isin(true_values)
-
-    if work["housekeeping_detection_floor_tpm"].isna().any():
-        raise ValueError("coverage has missing housekeeping_detection_floor_tpm values")
-    floors = work["housekeeping_detection_floor_tpm"].unique()
-    if len(floors) != 1:
-        raise ValueError(
-            "coverage must use exactly one housekeeping_detection_floor_tpm; "
-            f"found {sorted(float(value) for value in floors)}"
+    work, floor, dimensions = _prepare_housekeeping_coverage_summary_input(coverage)
+    rows = [
+        _summarize_housekeeping_gene_coverage(
+            str(gene_id), gene_rows, floor=floor, dimensions=dimensions
         )
-    floor = float(floors[0])
-    if not np.isfinite(floor) or floor < 0:
-        raise ValueError("housekeeping_detection_floor_tpm must be finite and non-negative")
-
-    dimensions: dict[str, str] = {}
-    for column in ("sample_qc", "expression_space"):
-        values = work[column].dropna().astype(str).unique()
-        if len(values) != 1 or work[column].isna().any():
-            raise ValueError(f"coverage must use exactly one non-missing {column}; found {values}")
-        dimensions[column] = str(values[0])
-
-    computed_p5_pass = work["p5_tpm"].notna() & work["p5_tpm"].ge(floor)
-    inconsistent_pass = work["passes_p5_floor"] != computed_p5_pass
-    if inconsistent_pass.any():
-        raise ValueError("coverage passes_p5_floor values disagree with p5_tpm and the floor")
-
-    audit_key = ["Ensembl_Gene_ID", "cancer_code", "source_cohort"]
-    duplicates = work.duplicated(audit_key, keep=False)
-    if duplicates.any():
-        repeated = work.loc[duplicates, audit_key].drop_duplicates().to_dict("records")
-        raise ValueError(f"coverage contains duplicate gene/cohort audit rows: {repeated[:5]}")
-
-    rows: list[dict] = []
-    for gene_id, gene_rows in work.groupby("Ensembl_Gene_ID", sort=False, dropna=False):
-        linear = gene_rows[gene_rows["recommended_for_absolute_tpm_floor"]]
-        noncomparable = gene_rows[~gene_rows["recommended_for_absolute_tpm_floor"]]
-        measured = linear[
-            linear["panel_member_present"]
-            & linear["n_measured_samples"].fillna(0).gt(0)
-            & linear["p5_tpm"].notna()
-        ]
-        missing_measurement = len(linear) - len(measured)
-        passing = int(measured["passes_p5_floor"].sum())
-
-        if linear.empty:
-            status = "not_audited"
-        elif missing_measurement:
-            status = "missing_linear_measurement"
-        elif passing == len(linear):
-            status = "passes_all_linear_cohorts"
-        else:
-            status = "fails_some_linear_cohorts"
-
-        worst = measured.sort_values("p5_tpm", kind="stable", na_position="last").head(1)
-        worst_row = worst.iloc[0] if not worst.empty else None
-        symbols = gene_rows["Symbol"].dropna().astype(str)
-        symbol = symbols.iloc[0] if not symbols.empty else str(gene_id)
-        rows.append(
-            {
-                "Ensembl_Gene_ID": gene_id,
-                "Symbol": symbol,
-                "housekeeping_detection_floor_tpm": floor,
-                "sample_qc": dimensions["sample_qc"],
-                "expression_space": dimensions["expression_space"],
-                "linear_cohorts_audited": len(linear),
-                "linear_samples_audited": int(linear["n_samples"].fillna(0).sum()),
-                "noncomparable_cohorts_observed": len(noncomparable),
-                "noncomparable_samples_observed": int(noncomparable["n_samples"].fillna(0).sum()),
-                "linear_cohorts_with_measurement": len(measured),
-                "linear_cohorts_missing_measurement": missing_measurement,
-                "linear_cohorts_passing_p5_floor": passing,
-                "linear_measured_cohort_pass_fraction": (
-                    passing / len(measured) if len(measured) else np.nan
-                ),
-                "minimum_linear_p5_tpm": (
-                    float(measured["p5_tpm"].min()) if not measured.empty else np.nan
-                ),
-                "minimum_linear_fraction_above_floor": (
-                    float(measured["fraction_above_floor"].min()) if not measured.empty else np.nan
-                ),
-                "worst_linear_p5_cancer_code": (
-                    worst_row["cancer_code"] if worst_row is not None else None
-                ),
-                "worst_linear_p5_source_cohort": (
-                    worst_row["source_cohort"] if worst_row is not None else None
-                ),
-                "linear_floor_status": status,
-            }
-        )
+        for gene_id, gene_rows in work.groupby("Ensembl_Gene_ID", sort=False)
+    ]
 
     out = pd.DataFrame(rows, columns=_HOUSEKEEPING_CANCER_COVERAGE_SUMMARY_COLUMNS)
     out.attrs["issue"] = "#202"

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2177,6 +2177,14 @@ def housekeeping_cancer_expression_coverage_from_matrix(
             **source_metadata,
         }
 
+    raw_linear_comparability = meta.get("linear_tpm_comparable")
+    linear_tpm_comparable = _optional_bool(raw_linear_comparability)
+    if linear_tpm_comparable is None:
+        if pd.isna(raw_linear_comparability):
+            linear_tpm_comparable = False
+        else:
+            raise ValueError("source_metadata linear_tpm_comparable must be a boolean value")
+
     floor = float(housekeeping_detection_floor_tpm)
     if not np.isfinite(floor) or floor < 0:
         raise ValueError("housekeeping_detection_floor_tpm must be finite and non-negative")
@@ -2206,8 +2214,8 @@ def housekeeping_cancer_expression_coverage_from_matrix(
                 "source_type": meta.get("source_type"),
                 "unit": meta.get("unit"),
                 "source_scale_class": meta.get("source_scale_class"),
-                "linear_tpm_comparable": bool(meta.get("linear_tpm_comparable")),
-                "recommended_for_absolute_tpm_floor": bool(meta.get("linear_tpm_comparable")),
+                "linear_tpm_comparable": linear_tpm_comparable,
+                "recommended_for_absolute_tpm_floor": linear_tpm_comparable,
                 "sample_qc": sample_qc,
                 "expression_space": expression_space,
                 "housekeeping_detection_floor_tpm": floor,

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -2046,6 +2046,27 @@ _HOUSEKEEPING_CANCER_COVERAGE_COLUMNS = [
     "passes_p5_floor",
 ]
 
+_HOUSEKEEPING_CANCER_COVERAGE_SUMMARY_COLUMNS = [
+    "Ensembl_Gene_ID",
+    "Symbol",
+    "housekeeping_detection_floor_tpm",
+    "sample_qc",
+    "expression_space",
+    "linear_cohorts_audited",
+    "linear_samples_audited",
+    "noncomparable_cohorts_observed",
+    "noncomparable_samples_observed",
+    "linear_cohorts_with_measurement",
+    "linear_cohorts_missing_measurement",
+    "linear_cohorts_passing_p5_floor",
+    "linear_measured_cohort_pass_fraction",
+    "minimum_linear_p5_tpm",
+    "minimum_linear_fraction_above_floor",
+    "worst_linear_p5_cancer_code",
+    "worst_linear_p5_source_cohort",
+    "linear_floor_status",
+]
+
 
 def _housekeeping_panel_rows(panel_ids=None) -> pd.DataFrame:
     from .gene_families import clean_tpm_biological_housekeeping_genes
@@ -2138,6 +2159,8 @@ def housekeeping_cancer_expression_coverage_from_matrix(
         }
 
     floor = float(housekeeping_detection_floor_tpm)
+    if not np.isfinite(floor) or floor < 0:
+        raise ValueError("housekeeping_detection_floor_tpm must be finite and non-negative")
     n_samples = len(samples)
     rows: list[dict] = []
     for panel_row in panel.itertuples(index=False):
@@ -2224,9 +2247,17 @@ def housekeeping_cancer_expression_coverage(
     else:
         codes = list(cancer_types)
 
+    requested_codes: list[str] = []
+    seen_codes: set[str] = set()
+    audited_codes: list[str] = []
+    missing_codes: list[str] = []
     frames: list[pd.DataFrame] = []
     for requested in codes:
-        code = resolve_cancer_type(requested, strict=False) or requested
+        code = str(resolve_cancer_type(requested, strict=False) or requested)
+        if code in seen_codes:
+            continue
+        seen_codes.add(code)
+        requested_codes.append(code)
         try:
             clean = per_sample_expression(
                 code,
@@ -2237,8 +2268,10 @@ def housekeeping_cancer_expression_coverage(
         except (FileNotFoundError, source_matrices.SourceMatrixError):
             if mode == "raise":
                 raise
+            missing_codes.append(code)
             continue
         meta = _selected_expression_source_metadata(str(code))
+        audited_codes.append(code)
         frames.append(
             housekeeping_cancer_expression_coverage_from_matrix(
                 clean,
@@ -2251,12 +2284,197 @@ def housekeeping_cancer_expression_coverage(
             )
         )
 
-    if not frames:
-        return pd.DataFrame(columns=_HOUSEKEEPING_CANCER_COVERAGE_COLUMNS)
-    out = pd.concat(frames, ignore_index=True)
+    out = (
+        pd.concat(frames, ignore_index=True)
+        if frames
+        else pd.DataFrame(columns=_HOUSEKEEPING_CANCER_COVERAGE_COLUMNS)
+    )
     out.attrs["issue"] = "#202"
     out.attrs["sample_qc"] = sample_qc
     out.attrs["expression_space"] = "tpm_clean"
+    out.attrs["requested_cancer_codes"] = tuple(requested_codes)
+    out.attrs["audited_cancer_codes"] = tuple(audited_codes)
+    out.attrs["missing_cancer_codes"] = tuple(missing_codes)
+    out.attrs["cohort_audit_complete"] = not missing_codes
+    return out
+
+
+def housekeeping_cancer_expression_coverage_summary(
+    coverage: pd.DataFrame,
+    *,
+    require_complete: bool = True,
+) -> pd.DataFrame:
+    """Summarize the cancer-side evidence for each housekeeping candidate.
+
+    This is the policy layer over :func:`housekeeping_cancer_expression_coverage`.
+    It answers one narrow question: across source rows whose scale supports absolute
+    clean-TPM comparison, does each candidate meet the recorded cohort p5 floor?
+    Non-comparable sources remain counted for visibility, but their numeric TPM values
+    never pass or veto the absolute floor.
+
+    ``linear_floor_status`` distinguishes a complete pass, a measured low-tail failure,
+    missing measurement in at least one comparable cohort, and no comparable audit.
+    These statuses are evidence for panel review, not an automatic promotion rule.
+    Changing a denominator panel still requires a consumer-specific benchmark because
+    it changes every HK-normalized value and any threshold calibrated on that scale.
+
+    Coverage returned by the multi-cohort audit records any unavailable requested
+    cohorts. The summary rejects that known-partial input by default; pass
+    ``require_complete=False`` only for an explicitly exploratory cache-local audit.
+    """
+    required = {
+        "cancer_code",
+        "source_cohort",
+        "recommended_for_absolute_tpm_floor",
+        "housekeeping_detection_floor_tpm",
+        "Ensembl_Gene_ID",
+        "Symbol",
+        "panel_member_present",
+        "n_samples",
+        "n_measured_samples",
+        "fraction_above_floor",
+        "p5_tpm",
+        "passes_p5_floor",
+        "sample_qc",
+        "expression_space",
+    }
+    missing = sorted(required - set(coverage.columns))
+    if missing:
+        raise ValueError(f"coverage missing required columns: {missing}")
+    missing_codes = tuple(str(code) for code in coverage.attrs.get("missing_cancer_codes", ()))
+    if require_complete and missing_codes:
+        raise ValueError(
+            "housekeeping coverage audit is incomplete; missing requested cancer codes: "
+            f"{list(missing_codes)}. Fetch the missing source matrices or pass "
+            "require_complete=False for an explicitly partial audit."
+        )
+    if coverage.empty:
+        out = pd.DataFrame(columns=_HOUSEKEEPING_CANCER_COVERAGE_SUMMARY_COLUMNS)
+        out.attrs.update(coverage.attrs)
+        return out
+
+    work = coverage.loc[:, sorted(required)].copy()
+    work["Ensembl_Gene_ID"] = work["Ensembl_Gene_ID"].astype(str).map(unversioned)
+    for column in (
+        "housekeeping_detection_floor_tpm",
+        "n_samples",
+        "n_measured_samples",
+        "fraction_above_floor",
+        "p5_tpm",
+    ):
+        work[column] = pd.to_numeric(work[column], errors="coerce")
+    true_values = {"true", "1", "yes"}
+    false_values = {"false", "0", "no"}
+    for column in (
+        "recommended_for_absolute_tpm_floor",
+        "panel_member_present",
+        "passes_p5_floor",
+    ):
+        normalized = work[column].astype(str).str.strip().str.lower()
+        invalid = normalized[~normalized.isin(true_values | false_values)]
+        if not invalid.empty:
+            values = sorted(invalid.unique().tolist())
+            raise ValueError(f"coverage column {column!r} contains non-boolean values: {values}")
+        work[column] = normalized.isin(true_values)
+
+    if work["housekeeping_detection_floor_tpm"].isna().any():
+        raise ValueError("coverage has missing housekeeping_detection_floor_tpm values")
+    floors = work["housekeeping_detection_floor_tpm"].unique()
+    if len(floors) != 1:
+        raise ValueError(
+            "coverage must use exactly one housekeeping_detection_floor_tpm; "
+            f"found {sorted(float(value) for value in floors)}"
+        )
+    floor = float(floors[0])
+    if not np.isfinite(floor) or floor < 0:
+        raise ValueError("housekeeping_detection_floor_tpm must be finite and non-negative")
+
+    dimensions: dict[str, str] = {}
+    for column in ("sample_qc", "expression_space"):
+        values = work[column].dropna().astype(str).unique()
+        if len(values) != 1 or work[column].isna().any():
+            raise ValueError(f"coverage must use exactly one non-missing {column}; found {values}")
+        dimensions[column] = str(values[0])
+
+    computed_p5_pass = work["p5_tpm"].notna() & work["p5_tpm"].ge(floor)
+    inconsistent_pass = work["passes_p5_floor"] != computed_p5_pass
+    if inconsistent_pass.any():
+        raise ValueError("coverage passes_p5_floor values disagree with p5_tpm and the floor")
+
+    audit_key = ["Ensembl_Gene_ID", "cancer_code", "source_cohort"]
+    duplicates = work.duplicated(audit_key, keep=False)
+    if duplicates.any():
+        repeated = work.loc[duplicates, audit_key].drop_duplicates().to_dict("records")
+        raise ValueError(f"coverage contains duplicate gene/cohort audit rows: {repeated[:5]}")
+
+    rows: list[dict] = []
+    for gene_id, gene_rows in work.groupby("Ensembl_Gene_ID", sort=False, dropna=False):
+        linear = gene_rows[gene_rows["recommended_for_absolute_tpm_floor"]]
+        noncomparable = gene_rows[~gene_rows["recommended_for_absolute_tpm_floor"]]
+        measured = linear[
+            linear["panel_member_present"]
+            & linear["n_measured_samples"].fillna(0).gt(0)
+            & linear["p5_tpm"].notna()
+        ]
+        missing_measurement = len(linear) - len(measured)
+        passing = int(measured["passes_p5_floor"].sum())
+
+        if linear.empty:
+            status = "not_audited"
+        elif missing_measurement:
+            status = "missing_linear_measurement"
+        elif passing == len(linear):
+            status = "passes_all_linear_cohorts"
+        else:
+            status = "fails_some_linear_cohorts"
+
+        worst = measured.sort_values("p5_tpm", kind="stable", na_position="last").head(1)
+        worst_row = worst.iloc[0] if not worst.empty else None
+        symbols = gene_rows["Symbol"].dropna().astype(str)
+        symbol = symbols.iloc[0] if not symbols.empty else str(gene_id)
+        rows.append(
+            {
+                "Ensembl_Gene_ID": gene_id,
+                "Symbol": symbol,
+                "housekeeping_detection_floor_tpm": floor,
+                "sample_qc": dimensions["sample_qc"],
+                "expression_space": dimensions["expression_space"],
+                "linear_cohorts_audited": len(linear),
+                "linear_samples_audited": int(linear["n_samples"].fillna(0).sum()),
+                "noncomparable_cohorts_observed": len(noncomparable),
+                "noncomparable_samples_observed": int(noncomparable["n_samples"].fillna(0).sum()),
+                "linear_cohorts_with_measurement": len(measured),
+                "linear_cohorts_missing_measurement": missing_measurement,
+                "linear_cohorts_passing_p5_floor": passing,
+                "linear_measured_cohort_pass_fraction": (
+                    passing / len(measured) if len(measured) else np.nan
+                ),
+                "minimum_linear_p5_tpm": (
+                    float(measured["p5_tpm"].min()) if not measured.empty else np.nan
+                ),
+                "minimum_linear_fraction_above_floor": (
+                    float(measured["fraction_above_floor"].min()) if not measured.empty else np.nan
+                ),
+                "worst_linear_p5_cancer_code": (
+                    worst_row["cancer_code"] if worst_row is not None else None
+                ),
+                "worst_linear_p5_source_cohort": (
+                    worst_row["source_cohort"] if worst_row is not None else None
+                ),
+                "linear_floor_status": status,
+            }
+        )
+
+    out = pd.DataFrame(rows, columns=_HOUSEKEEPING_CANCER_COVERAGE_SUMMARY_COLUMNS)
+    out.attrs["issue"] = "#202"
+    out.attrs["housekeeping_detection_floor_tpm"] = floor
+    out.attrs["panel_selection_policy"] = "consumer_benchmark_required"
+    out.attrs["sample_qc"] = dimensions["sample_qc"]
+    out.attrs["expression_space"] = dimensions["expression_space"]
+    out.attrs["requested_cancer_codes"] = coverage.attrs.get("requested_cancer_codes")
+    out.attrs["audited_cancer_codes"] = coverage.attrs.get("audited_cancer_codes")
+    out.attrs["missing_cancer_codes"] = missing_codes
+    out.attrs["cohort_audit_complete"] = not missing_codes
     return out
 
 

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.164"
+__version__ = "1.8.165"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1835,9 +1835,9 @@ def test_housekeeping_cancer_expression_coverage_summary_is_source_scale_aware()
         "recommended_for_absolute_tpm_floor"
     ].map({True: "true", False: "false"})
 
-    summary = expression.housekeeping_cancer_expression_coverage_summary(coverage).set_index(
-        "Ensembl_Gene_ID"
-    )
+    summary = expression.housekeeping_cancer_expression_coverage_summary(
+        coverage, require_complete=False
+    ).set_index("Ensembl_Gene_ID")
 
     passing = summary.loc["ENSG_HK_PASS"]
     assert passing["linear_floor_status"] == "passes_all_linear_cohorts"
@@ -1881,7 +1881,7 @@ def test_housekeeping_cancer_expression_coverage_summary_rejects_mixed_floors():
     )
 
     with pytest.raises(ValueError, match="exactly one housekeeping_detection_floor_tpm"):
-        expression.housekeeping_cancer_expression_coverage_summary(coverage)
+        expression.housekeeping_cancer_expression_coverage_summary(coverage, require_complete=False)
 
 
 def test_housekeeping_cancer_expression_coverage_rejects_invalid_floor():
@@ -1939,7 +1939,7 @@ def test_housekeeping_cancer_expression_coverage_summary_rejects_known_partial_a
     assert coverage.attrs["audited_cancer_codes"] == ("LUAD",)
     assert coverage.attrs["missing_cancer_codes"] == ("MISSING",)
     assert not coverage.attrs["cohort_audit_complete"]
-    with pytest.raises(ValueError, match="audit is incomplete"):
+    with pytest.raises(ValueError, match="not confirmed complete"):
         expression.housekeeping_cancer_expression_coverage_summary(coverage)
 
     partial = expression.housekeeping_cancer_expression_coverage_summary(

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1901,6 +1901,44 @@ def test_housekeeping_cancer_expression_coverage_rejects_invalid_floor():
         )
 
 
+@pytest.mark.parametrize(
+    ("column", "value", "message"),
+    [
+        ("n_samples", -1, "non-negative integers"),
+        ("fraction_above_floor", 1.5, "between 0 and 1"),
+        ("recommended_for_absolute_tpm_floor", "maybe", "non-boolean values"),
+        ("passes_p5_floor", False, "disagree with p5_tpm"),
+        ("panel_member_present", False, "measured samples for an absent panel member"),
+    ],
+)
+def test_housekeeping_cancer_expression_coverage_summary_rejects_corrupt_rows(
+    column, value, message
+):
+    coverage = expression.housekeeping_cancer_expression_coverage_from_matrix(
+        pd.DataFrame(
+            {
+                "Ensembl_Gene_ID": ["ENSG_HK"],
+                "Symbol": ["HK"],
+                "sample": [100.0],
+            }
+        ),
+        cancer_type="LUAD",
+        source_metadata={
+            "source_cohort": "LUAD_SOURCE",
+            "linear_tpm_comparable": True,
+        },
+        panel_ids=["ENSG_HK"],
+        housekeeping_detection_floor_tpm=30.0,
+    )
+    coverage.attrs["cohort_audit_complete"] = True
+    if isinstance(value, str):
+        coverage[column] = coverage[column].astype(object)
+    coverage.loc[0, column] = value
+
+    with pytest.raises(ValueError, match=message):
+        expression.housekeeping_cancer_expression_coverage_summary(coverage)
+
+
 def test_housekeeping_cancer_expression_coverage_summary_rejects_known_partial_audit(
     monkeypatch,
 ):

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1763,6 +1763,190 @@ def test_housekeeping_cancer_expression_coverage_threads_sample_qc_and_source_sc
     assert keyed.loc["MTC", "source_scale_class"] == "microarray_tpm_proxy"
     assert set(out["sample_qc"]) == {"pass"}
     assert set(out["expression_space"]) == {"tpm_clean"}
+    assert out.attrs["requested_cancer_codes"] == ("LUAD", "MTC")
+    assert out.attrs["audited_cancer_codes"] == ("LUAD", "MTC")
+    assert out.attrs["missing_cancer_codes"] == ()
+    assert out.attrs["cohort_audit_complete"]
+
+
+def test_housekeeping_cancer_expression_coverage_summary_is_source_scale_aware():
+    panel_ids = ["ENSG_HK_PASS", "ENSG_HK_LOW", "ENSG_HK_MISSING"]
+
+    def audit(code, source, values, *, comparable):
+        matrix = pd.DataFrame(
+            {
+                "Ensembl_Gene_ID": list(values),
+                "Symbol": [gene_id.removeprefix("ENSG_") for gene_id in values],
+                "s1": [pair[0] for pair in values.values()],
+                "s2": [pair[1] for pair in values.values()],
+            }
+        )
+        return expression.housekeeping_cancer_expression_coverage_from_matrix(
+            matrix,
+            cancer_type=code,
+            source_metadata={
+                "source_cohort": source,
+                "source_type": "bulk RNA-seq" if comparable else "microarray",
+                "unit": "TPM" if comparable else "TPM proxy",
+                "source_scale_class": (
+                    "linear_rnaseq_tpm" if comparable else "microarray_tpm_proxy"
+                ),
+                "linear_tpm_comparable": comparable,
+            },
+            panel_ids=panel_ids,
+            housekeeping_detection_floor_tpm=30.0,
+        )
+
+    coverage = pd.concat(
+        [
+            audit(
+                "LUAD",
+                "LUAD_SOURCE",
+                {
+                    "ENSG_HK_PASS": (40.0, 50.0),
+                    "ENSG_HK_LOW": (20.0, 25.0),
+                    "ENSG_HK_MISSING": (35.0, 45.0),
+                },
+                comparable=True,
+            ),
+            audit(
+                "MBL",
+                "MBL_SOURCE",
+                {
+                    "ENSG_HK_PASS": (60.0, 70.0),
+                    "ENSG_HK_LOW": (40.0, 50.0),
+                },
+                comparable=True,
+            ),
+            audit(
+                "MTC",
+                "MTC_PROXY_SOURCE",
+                {
+                    "ENSG_HK_PASS": (1.0, 2.0),
+                    "ENSG_HK_LOW": (1.0, 2.0),
+                    "ENSG_HK_MISSING": (1.0, 2.0),
+                },
+                comparable=False,
+            ),
+        ],
+        ignore_index=True,
+    )
+    coverage["recommended_for_absolute_tpm_floor"] = coverage[
+        "recommended_for_absolute_tpm_floor"
+    ].map({True: "true", False: "false"})
+
+    summary = expression.housekeeping_cancer_expression_coverage_summary(coverage).set_index(
+        "Ensembl_Gene_ID"
+    )
+
+    passing = summary.loc["ENSG_HK_PASS"]
+    assert passing["linear_floor_status"] == "passes_all_linear_cohorts"
+    assert passing["linear_cohorts_audited"] == 2
+    assert passing["linear_cohorts_passing_p5_floor"] == 2
+    assert passing["noncomparable_cohorts_observed"] == 1
+    assert passing["minimum_linear_p5_tpm"] == pytest.approx(40.5)
+    assert passing["worst_linear_p5_cancer_code"] == "LUAD"
+    assert passing["worst_linear_p5_source_cohort"] == "LUAD_SOURCE"
+
+    low = summary.loc["ENSG_HK_LOW"]
+    assert low["linear_floor_status"] == "fails_some_linear_cohorts"
+    assert low["linear_measured_cohort_pass_fraction"] == pytest.approx(0.5)
+    assert low["worst_linear_p5_cancer_code"] == "LUAD"
+
+    missing = summary.loc["ENSG_HK_MISSING"]
+    assert missing["linear_floor_status"] == "missing_linear_measurement"
+    assert missing["linear_cohorts_with_measurement"] == 1
+    assert missing["linear_cohorts_missing_measurement"] == 1
+    assert summary.attrs["panel_selection_policy"] == "consumer_benchmark_required"
+
+
+def test_housekeeping_cancer_expression_coverage_summary_rejects_mixed_floors():
+    coverage = pd.DataFrame(
+        {
+            "cancer_code": ["A", "B"],
+            "source_cohort": ["A_SOURCE", "B_SOURCE"],
+            "recommended_for_absolute_tpm_floor": [True, True],
+            "housekeeping_detection_floor_tpm": [30.0, 50.0],
+            "Ensembl_Gene_ID": ["ENSG_HK", "ENSG_HK"],
+            "Symbol": ["HK", "HK"],
+            "panel_member_present": [True, True],
+            "n_samples": [2, 2],
+            "n_measured_samples": [2, 2],
+            "fraction_above_floor": [1.0, 1.0],
+            "p5_tpm": [40.0, 60.0],
+            "passes_p5_floor": [True, True],
+            "sample_qc": ["pass", "pass"],
+            "expression_space": ["tpm_clean", "tpm_clean"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="exactly one housekeeping_detection_floor_tpm"):
+        expression.housekeeping_cancer_expression_coverage_summary(coverage)
+
+
+def test_housekeeping_cancer_expression_coverage_rejects_invalid_floor():
+    matrix = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG_HK"],
+            "Symbol": ["HK"],
+            "sample": [100.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        expression.housekeeping_cancer_expression_coverage_from_matrix(
+            matrix,
+            panel_ids=["ENSG_HK"],
+            housekeeping_detection_floor_tpm=float("nan"),
+        )
+
+
+def test_housekeeping_cancer_expression_coverage_summary_rejects_known_partial_audit(
+    monkeypatch,
+):
+    matrix = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG_HK"],
+            "Symbol": ["HK"],
+            "sample": [100.0],
+        }
+    )
+
+    def fake_per_sample_expression(code, **_kwargs):
+        if code == "MISSING":
+            raise FileNotFoundError(code)
+        return matrix.copy()
+
+    monkeypatch.setattr(expression, "per_sample_expression", fake_per_sample_expression)
+    monkeypatch.setattr(
+        expression,
+        "_selected_expression_source_metadata",
+        lambda code: {
+            "source_cohort": f"{code}_SOURCE",
+            "source_type": "bulk RNA-seq",
+            "unit": "TPM",
+            "source_scale_class": "linear_rnaseq_tpm",
+            "linear_tpm_comparable": True,
+        },
+    )
+
+    coverage = expression.housekeeping_cancer_expression_coverage(
+        ["LUAD", "MISSING"],
+        auto_fetch=False,
+        panel_ids=["ENSG_HK"],
+    )
+
+    assert coverage.attrs["audited_cancer_codes"] == ("LUAD",)
+    assert coverage.attrs["missing_cancer_codes"] == ("MISSING",)
+    assert not coverage.attrs["cohort_audit_complete"]
+    with pytest.raises(ValueError, match="audit is incomplete"):
+        expression.housekeeping_cancer_expression_coverage_summary(coverage)
+
+    partial = expression.housekeeping_cancer_expression_coverage_summary(
+        coverage, require_complete=False
+    )
+    assert partial.loc[0, "linear_floor_status"] == "passes_all_linear_cohorts"
+    assert not partial.attrs["cohort_audit_complete"]
 
 
 def test_per_sample_expression_filters_by_sample_qc(tmp_path, monkeypatch):

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1721,6 +1721,31 @@ def test_housekeeping_cancer_expression_coverage_from_matrix_reports_low_tail_st
     assert out.attrs["issue"] == "#202"
 
 
+def test_housekeeping_cancer_expression_coverage_parses_source_comparability_strictly():
+    matrix = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["ENSG_HK"],
+            "Symbol": ["HK"],
+            "sample": [100.0],
+        }
+    )
+
+    proxy = expression.housekeeping_cancer_expression_coverage_from_matrix(
+        matrix,
+        source_metadata={"linear_tpm_comparable": "false"},
+        panel_ids=["ENSG_HK"],
+    )
+    assert not proxy.loc[0, "linear_tpm_comparable"]
+    assert not proxy.loc[0, "recommended_for_absolute_tpm_floor"]
+
+    with pytest.raises(ValueError, match="must be a boolean value"):
+        expression.housekeeping_cancer_expression_coverage_from_matrix(
+            matrix,
+            source_metadata={"linear_tpm_comparable": "maybe"},
+            panel_ids=["ENSG_HK"],
+        )
+
+
 def test_housekeeping_cancer_expression_coverage_threads_sample_qc_and_source_scale(monkeypatch):
     matrix = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary

- add a source-aware per-gene summary over the existing cancer housekeeping coverage audit
- distinguish comparable linear-TPM evidence from proxy/nonlinear observations
- preserve requested, audited, and unavailable cohort provenance and reject known-partial policy summaries by default
- document that housekeeping normalization is consumer-specific and that panel changes require downstream recalibration
- keep the active 30-gene panel and data-bundle version unchanged

## Why

Issue #202 had raw per-cohort coverage diagnostics but no robust policy layer. Consumers could accidentally treat proxy TPM values as linear evidence or summarize a partial local cache as though every requested cohort had been audited. The new summary makes those conditions explicit without promoting a weakly supported candidate-panel swap.

## Validation

- `./test.sh` (`967 passed`, zero skipped)
- `./lint.sh`
- `python -m mkdocs build --strict --site-dir /tmp/oncoref-site-202`
- real cached LUAD/SKCM audit smoke: 60 coverage rows, 30 summarized genes, no missing requested cohorts

Closes #202.
