### PR TITLE
Add co-occurrence-aware CTA p90/p95 plots

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -333,6 +333,25 @@ candidate is called a CTA by an explicit Human Protein Atlas (HPA) normal-tissue
 expression rule; the call is not evidence that its antigen is presented by the
 major histocompatibility complex (MHC) or that it is a validated therapy target.
 
+CTA identity and tumor coverage answer different questions. The HPA-derived CTA
+definition determines which genes are in the reference set. Tumor expression
+then asks how often those CTAs are active in a cohort. An absolute threshold such
+as 50 clean TPM compares expression magnitudes. A within-sample p90 or p95
+threshold instead ranks the complete biological transcriptome inside each tumor:
+p90 means the CTA is in that tumor's top 10% of expression values, and p95 means
+the top 5%. Rank thresholds are appropriate when source scales are not directly
+comparable.
+
+Patient coverage requires the joint per-sample matrix. It is the fraction of
+patients with at least one positive CTA, counting a patient once even when
+several CTAs are positive. It cannot be recovered by adding per-gene prevalence
+or taking the largest prevalence value. `cta_within_sample_percentile_coverage()`
+retains this co-occurrence and returns a deterministic greedy antigen order for
+p90/p95; `cta_within_sample_percentile_addressable_fraction_by_cohort()` returns
+the final true patient union. Both use biological clean TPM and collapse
+identical-protein CTA loci before ranking by default. They use QC-passing samples
+by default; pass `sample_qc="all"` only for an explicit forensic view.
+
 ### Restriction synthesis
 
 `synthesize_restriction()` prefers the HPA protein restriction when protein data
@@ -368,8 +387,21 @@ cta.cta_gene_names()
 cta.cta_clinical_target_evidence()
 cta.cta_specificity_audit()
 cta_coverage.cta_addressable_fraction("LUAD")
