### PR TITLE
Speed up registry queries and the test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -218,4 +218,4 @@ jobs:
           PY
 
       - name: Run unit tests
-        run: pytest tests/ -v --cov=oncoref --cov-report=xml
+        run: pytest tests/ -v -n 2 --dist load --cov=oncoref --cov-report=xml

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ oncoref version
 ./develop.sh   # editable install with dev extras
 ./format.sh    # ruff format
 ./lint.sh      # ruff check + format --check
-./test.sh      # lint + pytest with coverage
+./test.sh      # lint + the full pytest suite with coverage and two workers
 ```
 
 ## License

--- a/oncoref/cancer_types.py
+++ b/oncoref/cancer_types.py
@@ -286,6 +286,7 @@ def _clear_caches():
     _classification_target_map.cache_clear()
     _classification_reference_code_map.cache_clear()
     _expression_source_cohort_counts.cache_clear()
+    _cancer_type_record_frame.cache_clear()
     _clear_cache()  # frame cache + registered derived caches (burden maps, CTA, …)
 
 
@@ -1106,6 +1107,7 @@ _CANCER_TYPE_RECORD_COLUMNS = [
 ]
 
 
+@lru_cache(maxsize=1)
 def _cancer_type_record_frame() -> pd.DataFrame:
     from .incidence import burden_category
     from .tmb import cancer_tmb
@@ -1219,7 +1221,8 @@ def cancer_type_records(
 
     Return type is always a DataFrame, including for empty results.
     """
-    df = _cancer_type_record_frame()
+    # Filtering must never mutate the shared, registry-derived base frame.
+    df = _cancer_type_record_frame().copy()
 
     exact_codes = _normalize_cancer_code_filter(cancer_types)
     if exact_codes is not None:

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.166"
+__version__ = "1.8.167"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ plots = [
 dev = [
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
     "ruff",
     "matplotlib",
     "adjustText",

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 set -o errexit
 
 ./lint.sh
-python -m pytest tests/ --cov=oncoref --cov-report=term-missing
+python -m pytest tests/ -n 2 --dist load --cov=oncoref --cov-report=term-missing

--- a/tests/test_cancer_types.py
+++ b/tests/test_cancer_types.py
@@ -295,6 +295,25 @@ def test_clear_caches_allows_reload(monkeypatch):
     assert "PRAD" in cd.CANCER_TYPE_NAMES
 
 
+def test_cancer_type_record_frame_is_cached_cleared_and_defensive():
+    cancer_types._clear_caches()
+    assert cancer_types._cancer_type_record_frame.cache_info().currsize == 0
+
+    first = cancer_types.cancer_type_records(["PRAD"])
+    after_first = cancer_types._cancer_type_record_frame.cache_info()
+    second = cancer_types.cancer_type_records(["LUAD"])
+    after_second = cancer_types._cancer_type_record_frame.cache_info()
+
+    assert after_first.misses == 1
+    assert after_second.hits == 1
+    first.loc[:, "name"] = "mutated caller frame"
+    assert cancer_types.cancer_type_records(["PRAD"])["name"].iloc[0] != "mutated caller frame"
+    assert second["code"].tolist() == ["LUAD"]
+
+    cancer_types._clear_caches()
+    assert cancer_types._cancer_type_record_frame.cache_info().currsize == 0
+
+
 def test_every_registry_family_has_a_curated_display_name():
     # Drift guard: every registry family must have a curated label, not the
     # title-cased fallback. (This caught the stale 'cns'/'endocrine' keys left

--- a/tests/test_workflow_actions.py
+++ b/tests/test_workflow_actions.py
@@ -1,4 +1,5 @@
 import re
+import shlex
 from pathlib import Path
 
 import yaml
@@ -89,3 +90,20 @@ def test_test_workflow_stages_required_real_data():
     assert 'os.environ["ONCOREF_CI_ACC_PERCENTILE_REFERENCE"]' in reference_step["run"]
     assert '"hpa_rna_consensus": os.environ["CI_HPA_RNA_SHA256"]' in reference_step["run"]
     assert '"hpa_normal_tissue": os.environ["CI_HPA_NORMAL_TISSUE_SHA256"]' in reference_step["run"]
+
+
+def test_test_commands_use_bounded_parallelism_with_coverage():
+    workflow = yaml.safe_load(Path(".github/workflows/tests.yml").read_text())
+    test_steps = workflow["jobs"]["test"]["steps"]
+    workflow_command = next(step["run"] for step in test_steps if step["name"] == "Run unit tests")
+    local_command = next(
+        line for line in Path("test.sh").read_text().splitlines() if "pytest" in line
+    )
+
+    for command in (workflow_command, local_command):
+        arguments = shlex.split(command)
+        assert arguments[arguments.index("-n") + 1] == "2"
+        assert arguments[arguments.index("--dist") + 1] == "load"
+        assert "--cov=oncoref" in arguments
+    assert "--cov-report=xml" in shlex.split(workflow_command)
+    assert "--cov-report=term-missing" in shlex.split(local_command)


### PR DESCRIPTION
## Summary
- cache the immutable 219-row cancer-type record base frame behind the existing explicit cache-reset hook
- return defensive query frames so caller mutation cannot affect cached state
- run the complete local and CI suites with exactly two pytest workers, retaining coverage aggregation
- add regression guards for cache reuse/invalidation and bounded test commands

## Benchmarks
Same local Python 3.12 environment and data caches:

- baseline full suite: 986 passed, 86% coverage, 385.32s
- cached serial suite: 988 passed, 86% coverage, 109.45s
- cached two-worker suite: 988 passed, 86% coverage, 59.61s
- cancer-type module: 130.32s before, 4.25s after with the new regression tests included

Observed combined controller/worker RSS peaked around 2.65 GB during the full two-worker run. Worker count is fixed at two; it never scales from CPU count.

## Validation
- `./lint.sh`
- `./test.sh` (988 passed, 86% coverage)
- serial `python -m pytest tests/ -q --cov=oncoref --cov-report=term` (988 passed, 86% coverage)
- focused cache/workflow regressions (59 passed)

No Salmon process was run.