+coverage = cta_coverage.cta_within_sample_percentile_coverage(
+    ["LUAD", "SKCM"], percentiles=(0.90, 0.95)
+)
+cta_coverage.cta_within_sample_percentile_addressable_fraction_by_cohort(
+    ["LUAD", "SKCM"], percentile=0.95, coverage=coverage
+)
 cta_peptides.cta_specific_9mer_count_map(by="proteoform_key")
 ```
+
+When `cohorts` is omitted, the percentile-coverage APIs inspect only cached
+per-sample matrices and do not download data. Use
+`locally_available_percentile_cohorts()` and
+`locally_available_within_sample_cohorts()` to plan local work across both
+package/artifact data and a partial bundle cache. Set `include_recomputable=False`
+when only already-built shards should count.
 
 ## Generic Antigen Panels
 
@@ -959,8 +991,11 @@ but it is not the clean-TPM biological denominator.
   `data_bundle.bundle_is_local()` reports whether the entire downloadable cache is
   populated. For a side-effect-free check of one required artifact across both an
   in-repository/package data directory and a partial cache, use
-  `data_bundle.item_is_local(path)` or `data_bundle.find_local_item(path)`. These
-  item-level probes never fetch data and reject empty files or directories. Use
+  `data_bundle.item_is_local(path)` or `data_bundle.find_local_item(path)`. When
+  package data and the cache can each hold different shards of the same artifact,
+  use `data_bundle.local_item_paths(path)` to inspect both non-empty roots in read
+  precedence order. These item-level probes never fetch data and reject empty
+  files or directories. Use
   `data_bundle.bundle_release_manifest()` to fetch and validate only the small
   release manifest/checksum for the active `DATA_VERSION`, including tarball
   sha256 plus any artifact inventory, builder commit, source-matrix version, and

--- a/oncoref/__init__.py
+++ b/oncoref/__init__.py
@@ -113,6 +113,8 @@ from .coverage import (
     greedy_coverage,
     mean_antigens_per_patient,
     mean_antigens_per_patient_by_cohort,
+    within_sample_percentile_addressable_fraction_by_cohort,
+    within_sample_percentile_coverage_sweep,
 )
 from .cta import (
     CTA_by_axes,
@@ -192,6 +194,8 @@ from .expression import (
     housekeeping_cancer_expression_coverage,
     housekeeping_cancer_expression_coverage_from_matrix,
     housekeeping_cancer_expression_coverage_summary,
+    locally_available_percentile_cohorts,
+    locally_available_within_sample_cohorts,
     pan_cancer_expression,
     per_sample_expression,
     pooled_cohort_stats,
@@ -605,6 +609,8 @@ __all__ = [
     "is_protein_coding_gene",
     "is_rescue_feature",
     "known_cohort_ids",
+    "locally_available_percentile_cohorts",
+    "locally_available_within_sample_cohorts",
     "log1p_transform",
     "log2_transform",
     "matched_normal_tissue",
@@ -676,5 +682,7 @@ __all__ = [
     "tpm_to_housekeeping_normalized",
     "unversioned",
     "viral_status",
+    "within_sample_percentile_addressable_fraction_by_cohort",
+    "within_sample_percentile_coverage_sweep",
     "within_sample_top_fraction",
 ]

--- a/oncoref/coverage.py
+++ b/oncoref/coverage.py
@@ -53,7 +53,31 @@ DEFAULT_EXPRESSED_TPM: float = 10.0
 # are comparable across packages.
 DEFAULT_THRESHOLDS: tuple[float, ...] = (25, 50, 100, 200)
 
+# The two within-sample percentile cuts used by the pirlygenes CTA plot catalog.
+# Values are percentile ranks on [0, 1], so 0.95 means the top 5% of biological
+# expression values within each individual tumor.
+DEFAULT_WITHIN_SAMPLE_PERCENTILES: tuple[float, ...] = (0.90, 0.95)
+
 _BASE = ["Ensembl_Gene_ID", "Symbol"]
+
+_GREEDY_COVERAGE_COLUMNS = [
+    "rank",
+    "Ensembl_Gene_ID",
+    "Symbol",
+    "marginal_patients",
+    "marginal_fraction",
+    "cumulative_patients",
+    "cumulative_fraction",
+    "proteoform_key",
+    "proteoform_members",
+]
+
+_PERCENTILE_COVERAGE_COLUMNS = [
+    "cancer_code",
+    "within_sample_percentile",
+    "n_patients",
+    *_GREEDY_COVERAGE_COLUMNS,
+]
 
 
 def _clean_id(value: str) -> str:
@@ -251,6 +275,66 @@ def addressable_fraction(
     return float(hits.any(axis=0).mean())
 
 
+def _empty_greedy_coverage() -> pd.DataFrame:
+    """Schema-stable empty result for a cohort with no coverable patients."""
+    return pd.DataFrame(columns=_GREEDY_COVERAGE_COLUMNS)
+
+
+def _greedy_coverage_from_hits(
+    panel: pd.DataFrame,
+    samples: list[str],
+    hits: np.ndarray,
+    *,
+    max_genes: int | None,
+) -> pd.DataFrame:
+    """Run deterministic greedy set cover over an already-defined hit matrix."""
+    n_patients = len(samples)
+    if n_patients == 0 or hits.size == 0:
+        return _empty_greedy_coverage()
+
+    rows: list[dict] = []
+    covered = np.zeros(n_patients, dtype=bool)
+    remaining = set(range(len(panel)))
+    total_prevalence = hits.sum(axis=1)
+    limit = len(panel) if max_genes is None else max_genes
+
+    while remaining and len(rows) < limit:
+        best_gene = None
+        best_new = 0
+        best_prevalence = -1
+        for gene_index in sorted(remaining):
+            newly_covered = int(np.count_nonzero(hits[gene_index] & ~covered))
+            score = (newly_covered, int(total_prevalence[gene_index]))
+            if score > (best_new, best_prevalence):
+                best_gene = gene_index
+                best_new, best_prevalence = score
+        if best_gene is None or best_new == 0:
+            break
+
+        covered |= hits[best_gene]
+        remaining.remove(best_gene)
+        cumulative = int(covered.sum())
+        row = {
+            "rank": len(rows) + 1,
+            "Ensembl_Gene_ID": str(panel.at[best_gene, "Ensembl_Gene_ID"]),
+            "Symbol": str(panel.at[best_gene, "Symbol"]),
+            "marginal_patients": best_new,
+            "marginal_fraction": best_new / n_patients,
+            "cumulative_patients": cumulative,
+            "cumulative_fraction": cumulative / n_patients,
+            "proteoform_key": pd.NA,
+            "proteoform_members": pd.NA,
+        }
+        for column in ("proteoform_key", "proteoform_members"):
+            if column in panel.columns:
+                row[column] = str(panel.at[best_gene, column])
+        rows.append(row)
+    columns = list(_GREEDY_COVERAGE_COLUMNS)
+    if "proteoform_key" not in panel.columns:
+        columns = columns[:-2]
+    return pd.DataFrame(rows, columns=columns)
+
+
 def greedy_coverage(
     cancer_type,
     *,
@@ -270,59 +354,230 @@ def greedy_coverage(
     cumulative fraction is the coverage curve; its last value equals
     :func:`addressable_fraction` once the panel is exhausted (unless ``max_genes``
     truncates it first). Ties are broken by total prevalence (deterministic)."""
-    sub, samples, hits, _ = _hit_matrix(
+    panel, samples, hits, _ = _hit_matrix(
         cancer_type, threshold_tpm=threshold_tpm, gene_ids=gene_ids, proteoform=proteoform
     )
-    n = len(samples)
+    return _greedy_coverage_from_hits(panel, samples, hits, max_genes=max_genes)
+
+
+def _validate_within_sample_percentiles(percentiles) -> tuple[float, ...]:
+    """Normalize percentile ranks and enforce the shipped within-sample contract."""
+    from .expression_builders import WITHIN_SAMPLE_THRESHOLDS
+
+    raw = (percentiles,) if isinstance(percentiles, (int, float)) else tuple(percentiles)
+    values = tuple(dict.fromkeys(float(value) for value in raw))
+    allowed = tuple(sorted(WITHIN_SAMPLE_THRESHOLDS))
+    invalid = [value for value in values if value not in WITHIN_SAMPLE_THRESHOLDS]
+    if not values or invalid:
+        raise ValueError(f"percentiles must contain one or more of {list(allowed)}")
+    return values
+
+
+def _normalize_cohort_codes(cohorts: Iterable[str] | str) -> list[str]:
+    """Resolve one code or an iterable while retaining first-seen order."""
+    requested = [cohorts] if isinstance(cohorts, str) else list(cohorts)
+    return list(
+        dict.fromkeys(resolve_cancer_type(code, strict=False) or str(code) for code in requested)
+    )
+
+
+def _within_sample_percentile_panel_ranks(
+    cancer_type,
+    *,
+    gene_ids: Iterable[str] | None,
+    proteoform: bool,
+    sample_qc: str,
+) -> tuple[pd.DataFrame, list[str], np.ndarray]:
+    """Return panel rows and their whole-transcriptome ranks in each patient."""
+    from .expression import _biological_per_sample
+
+    biological = _biological_per_sample(
+        cancer_type,
+        proteoform=proteoform,
+        auto_fetch=False,
+        scope="cta",
+        sample_qc=sample_qc,
+    )
+    samples = [column for column in biological.columns if column not in _ANTIGEN_ID_COLS]
+    if not samples:
+        raise ValueError(f"no per-sample columns to rank for {cancer_type!r}")
+
+    panel_ids = _panel_ids(gene_ids)
+    if proteoform:
+        from .proteoforms import gene_to_proteoform_id
+
+        panel_keys = set(gene_to_proteoform_id(sorted(panel_ids), scope="cta").values())
+        in_panel = biological["proteoform_key"].astype(str).isin(panel_keys)
+    else:
+        row_ids = biological["Ensembl_Gene_ID"].astype(str).str.split(".").str[0]
+        in_panel = row_ids.isin(panel_ids)
+
+    panel = biological.loc[in_panel].reset_index(drop=True)
+    if panel.empty:
+        return panel, samples, np.empty((0, len(samples)), dtype=float)
+
+    # Use the same rank definition as the shipped within-sample artifacts:
+    # average ranks for ties, divided by the number of measured biological rows.
+    ranks = biological[samples].rank(axis=0, pct=True)
+    panel_ranks = ranks.loc[in_panel].to_numpy(dtype=float)
+    return panel, samples, panel_ranks
+
+
+def _zero_coverage_row(code: str, percentile: float, n_patients: int) -> dict:
+    """Represent an audited cohort with no CTA-positive patient at one cutoff."""
+    return {
+        "cancer_code": code,
+        "within_sample_percentile": percentile,
+        "n_patients": n_patients,
+        "rank": 0,
+        "Ensembl_Gene_ID": pd.NA,
+        "Symbol": pd.NA,
+        "marginal_patients": 0,
+        "marginal_fraction": 0.0,
+        "cumulative_patients": 0,
+        "cumulative_fraction": 0.0,
+        "proteoform_key": pd.NA,
+        "proteoform_members": pd.NA,
+    }
+
+
+def within_sample_percentile_coverage_sweep(
+    cohorts: Iterable[str] | None = None,
+    *,
+    percentiles: Iterable[float] = DEFAULT_WITHIN_SAMPLE_PERCENTILES,
+    gene_ids: Iterable[str] | None = None,
+    proteoform: bool = True,
+    sample_qc: str = "pass",
+    on_missing: str = "raise",
+) -> pd.DataFrame:
+    """Co-occurrence-aware antigen coverage at within-sample percentile cuts.
+
+    Each tumor is ranked across its biological clean-TPM transcriptome.  A panel
+    antigen is positive at ``0.95`` when it is in that tumor's top 5% of ranked
+    expression values.  The returned long table contains the deterministic greedy
+    set-cover order for every cohort and requested percentile.  Identical-protein
+    CTA loci are summed before ranking by default.
+
+    ``cohorts=None`` uses only locally cached per-sample matrices and never fetches.
+    Explicit cohorts are also read with downloads disabled.  ``on_missing='record'``
+    keeps available cohorts and records missing paths in ``attrs['missing_cohorts']``;
+    the default raises.  Audited cohorts with zero coverage receive one ``rank=0``
+    row so absence is distinguishable from missing data.
+    """
+    if on_missing not in {"raise", "record"}:
+        raise ValueError("on_missing must be 'raise' or 'record'")
+    percentile_values = _validate_within_sample_percentiles(percentiles)
+
+    from . import source_matrices
+
+    if cohorts is None:
+        requested = [
+            code for code in source_matrices.available_cohorts() if source_matrices.is_cached(code)
+        ]
+    else:
+        requested = cohorts
+    codes = _normalize_cohort_codes(requested)
+
     rows: list[dict] = []
-    if n == 0 or hits.size == 0:
-        return pd.DataFrame(
-            columns=[
-                "rank",
-                "Ensembl_Gene_ID",
-                "Symbol",
-                "marginal_patients",
-                "marginal_fraction",
-                "cumulative_patients",
-                "cumulative_fraction",
-                "proteoform_key",
-                "proteoform_members",
-            ]
-        )
+    audited: list[str] = []
+    missing: dict[str, str] = {}
+    for code in codes:
+        try:
+            panel, samples, panel_ranks = _within_sample_percentile_panel_ranks(
+                code,
+                gene_ids=gene_ids,
+                proteoform=proteoform,
+                sample_qc=sample_qc,
+            )
+        except FileNotFoundError as error:
+            if on_missing == "raise":
+                raise
+            missing[code] = str(error)
+            continue
 
-    covered = np.zeros(n, dtype=bool)
-    remaining = set(range(len(sub)))
-    total_prev = hits.sum(axis=1)  # tie-break: prefer the more broadly expressed gene
-    limit = max_genes if max_genes is not None else len(sub)
+        audited.append(code)
+        for percentile in percentile_values:
+            hits = panel_ranks >= percentile
+            greedy = _greedy_coverage_from_hits(panel, samples, hits, max_genes=None)
+            if greedy.empty:
+                rows.append(_zero_coverage_row(code, percentile, len(samples)))
+                continue
+            for record in greedy.to_dict(orient="records"):
+                rows.append(
+                    {
+                        "cancer_code": code,
+                        "within_sample_percentile": percentile,
+                        "n_patients": len(samples),
+                        **record,
+                    }
+                )
 
-    while remaining and len(rows) < limit:
-        # Pick the gene covering the most still-uncovered patients; ties by total
-        # prevalence, then by smallest row index — fully deterministic (sorted scan +
-        # strict tuple comparison), independent of set-iteration order.
-        best_g, best_new, best_prev = None, 0, -1
-        for g in sorted(remaining):
-            new = int(np.count_nonzero(hits[g] & ~covered))
-            if (new, total_prev[g]) > (best_new, best_prev):
-                best_g, best_new, best_prev = g, new, int(total_prev[g])
-        if best_g is None or best_new == 0:
-            break  # no remaining gene covers a new patient
-        covered |= hits[best_g]
-        remaining.discard(best_g)
-        cum = int(covered.sum())
-        row = {
-            "rank": len(rows) + 1,
-            "Ensembl_Gene_ID": str(sub.at[best_g, "Ensembl_Gene_ID"]),
-            "Symbol": str(sub.at[best_g, "Symbol"]),
-            "marginal_patients": best_new,
-            "marginal_fraction": best_new / n,
-            "cumulative_patients": cum,
-            "cumulative_fraction": cum / n,
+    out = pd.DataFrame(rows, columns=_PERCENTILE_COVERAGE_COLUMNS)
+    out.attrs.update(
+        {
+            "threshold_basis": "biological_clean_tpm_rank_within_sample",
+            "requested_cohorts": codes,
+            "audited_cohorts": audited,
+            "missing_cohorts": missing,
+            "percentiles": percentile_values,
+            "proteoform": proteoform,
+            "sample_qc": sample_qc,
         }
-        for _idcol in ("proteoform_key", "proteoform_members"):
-            if _idcol in sub.columns:
-                row[_idcol] = str(sub.at[best_g, _idcol])
-        rows.append(row)
-    return pd.DataFrame(rows)
+    )
+    return out
+
+
+def _coverage_at_percentile(coverage: pd.DataFrame, percentile: float) -> pd.DataFrame:
+    """Validate and select one percentile from a coverage sweep."""
+    required = set(_PERCENTILE_COVERAGE_COLUMNS)
+    missing = sorted(required - set(coverage.columns))
+    if missing:
+        raise ValueError(f"coverage table is missing required columns: {missing}")
+    target = _validate_within_sample_percentiles((percentile,))[0]
+    values = pd.to_numeric(coverage["within_sample_percentile"], errors="coerce")
+    if values.isna().any():
+        raise ValueError("coverage table contains a nonnumeric within_sample_percentile")
+    matches = np.isclose(values.to_numpy(dtype=float), target)
+    if not coverage.empty and not matches.any():
+        raise ValueError(f"coverage table does not contain percentile {target:g}")
+    return coverage.loc[matches].copy()
+
+
+def within_sample_percentile_addressable_fraction_by_cohort(
+    cohorts: Iterable[str] | None = None,
+    *,
+    percentile: float = 0.95,
+    gene_ids: Iterable[str] | None = None,
+    proteoform: bool = True,
+    sample_qc: str = "pass",
+    coverage: pd.DataFrame | None = None,
+    on_missing: str = "raise",
+) -> pd.Series:
+    """Fraction of patients with at least one panel antigen above a rank cutoff.
+
+    This is the faithful patient union, derived from the joint per-sample matrix;
+    it is not the maximum of independent per-gene prevalence summaries.  Supply a
+    precomputed :func:`within_sample_percentile_coverage_sweep` table to reuse one
+    matrix pass across plots.
+    """
+    if coverage is None:
+        coverage = within_sample_percentile_coverage_sweep(
+            cohorts,
+            percentiles=(percentile,),
+            gene_ids=gene_ids,
+            proteoform=proteoform,
+            sample_qc=sample_qc,
+            on_missing=on_missing,
+        )
+    selected = _coverage_at_percentile(coverage, percentile)
+    if cohorts is not None:
+        requested = set(_normalize_cohort_codes(cohorts))
+        selected = selected[selected["cancer_code"].astype(str).isin(requested)]
+    if selected.empty:
+        return pd.Series(dtype=float, name="addressable_fraction")
+    ordered = selected.sort_values(["cancer_code", "rank"], kind="stable")
+    final = ordered.groupby("cancer_code", sort=False)["cumulative_fraction"].last()
+    return pd.to_numeric(final, errors="raise").rename("addressable_fraction")
 
 
 def mean_antigens_per_patient(

--- a/oncoref/cta_coverage.py
+++ b/oncoref/cta_coverage.py
@@ -16,12 +16,15 @@ from __future__ import annotations
 
 from .coverage import (
     DEFAULT_EXPRESSED_TPM,
+    DEFAULT_WITHIN_SAMPLE_PERCENTILES,
     addressable_fraction,
     addressable_fraction_by_cohort,
     cta_patient_fractions,
     greedy_coverage,
     mean_antigens_per_patient,
     mean_antigens_per_patient_by_cohort,
+    within_sample_percentile_addressable_fraction_by_cohort,
+    within_sample_percentile_coverage_sweep,
 )
 
 
@@ -72,12 +75,53 @@ def cta_mean_antigens_per_patient_by_cohort(
     )
 
 
+def cta_within_sample_percentile_coverage(
+    cohorts=None,
+    *,
+    percentiles=DEFAULT_WITHIN_SAMPLE_PERCENTILES,
+    proteoform: bool = True,
+    sample_qc: str = "pass",
+    on_missing: str = "raise",
+):
+    """Greedy CTA patient coverage at tumor-specific p90/p95 rank cutoffs."""
+    return within_sample_percentile_coverage_sweep(
+        cohorts,
+        percentiles=percentiles,
+        proteoform=proteoform,
+        sample_qc=sample_qc,
+        on_missing=on_missing,
+    )
+
+
+def cta_within_sample_percentile_addressable_fraction_by_cohort(
+    cohorts=None,
+    *,
+    percentile: float = 0.95,
+    proteoform: bool = True,
+    sample_qc: str = "pass",
+    coverage=None,
+    on_missing: str = "raise",
+):
+    """CTA-positive patient union per cohort at a within-tumor rank cutoff."""
+    return within_sample_percentile_addressable_fraction_by_cohort(
+        cohorts,
+        percentile=percentile,
+        proteoform=proteoform,
+        sample_qc=sample_qc,
+        coverage=coverage,
+        on_missing=on_missing,
+    )
+
+
 __all__ = [
     "DEFAULT_EXPRESSED_TPM",
+    "DEFAULT_WITHIN_SAMPLE_PERCENTILES",
     "cta_addressable_fraction",
     "cta_addressable_fraction_by_cohort",
     "cta_greedy_coverage",
     "cta_mean_antigens_per_patient",
     "cta_mean_antigens_per_patient_by_cohort",
     "cta_patient_fractions",
+    "cta_within_sample_percentile_addressable_fraction_by_cohort",
+    "cta_within_sample_percentile_coverage",
 ]

--- a/oncoref/data_bundle.py
+++ b/oncoref/data_bundle.py
@@ -464,6 +464,30 @@ def find_local_item(relative_path: str) -> Path | None:
     return None
 
 
+def local_item_paths(relative_path: str) -> tuple[Path, ...]:
+    """Return every non-empty local copy of one data item, without downloading.
+
+    Package/artifact checkouts and the active bundle cache can each contain a
+    partial shard directory.  Callers that enumerate shards must inspect both
+    roots instead of stopping at the first non-empty directory.  Paths retain
+    normal read precedence (package data first, then cache) and are de-duplicated
+    when both roots resolve to the same location.
+    """
+    path = Path(relative_path)
+    if path.is_absolute() or not path.parts or ".." in path.parts:
+        raise ValueError("relative_path must stay within a data root")
+
+    found: list[Path] = []
+    seen: set[Path] = set()
+    for root in (_PACKAGE_DATA_DIR, cache_dir()):
+        candidate = root / path
+        resolved = candidate.resolve()
+        if _path_complete(candidate) and resolved not in seen:
+            found.append(candidate)
+            seen.add(resolved)
+    return tuple(found)
+
+
 def item_is_local(relative_path: str) -> bool:
     """Whether one data item is non-empty in the package or active cache."""
     return find_local_item(relative_path) is not None
@@ -864,6 +888,7 @@ __all__ = [
     "is_local",
     "item_is_local",
     "list_cache_versions",
+    "local_item_paths",
     "prune_cache",
     "status",
     "verify_local",

--- a/oncoref/expression.py
+++ b/oncoref/expression.py
@@ -234,6 +234,26 @@ def _available_shard_codes(root: Path) -> list[str]:
     return sorted(p.stem for p in root.glob("*.parquet") if not p.name.startswith("._"))
 
 
+def _local_shard_dirs(
+    dataset: ShardDataset, *, proteoform: bool = False, scope: str = "cta"
+) -> tuple[Path, ...]:
+    """Every locally present directory for one shard variant, without fetching."""
+    return data_bundle.local_item_paths(dataset.subdir(proteoform=proteoform, scope=scope))
+
+
+def _available_local_cohorts(
+    dataset: ShardDataset, *, proteoform: bool = False, scope: str = "cta"
+) -> list[str]:
+    """Sorted union of shard codes across package and active-cache roots."""
+    return sorted(
+        {
+            code
+            for root in _local_shard_dirs(dataset, proteoform=proteoform, scope=scope)
+            for code in _available_shard_codes(root)
+        }
+    )
+
+
 def _shard_dir(dataset: ShardDataset, *, proteoform: bool = False, scope: str = "cta") -> Path:
     """The bundle directory holding ``dataset``'s per-cohort shards at the requested
     level and ``scope`` (the proteoform variant is scope-specific — see
@@ -250,6 +270,9 @@ def _available_cohorts(
 ) -> list[str]:
     """Sorted cohort codes with a shipped shard for ``dataset`` (gene, or the
     scope-specific proteoform variant)."""
+    local = _available_local_cohorts(dataset, proteoform=proteoform, scope=scope)
+    if local:
+        return local
     return _available_shard_codes(_shard_dir(dataset, proteoform=proteoform, scope=scope))
 
 
@@ -260,7 +283,12 @@ def _shard_path(
     proteoform: bool = False,
     scope: str = "cta",
 ) -> Path:
-    return _shard_dir(dataset, proteoform=proteoform, scope=scope) / f"{code}.parquet"
+    filename = f"{code}.parquet"
+    for root in _local_shard_dirs(dataset, proteoform=proteoform, scope=scope):
+        candidate = root / filename
+        if candidate.is_file():
+            return candidate
+    return _shard_dir(dataset, proteoform=proteoform, scope=scope) / filename
 
 
 def _resolve_cancer_types(
@@ -1060,6 +1088,43 @@ def available_percentile_cohorts(*, proteoform: bool = False, scope: str = "cta"
     ``proteoform=True``, the proteoform-summed variant (one vector per proteoform
     key, identical-protein members collapsed before ranking, in ``scope``)."""
     return _available_cohorts(_PERCENTILES, proteoform=proteoform, scope=scope)
+
+
+def _locally_available_summary_cohorts(
+    dataset: ShardDataset,
+    *,
+    proteoform: bool,
+    scope: str,
+    include_recomputable: bool,
+) -> list[str]:
+    """Local shard union, optionally extended by cached source matrices."""
+    available = set(_available_local_cohorts(dataset, proteoform=proteoform, scope=scope))
+    if include_recomputable:
+        available.update(
+            code for code in source_matrices.available_cohorts() if source_matrices.is_cached(code)
+        )
+    return sorted(available)
+
+
+def locally_available_percentile_cohorts(
+    *,
+    proteoform: bool = False,
+    scope: str = "cta",
+    include_recomputable: bool = True,
+) -> list[str]:
+    """Cohorts readable as percentile vectors without a download.
+
+    The result is the union of shards in package/artifact data and the active
+    partial bundle cache. With ``include_recomputable=True`` (default), it also
+    includes cohorts whose per-sample source matrix is cached locally. This
+    function never fetches either data source.
+    """
+    return _locally_available_summary_cohorts(
+        _PERCENTILES,
+        proteoform=proteoform,
+        scope=scope,
+        include_recomputable=include_recomputable,
+    )
 
 
 _ARTIFACT_TECHNICAL_EXTRA_STATUSES = frozenset(
@@ -5597,6 +5662,28 @@ def available_within_sample_cohorts(*, proteoform: bool = False, scope: str = "c
     With ``proteoform=True``, the proteoform-summed variant (identical-protein
     members collapsed before ranking, in ``scope`` — see :func:`within_sample_top_fraction`)."""
     return _available_cohorts(_WITHIN_SAMPLE, proteoform=proteoform, scope=scope)
+
+
+def locally_available_within_sample_cohorts(
+    *,
+    proteoform: bool = False,
+    scope: str = "cta",
+    include_recomputable: bool = True,
+) -> list[str]:
+    """Cohorts readable as within-sample prevalence without a download.
+
+    The result is the union of shards in the package/artifact checkout and the
+    active partial bundle cache.  With ``include_recomputable=True`` (default),
+    it also includes cohorts whose per-sample source matrix is cached locally,
+    because :func:`within_sample_top_fraction` can derive the same artifact from
+    that matrix.  This function never fetches either data source.
+    """
+    return _locally_available_summary_cohorts(
+        _WITHIN_SAMPLE,
+        proteoform=proteoform,
+        scope=scope,
+        include_recomputable=include_recomputable,
+    )
 
 
 def within_sample_top_fraction(

--- a/oncoref/plots.py
+++ b/oncoref/plots.py
@@ -32,12 +32,13 @@ from .cancer_types import (
     cancer_lineage_group,
     cancer_type_registry,
     format_cancer_code_label,
+    resolve_cancer_type,
 )
 from .cta import cta_gene_id_to_name, cta_gene_ids
 from .expression import (
     available_percentile_cohorts,
-    available_within_sample_cohorts,
     cohort_gene_percentiles,
+    locally_available_within_sample_cohorts,
     within_sample_top_fraction,
 )
 from .ici import cancer_ici_response
@@ -890,7 +891,7 @@ def _cta_prevalence_by_cohort(threshold):
 
     cta_ids = set(cta_gene_ids())
     out = {}
-    for code in available_within_sample_cohorts():
+    for code in locally_available_within_sample_cohorts(include_recomputable=False):
         df = within_sample_top_fraction(code, threshold=threshold)
         frac_col = next((c for c in df.columns if c.startswith("frac_samples_top")), None)
         if frac_col is None:
@@ -914,6 +915,41 @@ def _addressable_prevalence(source, *, threshold, threshold_tpm):
         prev = _cta_prevalence_by_cohort(threshold)
         return prev, f"top-CTA prevalence, thr={threshold}"
     raise ValueError("source must be 'within_sample' or 'per_sample'")
+
+
+def _cta_addressable_burden_from_prevalence(
+    prevalence,
+    *,
+    prevalence_label,
+    metric,
+    n,
+    save,
+):
+    """Render addressable burden from an already-audited cohort prevalence map."""
+    if not prevalence:
+        raise ValueError("no CTA prevalence available for the requested data source")
+    burden = cancer_burden(metric=metric)
+    burden_label = _burden_metric_label(metric)
+    xlabel = f"Addressable burden ({burden_label} × {prevalence_label})"
+
+    rows = []
+    for code, fraction in prevalence.items():
+        category = burden_category(code)
+        burden_share = burden.get(category) if category else None
+        if burden_share:
+            rows.append((code, float(burden_share) * float(fraction)))
+    if not rows:
+        raise ValueError("no cohort mapped to both a burden category and CTA prevalence")
+
+    rows.sort(key=lambda row: row[1], reverse=True)
+    rows = rows[:n]
+    return _ranked_family_barh(
+        rows,
+        xlabel=xlabel,
+        title=f"CTA-addressable {burden_label} — top {len(rows)} cancers",
+        legend=True,
+        save=save,
+    )
 
 
 def cta_addressable_burden(
@@ -945,32 +981,47 @@ def cta_addressable_burden(
     prevalence, prevalence_label = _addressable_prevalence(
         source, threshold=threshold, threshold_tpm=threshold_tpm
     )
-    if not prevalence:
-        raise ValueError(
-            f"no CTA prevalence available for source={source!r} — is the required data "
-            "present? (within-sample bundle, or cached per-sample matrices)"
-        )
-    burden = cancer_burden(metric=metric)  # {burden category: share}
-    burden_label = _burden_metric_label(metric)
-    xlabel = f"Addressable burden ({burden_label} × {prevalence_label})"
+    return _cta_addressable_burden_from_prevalence(
+        prevalence,
+        prevalence_label=prevalence_label,
+        metric=metric,
+        n=n,
+        save=save,
+    )
 
-    rows = []
-    for code, prev in prevalence.items():
-        category = burden_category(code)
-        inc = burden.get(category) if category else None
-        if inc is None or not inc:
-            continue
-        rows.append((code, float(inc) * prev, prev))
-    if not rows:
-        raise ValueError("no cohort mapped to both a burden category and CTA prevalence")
 
-    rows.sort(key=lambda r: r[1], reverse=True)
-    rows = rows[:n]
-    return _ranked_family_barh(
-        [(r[0], r[1]) for r in rows],
-        xlabel=xlabel,
-        title=f"CTA-addressable {burden_label} — top {len(rows)} cancers",
-        legend=True,
+def cta_within_sample_percentile_addressable_burden(
+    *,
+    percentile=0.95,
+    cohorts=None,
+    coverage_table=None,
+    metric="us_incidence_pct",
+    n=25,
+    save=None,
+):
+    """CTA-addressable burden using the true patient union at p90/p95.
+
+    A CTA is positive when its biological clean-TPM rank within that individual
+    tumor is at least ``percentile``.  Unlike ``source='within_sample'`` in
+    :func:`cta_addressable_burden`, this calculation retains CTA co-occurrence and
+    counts each patient once when any CTA is positive.  It therefore needs cached
+    per-sample matrices.  ``coverage_table`` can reuse one
+    :func:`oncoref.coverage.within_sample_percentile_coverage_sweep` across a plot
+    batch.
+    """
+    from .coverage import within_sample_percentile_addressable_fraction_by_cohort
+
+    fractions = within_sample_percentile_addressable_fraction_by_cohort(
+        cohorts,
+        percentile=percentile,
+        coverage=coverage_table,
+        on_missing="record",
+    )
+    return _cta_addressable_burden_from_prevalence(
+        fractions.to_dict(),
+        prevalence_label=f"P(≥1 CTA at within-sample p{round(percentile * 100)})",
+        metric=metric,
+        n=n,
         save=save,
     )
 
@@ -998,18 +1049,29 @@ def cta_patient_count_heatmap(
     ranks in the top ``(1 - threshold)`` *within that patient* — ``threshold=0.95`` →
     the within-sample **p95** (top 5%) convention pirlygenes uses, far more stringent
     than a flat low-TPM cut. Pass ``threshold_tpm=<TPM>`` instead to use the absolute
-    "fraction of patients with clean TPM ≥ threshold" from the per-sample matrices.
+    "fraction of patients with clean TPM > threshold" from the per-sample matrices.
 
     Columns are ordered by **mean prevalence across the shown cohorts** (most broadly
-    expressed antigen first); rows by their single best CTA. ``cohorts`` defaults to
-    every cohort with a cached per-sample matrix."""
+    expressed antigen first); rows by their single best CTA. ``cohorts`` defaults
+    to locally readable within-sample data in rank mode and cached per-sample
+    matrices in absolute-TPM mode. Neither default triggers a download."""
     import pandas as pd
 
-    cohorts = list(cohorts) if cohorts is not None else _cached_per_sample_cohorts()
+    if cohorts is not None:
+        cohorts = list(cohorts)
+    elif threshold_tpm is not None:
+        cohorts = _cached_per_sample_cohorts()
+    else:
+        cohorts = locally_available_within_sample_cohorts(proteoform=True, scope="cta")
     if not cohorts:
+        if threshold_tpm is not None:
+            raise ValueError(
+                "no cached per-sample matrices for absolute-TPM prevalence — "
+                "stage source matrices first."
+            )
         raise ValueError(
-            "no cohorts with a cached per-sample matrix — fetch them via "
-            "source_matrices.fetch(code) (or stage them) first."
+            "no local proteoform within-sample shards or cached per-sample matrices — "
+            "fetch the bundle or stage source matrices first."
         )
     rows = {}
     key_to_symbol = {}
@@ -1060,49 +1122,31 @@ def cta_patient_count_heatmap(
     )
 
 
-def cta_coverage_curves(
-    cancer_types,
+def _render_cta_coverage_curves(
+    coverage_by_code,
     *,
-    threshold_tpm=50.0,
-    max_genes=20,
-    top_n=10,
-    save=None,
+    max_genes,
+    top_n,
+    threshold_label,
+    save,
 ):
-    """Greedy **antigen-coverage curves**, the **top ``top_n`` cohorts by final coverage
-    overlaid on one axes** — for each cohort, the cumulative fraction of patients covered
-    as CTAs are added to the panel in greedy set-cover order
-    (:func:`oncoref.coverage.greedy_coverage`, proteoform-aggregated). Answers "how many
-    antigens a panel needs to reach most patients", and lets cancers be compared directly.
-
-    Curves are colored by lineage group; the legend gives each cohort's final coverage.
-    ``cancer_types`` is a code or iterable of codes (each needs a cached per-sample
-    matrix); coverage is computed for all of them and the broadest ``top_n`` (default 10)
-    are drawn (pass ``top_n=None`` for all)."""
+    """Render comparable greedy curves from precomputed per-cohort tables."""
     import numpy as np
 
-    from .coverage import greedy_coverage
-
-    codes = [cancer_types] if isinstance(cancer_types, str) else list(cancer_types)
     plt = _plt()
-
-    curves = []  # (code, x, y)
-    for code in codes:
-        gc = greedy_coverage(code, threshold_tpm=threshold_tpm, max_genes=max_genes)
-        if gc.empty:
+    curves = []
+    for code, coverage in coverage_by_code.items():
+        if coverage.empty:
             continue
-        x = np.concatenate([[0], gc["rank"].to_numpy()])
-        y = np.concatenate([[0.0], gc["cumulative_fraction"].to_numpy()])
+        x = np.concatenate([[0], coverage["rank"].to_numpy()])
+        y = np.concatenate([[0.0], coverage["cumulative_fraction"].to_numpy()])
         curves.append((code, x, y))
     if not curves:
-        raise ValueError(
-            "no coverage curve could be drawn — are the cohorts' per-sample matrices "
-            "cached, and does any CTA clear the threshold?"
-        )
-    curves.sort(key=lambda t: t[2][-1], reverse=True)  # broadest coverage first
+        raise ValueError("no coverage curve could be drawn from the available cohort data")
+
+    curves.sort(key=lambda item: item[2][-1], reverse=True)
     total = len(curves)
     shown = curves[:top_n] if top_n else curves
-    # Distinct per-cohort colors — lineage colors would collide for the several
-    # same-lineage cohorts usually in the top-coverage set (e.g. multiple sarcomas).
     cmap = plt.get_cmap("tab10" if len(shown) <= 10 else "tab20")
     code_color = {code: cmap(i % cmap.N) for i, (code, _, _) in enumerate(shown)}
 
@@ -1117,7 +1161,7 @@ def cta_coverage_curves(
             label=f"{format_cancer_code_label(code)} ({y[-1]:.0%})",
         )
     ax.set_xlabel("number of CTAs in panel (greedy set cover)")
-    ax.set_ylabel(f"fraction of patients covered (≥1 CTA > {threshold_tpm:g} TPM)")
+    ax.set_ylabel(f"fraction of patients covered ({threshold_label})")
     ax.set_ylim(0, 1)
     ax.set_xlim(0, max_genes)
     ax.grid(True, alpha=0.3)
@@ -1128,6 +1172,141 @@ def cta_coverage_curves(
     return _save(fig, save)
 
 
+def _render_cta_coverage_stacked_bars(
+    coverage_by_code,
+    *,
+    total_cohorts,
+    top_n,
+    threshold_label,
+    save,
+):
+    """Render marginal antigen contributions from precomputed greedy tables."""
+    if not coverage_by_code:
+        raise ValueError("no coverage to plot from the available cohort data")
+    ordered = sorted(
+        coverage_by_code.items(),
+        key=lambda item: float(item[1]["cumulative_fraction"].iloc[-1]),
+        reverse=True,
+    )
+    if top_n:
+        ordered = ordered[:top_n]
+    all_symbols = {str(symbol) for _, table in ordered for symbol in table["Symbol"]}
+    symbol_colors, family_colors = _antigen_family_colors(all_symbols)
+
+    rows = []
+    for code, table in ordered:
+        covered = float(table["cumulative_fraction"].iloc[-1])
+        segments = [
+            (
+                str(row.Symbol),
+                float(row.marginal_fraction),
+                symbol_colors[str(row.Symbol)],
+            )
+            for row in table.itertuples()
+        ]
+        rows.append((f"{format_cancer_code_label(code)}  ({covered:.0%})", segments))
+    suffix = (
+        f"top {len(rows)} of {total_cohorts} cohorts by coverage"
+        if top_n and total_cohorts > len(rows)
+        else f"{len(rows)} cohorts"
+    )
+    return _stacked_barh(
+        rows,
+        xlabel=f"fraction of patients covered ({threshold_label})",
+        title=f"CTA greedy coverage by antigen — {suffix}",
+        legend=family_colors,
+        save=save,
+    )
+
+
+def _percentile_coverage_by_code(
+    cancer_types,
+    *,
+    percentile,
+    max_genes,
+    coverage_table,
+):
+    """Select one p90/p95 greedy table per requested cohort."""
+    import pandas as pd
+
+    from .coverage import _coverage_at_percentile, within_sample_percentile_coverage_sweep
+
+    requested = [cancer_types] if isinstance(cancer_types, str) else list(cancer_types)
+    codes = [resolve_cancer_type(code, strict=False) or str(code) for code in requested]
+    if coverage_table is None:
+        coverage_table = within_sample_percentile_coverage_sweep(
+            codes,
+            percentiles=(percentile,),
+            on_missing="record",
+        )
+    selected = _coverage_at_percentile(coverage_table, percentile)
+    selected = selected[selected["cancer_code"].astype(str).isin(set(codes))]
+    selected = selected[pd.to_numeric(selected["rank"], errors="coerce") > 0]
+
+    by_code = {}
+    for code, table in selected.groupby("cancer_code", sort=False):
+        ordered = table.sort_values("rank", kind="stable")
+        by_code[str(code)] = ordered.head(max_genes).reset_index(drop=True)
+    return codes, by_code
+
+
+def _absolute_coverage_by_code(codes, *, threshold_tpm, max_genes):
+    """Compute one absolute-TPM greedy table per cohort, omitting empty results."""
+    from .coverage import greedy_coverage
+
+    by_code = {}
+    for code in codes:
+        table = greedy_coverage(code, threshold_tpm=threshold_tpm, max_genes=max_genes)
+        if not table.empty:
+            by_code[code] = table
+    return by_code
+
+
+def cta_coverage_curves(
+    cancer_types,
+    *,
+    threshold_tpm=50.0,
+    max_genes=20,
+    top_n=10,
+    save=None,
+):
+    """Greedy CTA coverage curves at one absolute clean-TPM threshold."""
+    codes = [cancer_types] if isinstance(cancer_types, str) else list(cancer_types)
+    by_code = _absolute_coverage_by_code(codes, threshold_tpm=threshold_tpm, max_genes=max_genes)
+    return _render_cta_coverage_curves(
+        by_code,
+        max_genes=max_genes,
+        top_n=top_n,
+        threshold_label=f"≥1 CTA > {threshold_tpm:g} TPM",
+        save=save,
+    )
+
+
+def cta_within_sample_percentile_coverage_curves(
+    cancer_types,
+    *,
+    percentile=0.95,
+    coverage_table=None,
+    max_genes=20,
+    top_n=10,
+    save=None,
+):
+    """Greedy CTA coverage curves at a tumor-specific p90/p95 rank cutoff."""
+    _, by_code = _percentile_coverage_by_code(
+        cancer_types,
+        percentile=percentile,
+        max_genes=max_genes,
+        coverage_table=coverage_table,
+    )
+    return _render_cta_coverage_curves(
+        by_code,
+        max_genes=max_genes,
+        top_n=top_n,
+        threshold_label=f"≥1 CTA at within-sample p{round(percentile * 100)}",
+        save=save,
+    )
+
+
 def cta_coverage_stacked_bars(
     cancer_types,
     *,
@@ -1136,60 +1315,39 @@ def cta_coverage_stacked_bars(
     top_n=40,
     save=None,
 ):
-    """Greedy **coverage plateau** as a stacked bar per cohort — one horizontal bar
-    per cancer type, split into the marginal new-patient fraction each CTA adds in
-    greedy set-cover order (:func:`oncoref.coverage.greedy_coverage`). The bar's
-    total length is the cohort's addressable share (≥1 CTA panel); each segment shows
-    how much a single antigen contributes, coloured by antigen family.
-
-    Complements :func:`cta_coverage_curves` (cumulative step curve) by showing *which*
-    antigens carry the coverage. ``cancer_types`` is a code or iterable; each needs a
-    cached per-sample matrix. ``max_genes`` caps the segments per cohort; coverage is
-    computed for all cohorts and the broadest ``top_n`` (default 40) are shown, **sorted
-    by fraction of patients covered (highest at top)** (pass ``top_n=None`` for all)."""
-    from .coverage import greedy_coverage
-
+    """Marginal CTA coverage per cohort at one absolute clean-TPM threshold."""
     codes = [cancer_types] if isinstance(cancer_types, str) else list(cancer_types)
-    total = len(codes)
-    coverage_by_code = {}
-    for code in codes:
-        gc = greedy_coverage(code, threshold_tpm=threshold_tpm, max_genes=max_genes)
-        if not gc.empty:
-            coverage_by_code[code] = gc
-    if not coverage_by_code:
-        raise ValueError(
-            "no coverage to plot — are the cohorts' per-sample matrices cached, and "
-            "does any CTA clear the threshold?"
-        )
-    # Rank cohorts by fraction of patients covered (highest first), then cap.
-    ordered = sorted(
-        coverage_by_code.items(),
-        key=lambda kv: float(kv[1]["cumulative_fraction"].iloc[-1]),
-        reverse=True,
+    by_code = _absolute_coverage_by_code(codes, threshold_tpm=threshold_tpm, max_genes=max_genes)
+    return _render_cta_coverage_stacked_bars(
+        by_code,
+        total_cohorts=len(codes),
+        top_n=top_n,
+        threshold_label=f"≥1 CTA > {threshold_tpm:g} TPM",
+        save=save,
     )
-    if top_n:
-        ordered = ordered[:top_n]
-    all_syms = {str(s) for _, gc in ordered for s in gc["Symbol"]}
-    sym_color, fam_color = _antigen_family_colors(all_syms)
 
-    rows = []
-    for code, gc in ordered:
-        covered = float(gc["cumulative_fraction"].iloc[-1])
-        segs = [
-            (str(r.Symbol), float(r.marginal_fraction), sym_color[str(r.Symbol)])
-            for r in gc.itertuples()
-        ]
-        rows.append((f"{format_cancer_code_label(code)}  ({covered:.0%})", segs))
-    suffix = (
-        f"top {len(rows)} of {total} cohorts by coverage"
-        if top_n and total > len(rows)
-        else f"{len(rows)} cohorts"
+
+def cta_within_sample_percentile_coverage_stacked_bars(
+    cancer_types,
+    *,
+    percentile=0.95,
+    coverage_table=None,
+    max_genes=12,
+    top_n=40,
+    save=None,
+):
+    """Marginal CTA coverage per cohort at a tumor-specific p90/p95 cutoff."""
+    codes, by_code = _percentile_coverage_by_code(
+        cancer_types,
+        percentile=percentile,
+        max_genes=max_genes,
+        coverage_table=coverage_table,
     )
-    return _stacked_barh(
-        rows,
-        xlabel=f"fraction of patients covered (≥1 CTA > {threshold_tpm:g} TPM)",
-        title=f"CTA greedy coverage by antigen — {suffix}",
-        legend=fam_color,
+    return _render_cta_coverage_stacked_bars(
+        by_code,
+        total_cohorts=len(codes),
+        top_n=top_n,
+        threshold_label=f"≥1 CTA at within-sample p{round(percentile * 100)}",
         save=save,
     )
 

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.165"
+__version__ = "1.8.166"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/scripts/regenerate_plots.py
+++ b/scripts/regenerate_plots.py
@@ -20,10 +20,10 @@ one. A ``latest`` symlink points at the most recent run; an ``index.md`` lists
 what was produced (and what was skipped).
 
 Each figure is independent: one that can't be drawn (missing per-sample matrix,
-empty data) is reported and skipped, never aborting the batch. Expression-backed
-figures need the relevant shards/matrices cached locally; the coverage/response
-panels in particular need per-sample matrices (see
-``plots._cached_per_sample_cohorts``), so they cover only the cached cohorts.
+empty data) is reported and skipped, never aborting the batch. The runner takes
+one side-effect-free inventory of package data and local caches before planning
+the batch. Joint p90/p95 patient coverage is computed once from the cached source
+matrices and shared by every dependent plot.
 
 Usage::
 
@@ -48,6 +48,8 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
 
 from oncoref import cta_curation_plots, plots  # noqa: E402
+from oncoref.coverage import within_sample_percentile_coverage_sweep  # noqa: E402
+from oncoref.expression import locally_available_percentile_cohorts  # noqa: E402
 from oncoref.plots import _cached_per_sample_cohorts  # noqa: E402
 
 CTA_TPM_THRESHOLDS = (25.0, 50.0)
@@ -55,12 +57,48 @@ WITHIN_SAMPLE_THRESHOLDS = (0.90, 0.95)
 BURDEN_AXES = ("us_incidence", "us_mortality", "world_incidence", "world_mortality")
 REFERENCE_AXES = ("tmb", "apd1", "ici", *BURDEN_AXES)
 
+_PERCENTILE_COVERAGE_PLOTS = frozenset(
+    {
+        "cta_within_sample_percentile_addressable_burden",
+        "cta_within_sample_percentile_coverage_curves",
+        "cta_within_sample_percentile_coverage_stacked_bars",
+    }
+)
 
-def _jobs() -> list[tuple[str, str, str, dict]]:
+
+def _plot_data_availability() -> dict[str, tuple[str, ...]]:
+    """Side-effect-free local inputs available to the plot batch."""
+    per_sample = tuple(sorted(_cached_per_sample_cohorts()))
+    within_sample = tuple(
+        plots.locally_available_within_sample_cohorts(
+            proteoform=True,
+            scope="cta",
+            include_recomputable=True,
+        )
+    )
+    percentile_gene = tuple(locally_available_percentile_cohorts(proteoform=False, scope="cta"))
+    percentile_proteoform = tuple(
+        locally_available_percentile_cohorts(proteoform=True, scope="cta")
+    )
+    return {
+        "per_sample": per_sample,
+        "percentile_gene": percentile_gene,
+        "percentile_proteoform": percentile_proteoform,
+        "within_sample": within_sample,
+    }
+
+
+def _jobs(
+    availability: dict[str, tuple[str, ...]] | None = None,
+) -> list[tuple[str, str, str, dict]]:
     """``(family, name, fn_attr, kwargs)`` for every figure, with sensible
     defaults. Coverage/response panels are restricted to the cohorts that
     actually have a cached per-sample matrix."""
-    cached = sorted(_cached_per_sample_cohorts())
+    availability = availability or _plot_data_availability()
+    cached = list(availability["per_sample"])
+    percentile_gene = list(availability["percentile_gene"])
+    percentile_proteoform = list(availability["percentile_proteoform"])
+    within_sample = list(availability["within_sample"])
     jobs: list[tuple[str, str, str, dict]] = [
         # aPD-1 / ICI response. Match pirlygenes' two response scopes:
         # broad ICI anchors (PD-1 + proxies/fallbacks) and strict PD-1 monotherapy.
@@ -131,73 +169,69 @@ def _jobs() -> list[tuple[str, str, str, dict]]:
             "burden_category_bars",
             {"region": "world"},
         ),
-        # CTA expression
-        (
-            "cta_expression",
-            "cta_expression_heatmap_q1",
-            "cta_expression_heatmap",
-            {"stat": "q1"},
-        ),
-        (
-            "cta_expression",
-            "cta_expression_heatmap_median",
-            "cta_expression_heatmap",
-            {"stat": "median"},
-        ),
-        (
-            "cta_expression",
-            "cta_expression_heatmap_median_gene",
-            "cta_expression_heatmap",
-            {"stat": "median", "proteoform": False},
-        ),
-        (
-            "cta_expression",
-            "cta_expression_heatmap_q3",
-            "cta_expression_heatmap",
-            {"stat": "q3"},
-        ),
         # CTA addressable burden + per-patient prevalence. Uses the faithful
-        # per-sample source (cached cohorts); the portable within_sample source
-        # needs the within-sample bundle, which isn't always cached locally.
+        # patient union from cached per-sample matrices.
     ]
-    for axis in BURDEN_AXES:
-        metric = f"{axis}_pct"
+    if percentile_proteoform:
         jobs.extend(
             (
-                "cta_addressable",
-                f"cta_addressable_burden_within_sample_p{int(threshold * 100)}_{axis}",
-                "cta_addressable_burden",
-                {"source": "within_sample", "threshold": threshold, "metric": metric},
+                "cta_expression",
+                f"cta_expression_heatmap_{stat}",
+                "cta_expression_heatmap",
+                {"stat": stat, "cohorts": percentile_proteoform},
+            )
+            for stat in ("q1", "median", "q3")
+        )
+    if percentile_gene:
+        jobs.append(
+            (
+                "cta_expression",
+                "cta_expression_heatmap_median_gene",
+                "cta_expression_heatmap",
+                {"stat": "median", "proteoform": False, "cohorts": percentile_gene},
+            )
+        )
+    if cached:
+        for axis in BURDEN_AXES:
+            metric = f"{axis}_pct"
+            jobs.extend(
+                (
+                    "cta_addressable",
+                    f"cta_addressable_burden_per_sample_p{int(percentile * 100)}_{axis}",
+                    "cta_within_sample_percentile_addressable_burden",
+                    {"cohorts": cached, "percentile": percentile, "metric": metric},
+                )
+                for percentile in WITHIN_SAMPLE_THRESHOLDS
+            )
+            jobs.extend(
+                (
+                    "cta_addressable",
+                    f"cta_addressable_burden_per_sample_t{threshold:g}_{axis}",
+                    "cta_addressable_burden",
+                    {"source": "per_sample", "threshold_tpm": threshold, "metric": metric},
+                )
+                for threshold in CTA_TPM_THRESHOLDS
+            )
+    if within_sample:
+        jobs.extend(
+            (
+                "cta_patient",
+                f"cta_patient_count_heatmap_p{int(threshold * 100)}",
+                "cta_patient_count_heatmap",
+                {"threshold": threshold, "cohorts": within_sample},
             )
             for threshold in WITHIN_SAMPLE_THRESHOLDS
         )
+    if cached:
         jobs.extend(
             (
-                "cta_addressable",
-                f"cta_addressable_burden_per_sample_t{threshold:g}_{axis}",
-                "cta_addressable_burden",
-                {"source": "per_sample", "threshold_tpm": threshold, "metric": metric},
+                "cta_patient",
+                f"cta_patient_count_heatmap_t{threshold:g}",
+                "cta_patient_count_heatmap",
+                {"threshold_tpm": threshold, "cohorts": cached},
             )
             for threshold in CTA_TPM_THRESHOLDS
         )
-    jobs.extend(
-        (
-            "cta_patient",
-            f"cta_patient_count_heatmap_p{int(threshold * 100)}",
-            "cta_patient_count_heatmap",
-            {"threshold": threshold},
-        )
-        for threshold in WITHIN_SAMPLE_THRESHOLDS
-    )
-    jobs.extend(
-        (
-            "cta_patient",
-            f"cta_patient_count_heatmap_t{threshold:g}",
-            "cta_patient_count_heatmap",
-            {"threshold_tpm": threshold},
-        )
-        for threshold in CTA_TPM_THRESHOLDS
-    )
     for threshold in CTA_TPM_THRESHOLDS:
         for axis in REFERENCE_AXES:
             jobs.append(
@@ -234,7 +268,75 @@ def _jobs() -> list[tuple[str, str, str, dict]]:
                     {"cancer_types": cached, "threshold_tpm": threshold},
                 ),
             ]
+        for percentile in WITHIN_SAMPLE_THRESHOLDS:
+            jobs += [
+                (
+                    "cta_coverage",
+                    f"cta_coverage_curves_p{int(percentile * 100)}",
+                    "cta_within_sample_percentile_coverage_curves",
+                    {"cancer_types": cached, "percentile": percentile},
+                ),
+                (
+                    "cta_coverage",
+                    f"cta_coverage_stacked_bars_p{int(percentile * 100)}",
+                    "cta_within_sample_percentile_coverage_stacked_bars",
+                    {"cancer_types": cached, "percentile": percentile},
+                ),
+            ]
     return jobs
+
+
+def _attach_shared_percentile_coverage(jobs, availability):
+    """Compute p90/p95 coverage once and attach it to every dependent plot."""
+    if not any(function in _PERCENTILE_COVERAGE_PLOTS for _, _, function, _ in jobs):
+        return jobs, None
+    coverage = within_sample_percentile_coverage_sweep(
+        availability["per_sample"],
+        percentiles=WITHIN_SAMPLE_THRESHOLDS,
+        on_missing="record",
+    )
+    prepared = []
+    for family, name, function, kwargs in jobs:
+        plot_kwargs = dict(kwargs)
+        if function in _PERCENTILE_COVERAGE_PLOTS:
+            plot_kwargs["coverage_table"] = coverage
+        prepared.append((family, name, function, plot_kwargs))
+    return prepared, coverage
+
+
+def _availability_index_lines(availability, percentile_coverage):
+    """Human-readable audit of the local data used for one plot run."""
+    per_sample = availability["per_sample"]
+    percentile_gene = availability["percentile_gene"]
+    percentile_proteoform = availability["percentile_proteoform"]
+    within_sample = availability["within_sample"]
+    lines = [
+        "## Local data",
+        "",
+        f"- Cached per-sample matrices: {len(per_sample)}",
+        f"- Local or locally recomputable gene percentile cohorts: {len(percentile_gene)}",
+        "- Local or locally recomputable proteoform percentile cohorts: "
+        f"{len(percentile_proteoform)}",
+        f"- Local or locally recomputable within-sample cohorts: {len(within_sample)}",
+    ]
+    if percentile_coverage is not None:
+        audited = percentile_coverage.attrs.get("audited_cohorts", ())
+        missing = percentile_coverage.attrs.get("missing_cohorts", {})
+        lines.extend(
+            [
+                f"- p90/p95 joint coverage cohorts audited: {len(audited)}",
+                f"- p90/p95 joint coverage cohorts missing: {len(missing)}",
+            ]
+        )
+        if missing:
+            lines.extend(
+                [
+                    "",
+                    "Missing p90/p95 inputs:",
+                    *(f"- `{code}`: {reason}" for code, reason in sorted(missing.items())),
+                ]
+            )
+    return lines
 
 
 def _resolve_run_dir(args: argparse.Namespace) -> Path:
@@ -294,7 +396,9 @@ def main() -> int:
     args = ap.parse_args()
 
     run_dir = _resolve_run_dir(args)
-    jobs = _jobs()
+    availability = _plot_data_availability()
+    jobs = _jobs(availability)
+    jobs, percentile_coverage = _attach_shared_percentile_coverage(jobs, availability)
     print(f"Regenerating {len(jobs)} figures into {run_dir}")
 
     done: list[str] = []
@@ -338,6 +442,8 @@ def main() -> int:
         f"{len(done)} generated, {len(skipped)} skipped.",
         "",
         f"Combined PDF: `{pdf.name}`" if pdf is not None else "Combined PDF: not generated.",
+        "",
+        *_availability_index_lines(availability, percentile_coverage),
         "",
         "## Generated",
         *(f"- `{p}`" for p in done),

--- a/scripts/regenerate_plots.py
+++ b/scripts/regenerate_plots.py
@@ -310,21 +310,28 @@ def _availability_index_lines(availability, percentile_coverage):
     percentile_gene = availability["percentile_gene"]
     percentile_proteoform = availability["percentile_proteoform"]
     within_sample = availability["within_sample"]
+
+    def inventory(label, codes):
+        values = ", ".join(f"`{code}`" for code in codes) or "none"
+        return f"- {label} ({len(codes)}): {values}"
+
     lines = [
         "## Local data",
         "",
-        f"- Cached per-sample matrices: {len(per_sample)}",
-        f"- Local or locally recomputable gene percentile cohorts: {len(percentile_gene)}",
-        "- Local or locally recomputable proteoform percentile cohorts: "
-        f"{len(percentile_proteoform)}",
-        f"- Local or locally recomputable within-sample cohorts: {len(within_sample)}",
+        inventory("Cached per-sample matrices", per_sample),
+        inventory("Local or locally recomputable gene percentile cohorts", percentile_gene),
+        inventory(
+            "Local or locally recomputable proteoform percentile cohorts",
+            percentile_proteoform,
+        ),
+        inventory("Local or locally recomputable within-sample cohorts", within_sample),
     ]
     if percentile_coverage is not None:
         audited = percentile_coverage.attrs.get("audited_cohorts", ())
         missing = percentile_coverage.attrs.get("missing_cohorts", {})
         lines.extend(
             [
-                f"- p90/p95 joint coverage cohorts audited: {len(audited)}",
+                inventory("p90/p95 joint coverage cohorts audited", audited),
                 f"- p90/p95 joint coverage cohorts missing: {len(missing)}",
             ]
         )

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -61,6 +61,9 @@ def test_greedy_coverage_is_set_cover(patched):
     # cumulative is monotonic non-decreasing
     assert (gc["cumulative_fraction"].diff().dropna() > 0).all()
 
+    gene_level = coverage.greedy_coverage("X", threshold_tpm=5, gene_ids=patched, proteoform=False)
+    assert "proteoform_key" not in gene_level.columns
+
 
 def test_mean_antigens_per_patient(patched):
     # hits: gA in p0,p1 (2) + gB in p2 (1) + gC in p1 (1) = 4 over 4 patients -> 1.0.
@@ -145,6 +148,104 @@ def test_proteoform_paralogs_are_summed(monkeypatch):
     # per-gene view: neither A1 nor A2 clears 10 alone -> 0 in p0
     pf_split = coverage.cta_patient_fractions("X", threshold_tpm=10, proteoform=False)
     assert pf_split[pf_split["Symbol"] == "A1"]["fraction_expressing"].iloc[0] == 0.0
+
+
+def test_within_sample_percentile_coverage_preserves_patient_cooccurrence(monkeypatch):
+    # Ten biological rows make p90 and p95 easy to inspect: each CTA is the top
+    # transcript in a different patient, so the true CTA union covers both patients.
+    biological = pd.DataFrame(
+        {
+            "proteoform_key": ["CTA_A", "CTA_B", *[f"BG{i}" for i in range(8)]],
+            "Ensembl_Gene_ID": ["CTA_A", "CTA_B", *[f"BG{i}" for i in range(8)]],
+            "Symbol": ["CTA-A", "CTA-B", *[f"BG{i}" for i in range(8)]],
+            "proteoform_members": ["CTA-A", "CTA-B", *[f"BG{i}" for i in range(8)]],
+            "patient_1": [100.0, 0.0, *range(1, 9)],
+            "patient_2": [0.0, 100.0, *range(1, 9)],
+        }
+    )
+    calls = []
+
+    def fake_biological(code, **kwargs):
+        calls.append((code, kwargs))
+        return biological.copy()
+
+    import oncoref.expression as expression
+
+    monkeypatch.setattr(expression, "_biological_per_sample", fake_biological)
+    monkeypatch.setattr(coverage, "_panel_ids", lambda gene_ids: {"CTA_A", "CTA_B"})
+    import oncoref.proteoforms as proteoforms
+
+    monkeypatch.setattr(
+        proteoforms,
+        "gene_to_proteoform_id",
+        lambda ids, scope="cta": {gene_id: gene_id for gene_id in ids},
+    )
+
+    sweep = coverage.within_sample_percentile_coverage_sweep(
+        ["NOT_A_REAL_CODE"], percentiles=(0.90, 0.95)
+    )
+
+    assert len(calls) == 1
+    assert calls[0][1] == {
+        "proteoform": True,
+        "auto_fetch": False,
+        "scope": "cta",
+        "sample_qc": "pass",
+    }
+    for percentile in (0.90, 0.95):
+        selected = sweep[sweep["within_sample_percentile"] == percentile]
+        assert selected["Symbol"].tolist() == ["CTA-A", "CTA-B"]
+        assert selected["cumulative_fraction"].iloc[-1] == 1.0
+
+    fractions = coverage.within_sample_percentile_addressable_fraction_by_cohort(
+        "NOT_A_REAL_CODE", percentile=0.95, coverage=sweep
+    )
+    assert fractions.to_dict() == {"NOT_A_REAL_CODE": 1.0}
+
+
+def test_within_sample_percentile_coverage_records_missing_and_zero(monkeypatch):
+    panel = pd.DataFrame(
+        {
+            "Ensembl_Gene_ID": ["CTA_A"],
+            "Symbol": ["CTA-A"],
+        }
+    )
+
+    def fake_ranks(code, **kwargs):
+        if code == "MISSING":
+            raise FileNotFoundError("not staged")
+        return panel, ["patient_1", "patient_2"], np.array([[0.1, 0.2]])
+
+    monkeypatch.setattr(coverage, "_within_sample_percentile_panel_ranks", fake_ranks)
+    result = coverage.within_sample_percentile_coverage_sweep(
+        ["ZERO", "MISSING"], percentiles=(0.95,), proteoform=False, on_missing="record"
+    )
+
+    assert result[["cancer_code", "rank", "cumulative_fraction"]].to_dict("records") == [
+        {"cancer_code": "ZERO", "rank": 0, "cumulative_fraction": 0.0}
+    ]
+    assert result.attrs["audited_cohorts"] == ["ZERO"]
+    assert result.attrs["missing_cohorts"] == {"MISSING": "not staged"}
+
+
+def test_within_sample_percentile_coverage_validates_inputs():
+    with pytest.raises(ValueError, match="percentiles"):
+        coverage.within_sample_percentile_coverage_sweep([], percentiles=(0.5,))
+    with pytest.raises(ValueError, match="on_missing"):
+        coverage.within_sample_percentile_coverage_sweep([], on_missing="skip")
+    with pytest.raises(ValueError, match="missing required columns"):
+        coverage.within_sample_percentile_addressable_fraction_by_cohort(
+            percentile=0.95, coverage=pd.DataFrame({"cancer_code": ["LUAD"]})
+        )
+    with pytest.raises(ValueError, match="does not contain percentile"):
+        coverage.within_sample_percentile_addressable_fraction_by_cohort(
+            percentile=0.90, coverage=_percentile_coverage_fixture(0.95)
+        )
+
+
+def _percentile_coverage_fixture(percentile):
+    row = coverage._zero_coverage_row("LUAD", percentile, 1)
+    return pd.DataFrame([row], columns=coverage._PERCENTILE_COVERAGE_COLUMNS)
 
 
 # ---- required real-data parity ----

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -47,6 +47,29 @@ def test_item_availability_checks_package_then_partial_cache(monkeypatch, tmp_pa
     assert data_bundle.find_local_item(item) == cached
 
 
+def test_local_item_paths_returns_package_and_partial_cache(monkeypatch, tmp_path):
+    package_root = tmp_path / "package"
+    cache_root = tmp_path / "cache"
+    item = "cancer-reference-expression-percentiles"
+    monkeypatch.setattr(data_bundle, "_PACKAGE_DATA_DIR", package_root)
+    monkeypatch.setenv("CANCERDATA_BUNDLED_DATA", str(cache_root))
+
+    packaged = package_root / item
+    cached = cache_root / item
+    packaged.mkdir(parents=True)
+    cached.mkdir(parents=True)
+    (packaged / "LUAD.parquet").write_text("packaged")
+    (cached / "SKCM.parquet").write_text("cached")
+
+    assert data_bundle.local_item_paths(item) == (packaged, cached)
+
+
+@pytest.mark.parametrize("path", ["/absolute", "../escape", "nested/../../escape"])
+def test_local_item_paths_rejects_paths_outside_data_roots(path):
+    with pytest.raises(ValueError, match="relative_path"):
+        data_bundle.local_item_paths(path)
+
+
 def test_item_availability_rejects_missing_and_empty_items(monkeypatch, tmp_path):
     package_root = tmp_path / "package"
     cache_root = tmp_path / "cache"

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -879,6 +879,29 @@ def test_regenerate_plots_runner_computes_percentile_coverage_once(monkeypatch):
     assert all(kwargs["coverage_table"] is sentinel for kwargs in dependent)
 
 
+def test_regenerate_plots_runner_records_exact_data_inventory():
+    import importlib.util
+
+    runner = Path(__file__).resolve().parent.parent / "scripts" / "regenerate_plots.py"
+    spec = importlib.util.spec_from_file_location("_regen_plots_inventory", runner)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    availability = {
+        "per_sample": ("LUAD", "SKCM"),
+        "percentile_gene": ("LUAD",),
+        "percentile_proteoform": ("SKCM",),
+        "within_sample": ("LUAD", "SKCM"),
+    }
+    coverage = pd.DataFrame()
+    coverage.attrs.update({"audited_cohorts": ["LUAD"], "missing_cohorts": {"SKCM": "not staged"}})
+
+    text = "\n".join(mod._availability_index_lines(availability, coverage))
+
+    assert "Cached per-sample matrices (2): `LUAD`, `SKCM`" in text
+    assert "p90/p95 joint coverage cohorts audited (1): `LUAD`" in text
+    assert "- `SKCM`: not staged" in text
+
+
 def test_regenerate_plots_runner_writes_all_figures_pdf(tmp_path):
     import importlib.util
     from pathlib import Path

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -447,7 +447,11 @@ def test_cta_patient_count_heatmap_renders(tmp_path, monkeypatch):
 
     from oncoref import proteoforms
 
-    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: ["LUAD", "SKCM"])
+    monkeypatch.setattr(
+        plots,
+        "locally_available_within_sample_cohorts",
+        lambda **kwargs: ["LUAD", "SKCM"],
+    )
     monkeypatch.setattr(plots, "within_sample_top_fraction", fake_ws)
     monkeypatch.setattr(plots, "cta_gene_ids", lambda: ["E1", "E2", "E3"])
     monkeypatch.setattr(proteoforms, "gene_to_proteoform_id", lambda ids: {i: i for i in ids})
@@ -458,9 +462,20 @@ def test_cta_patient_count_heatmap_renders(tmp_path, monkeypatch):
 
 
 def test_cta_patient_count_heatmap_no_cohorts(monkeypatch):
-    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: [])
-    with pytest.raises(ValueError, match="no cohorts with a cached per-sample matrix"):
+    monkeypatch.setattr(plots, "locally_available_within_sample_cohorts", lambda **kwargs: [])
+    with pytest.raises(ValueError, match="no local proteoform within-sample"):
         plots.cta_patient_count_heatmap()
+
+
+def test_cta_patient_count_heatmap_absolute_mode_uses_only_cached_matrices(monkeypatch):
+    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: [])
+    monkeypatch.setattr(
+        plots,
+        "locally_available_within_sample_cohorts",
+        lambda **kwargs: pytest.fail("absolute mode must not plan from summary shards"),
+    )
+    with pytest.raises(ValueError, match="no cached per-sample matrices"):
+        plots.cta_patient_count_heatmap(threshold_tpm=50)
 
 
 def test_cta_patient_count_heatmap_duplicate_symbols(tmp_path, monkeypatch):
@@ -480,7 +495,11 @@ def test_cta_patient_count_heatmap_duplicate_symbols(tmp_path, monkeypatch):
 
     from oncoref import proteoforms
 
-    monkeypatch.setattr(plots, "_cached_per_sample_cohorts", lambda: ["LUAD", "SKCM"])
+    monkeypatch.setattr(
+        plots,
+        "locally_available_within_sample_cohorts",
+        lambda **kwargs: ["LUAD", "SKCM"],
+    )
     monkeypatch.setattr(plots, "within_sample_top_fraction", fake_ws)
     monkeypatch.setattr(plots, "cta_gene_ids", lambda: ["K1", "K2", "K3"])
     monkeypatch.setattr(proteoforms, "gene_to_proteoform_id", lambda ids: {i: i for i in ids})
@@ -522,6 +541,84 @@ def test_cta_coverage_curves_empty_raises(monkeypatch):
     monkeypatch.setattr(coverage, "greedy_coverage", lambda *a, **k: pd.DataFrame())
     with pytest.raises(ValueError, match="no coverage curve"):
         plots.cta_coverage_curves(["LUAD"])
+
+
+def _percentile_coverage_table():
+    rows = []
+    for code, final in (("LUAD", 0.8), ("SKCM", 1.0)):
+        rows.extend(
+            [
+                {
+                    "cancer_code": code,
+                    "within_sample_percentile": 0.95,
+                    "n_patients": 10,
+                    "rank": 1,
+                    "Ensembl_Gene_ID": "E1",
+                    "Symbol": "MAGEA4",
+                    "marginal_patients": 6,
+                    "marginal_fraction": 0.6,
+                    "cumulative_patients": 6,
+                    "cumulative_fraction": 0.6,
+                    "proteoform_key": "E1",
+                    "proteoform_members": "MAGEA4",
+                },
+                {
+                    "cancer_code": code,
+                    "within_sample_percentile": 0.95,
+                    "n_patients": 10,
+                    "rank": 2,
+                    "Ensembl_Gene_ID": "E2",
+                    "Symbol": "CTAG1B",
+                    "marginal_patients": round((final - 0.6) * 10),
+                    "marginal_fraction": final - 0.6,
+                    "cumulative_patients": round(final * 10),
+                    "cumulative_fraction": final,
+                    "proteoform_key": "E2",
+                    "proteoform_members": "CTAG1B",
+                },
+            ]
+        )
+    return pd.DataFrame(rows)
+
+
+def test_cta_within_sample_percentile_coverage_plots_render(tmp_path):
+    coverage_table = _percentile_coverage_table()
+    curves = tmp_path / "percentile-curves.png"
+    stacked = tmp_path / "percentile-stacked.png"
+
+    curve_figure = plots.cta_within_sample_percentile_coverage_curves(
+        ["lung adenocarcinoma", "SKCM"], coverage_table=coverage_table, save=str(curves)
+    )
+    stacked_figure = plots.cta_within_sample_percentile_coverage_stacked_bars(
+        ["LUAD", "SKCM"], coverage_table=coverage_table, save=str(stacked)
+    )
+
+    assert curves.stat().st_size > 0 and stacked.stat().st_size > 0
+    assert "within-sample p95" in curve_figure.axes[0].get_ylabel()
+    assert "within-sample p95" in stacked_figure.axes[0].get_xlabel()
+
+
+def test_cta_within_sample_percentile_addressable_burden_uses_joint_union(tmp_path, monkeypatch):
+    from oncoref import coverage
+
+    supplied = _percentile_coverage_table()
+    captured = {}
+
+    def fake_fraction(cohorts, **kwargs):
+        captured.update(kwargs)
+        return pd.Series({"LUAD": 0.8, "SKCM": 1.0})
+
+    monkeypatch.setattr(
+        coverage, "within_sample_percentile_addressable_fraction_by_cohort", fake_fraction
+    )
+    out = tmp_path / "percentile-burden.png"
+    figure = plots.cta_within_sample_percentile_addressable_burden(
+        cohorts=["LUAD", "SKCM"], coverage_table=supplied, save=str(out)
+    )
+
+    assert captured["coverage"] is supplied
+    assert captured["percentile"] == 0.95
+    assert out.stat().st_size > 0 and figure is not None
 
 
 def test_antigen_family_grouping():
@@ -713,7 +810,13 @@ def test_regenerate_plots_runner_references_real_functions():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
 
-    jobs = mod._jobs()
+    availability = {
+        "per_sample": ("LUAD", "SKCM"),
+        "percentile_gene": ("LUAD", "SKCM"),
+        "percentile_proteoform": ("LUAD", "SKCM"),
+        "within_sample": ("LUAD", "SKCM"),
+    }
+    jobs = mod._jobs(availability)
     assert jobs, "runner produced no jobs"
     names = {name for _, name, _, _ in jobs}
     assert {"apd1_vs_tmb_ici", "apd1_vs_tmb_strict_pd1"} <= names
@@ -728,13 +831,52 @@ def test_regenerate_plots_runner_references_real_functions():
         "cta_specific_9mer_load_vs_world_mortality_t50",
     } <= names
     assert {
-        "cta_addressable_burden_within_sample_p90_world_mortality",
+        "cta_addressable_burden_per_sample_p90_world_mortality",
         "cta_addressable_burden_per_sample_t50_us_mortality",
+    } <= names
+    assert {
+        "cta_coverage_curves_p90",
+        "cta_coverage_curves_p95",
+        "cta_coverage_stacked_bars_p90",
+        "cta_coverage_stacked_bars_p95",
     } <= names
     assert {"cta_patient_count_heatmap_p90", "cta_patient_count_heatmap_t50"} <= names
     for family, name, fn_attr, kwargs in jobs:
         assert family and name and isinstance(kwargs, dict)
         assert callable(getattr(plots, fn_attr, None)), f"{fn_attr} is not a plots function"
+
+
+def test_regenerate_plots_runner_computes_percentile_coverage_once(monkeypatch):
+    import importlib.util
+
+    runner = Path(__file__).resolve().parent.parent / "scripts" / "regenerate_plots.py"
+    spec = importlib.util.spec_from_file_location("_regen_plots_shared", runner)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    availability = {
+        "per_sample": ("LUAD", "SKCM"),
+        "percentile_gene": (),
+        "percentile_proteoform": (),
+        "within_sample": (),
+    }
+    jobs = mod._jobs(availability)
+    sentinel = _percentile_coverage_table()
+    calls = []
+
+    def fake_sweep(cohorts, **kwargs):
+        calls.append((cohorts, kwargs))
+        return sentinel
+
+    monkeypatch.setattr(mod, "within_sample_percentile_coverage_sweep", fake_sweep)
+    prepared, result = mod._attach_shared_percentile_coverage(jobs, availability)
+
+    assert result is sentinel
+    assert calls == [(("LUAD", "SKCM"), {"percentiles": (0.9, 0.95), "on_missing": "record"})]
+    dependent = [
+        kwargs for _, _, function, kwargs in prepared if function in mod._PERCENTILE_COVERAGE_PLOTS
+    ]
+    assert len(dependent) == 12
+    assert all(kwargs["coverage_table"] is sentinel for kwargs in dependent)
 
 
 def test_regenerate_plots_runner_writes_all_figures_pdf(tmp_path):
@@ -782,10 +924,20 @@ def test_regenerate_plots_runner_closes_each_returned_figure(tmp_path, monkeypat
     monkeypatch.setattr(
         mod,
         "_jobs",
-        lambda: [
+        lambda availability: [
             ("memory", "first", "_memory_test_plot", {"label": "first"}),
             ("memory", "second", "_memory_test_plot", {"label": "second"}),
         ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "_plot_data_availability",
+        lambda: {
+            "per_sample": (),
+            "percentile_gene": (),
+            "percentile_proteoform": (),
+            "within_sample": (),
+        },
     )
     monkeypatch.setattr(
         mod.cta_curation_plots,

--- a/tests/test_within_sample.py
+++ b/tests/test_within_sample.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from oncoref import expression, expression_builders
+from oncoref import data_bundle, expression, expression_builders, source_matrices
 
 
 def _matrix(genes, samples, values):
@@ -72,6 +72,40 @@ def within_sample_cache(monkeypatch, tmp_path):
 
 def test_available_within_sample_cohorts(within_sample_cache):
     assert expression.available_within_sample_cohorts() == ["PRAD"]
+
+
+def test_locally_available_within_sample_cohorts_unions_all_local_roots(
+    within_sample_cache, monkeypatch, tmp_path
+):
+    package_root = tmp_path / "package"
+    package_shards = package_root / "cancer-reference-expression-within-sample-top5"
+    package_shards.mkdir(parents=True)
+    (package_shards / "LUAD.parquet").write_text("present")
+    package_percentiles = package_root / "cancer-reference-expression-percentiles"
+    package_percentiles.mkdir(parents=True)
+    (package_percentiles / "LUAD.parquet").write_text("present")
+    cached_percentiles = within_sample_cache / "cancer-reference-expression-percentiles"
+    cached_percentiles.mkdir(parents=True)
+    (cached_percentiles / "PRAD.parquet").write_text("present")
+    monkeypatch.setattr(data_bundle, "_PACKAGE_DATA_DIR", package_root)
+    monkeypatch.setattr(source_matrices, "available_cohorts", lambda: ["BRCA", "SKCM"])
+    monkeypatch.setattr(source_matrices, "is_cached", lambda code: code == "BRCA")
+    monkeypatch.setattr(
+        data_bundle,
+        "ensure_local",
+        lambda: pytest.fail("local availability must not download the bundle"),
+    )
+
+    assert expression.locally_available_within_sample_cohorts() == ["BRCA", "LUAD", "PRAD"]
+    assert expression.locally_available_within_sample_cohorts(include_recomputable=False) == [
+        "LUAD",
+        "PRAD",
+    ]
+    assert expression.locally_available_percentile_cohorts() == ["BRCA", "LUAD", "PRAD"]
+    assert expression.locally_available_percentile_cohorts(include_recomputable=False) == [
+        "LUAD",
+        "PRAD",
+    ]
 
 
 def test_within_sample_top_fraction_default_threshold(within_sample_cache):


### PR DESCRIPTION
## Summary
- add QC-pass, co-occurrence-aware CTA p90/p95 greedy coverage and true patient-union APIs
- add p90/p95 coverage curves, marginal stacked bars, and incidence/mortality addressable-burden jobs
- inventory package data, partial bundle caches, and cached source matrices without downloads; share one bounded coverage sweep across the plot batch
- clarify CTA identity, rank-threshold semantics, patient union, and local-data behavior in the API guide

## Ownership decision
oncoref owns the reusable empirical CTA definition, expression thresholds, patient coverage, and standard reference plots implemented here. Purpose-specific causal models, therapy registries, suppressor panels, placental-privilege analyses, and large visual-variant catalogs remain downstream in pirlygenes. This resolves the oncoref-owned portion of the broad parity tracker rather than copying downstream policy into the base layer.

## Validation
- `./test.sh`: 985 passed, zero skipped
- `mkdocs build --strict`
- real LUAD/SKCM p90/p95 smoke: six plots rendered from one shared sweep
- active full-test process observed at about 92 MB RSS; no Salmon execution

Closes #178