### PR TITLE
Preserve lossless exact-case gene aliases

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -942,6 +942,13 @@ but it is not the clean-TPM biological denominator.
 
 ## Genes and Proteoforms
 
+Gene-symbol aliases are loaded as lossless strings, including literal aliases
+such as `NA` and `NaN`. `gene_ids.resolve_symbol()` checks the NCBI alias's exact
+case first. It falls back case-insensitively only when the folded alias is
+unambiguous or the pinned NCBI snapshot supplies an exact uppercase row;
+otherwise the input is returned unchanged rather than selecting a gene by row
+order.
+
 - `oncoref.gene_ids` — bundled canonical Ensembl gene space, cross-release alias
   resolution, symbol synonyms, and biotype checks.
 - `oncoref.genome` — optional (`pip install 'oncoref[genome]'`) pyensembl-backed

--- a/oncoref/gene_ids.py
+++ b/oncoref/gene_ids.py
@@ -24,7 +24,7 @@ from functools import lru_cache
 
 import pandas as pd
 
-from .load_dataset import get_data
+from .load_dataset import _register_derived_cache, get_data
 
 
 def unversioned(gene_id: str) -> str:
@@ -290,16 +290,61 @@ def ensembl_id_alias_symbols() -> dict[str, str]:
 
 
 @lru_cache(maxsize=1)
-def symbol_synonyms() -> dict[str, str]:
-    """``{ALIAS (uppercased): official_symbol}`` from NCBI gene synonyms."""
+def _symbol_synonym_indexes() -> tuple[dict[str, str], dict[str, str]]:
+    """Build exact-case and safe case-insensitive NCBI synonym indexes."""
     df = get_data("ncbi-symbol-synonyms", copy=False)
-    return {str(a).upper(): str(o) for a, o in zip(df["alias"], df["official_symbol"])}
+    exact: dict[str, str] = {}
+    targets_by_uppercase_alias: dict[str, set[str]] = {}
+    for alias_value, official_value in zip(df["alias"], df["official_symbol"]):
+        if pd.isna(alias_value) or pd.isna(official_value):
+            continue
+        alias = str(alias_value)
+        official = str(official_value)
+        if not alias or not official:
+            continue
+        previous = exact.get(alias)
+        if previous is not None and previous != official:
+            raise ValueError(
+                f"NCBI synonym alias {alias!r} maps to both {previous!r} and {official!r}"
+            )
+        exact[alias] = official
+        targets_by_uppercase_alias.setdefault(alias.upper(), set()).add(official)
+
+    case_insensitive: dict[str, str] = {}
+    for uppercase_alias, targets in targets_by_uppercase_alias.items():
+        if len(targets) == 1:
+            case_insensitive[uppercase_alias] = next(iter(targets))
+        elif uppercase_alias in exact:
+            # The snapshot's exact uppercase row is the deterministic fallback.
+            case_insensitive[uppercase_alias] = exact[uppercase_alias]
+    return exact, case_insensitive
+
+
+_register_derived_cache(_symbol_synonym_indexes.cache_clear)
+
+
+def symbol_synonyms() -> dict[str, str]:
+    """Safe case-insensitive ``{ALIAS: official_symbol}`` NCBI synonym index.
+
+    Keys are uppercase. Ambiguous case-folded aliases are omitted unless the
+    NCBI snapshot contains an exact uppercase alias, which supplies the stable
+    fallback. Use :func:`resolve_symbol` when exact-case distinctions matter.
+    """
+    return _symbol_synonym_indexes()[1].copy()
 
 
 def resolve_symbol(symbol: str) -> str:
-    """Map a gene-symbol synonym to its official symbol (case-insensitive); returns
-    the input unchanged if it's already official / unknown."""
-    return symbol_synonyms().get(str(symbol).upper(), str(symbol))
+    """Resolve an NCBI gene-symbol synonym without collapsing case collisions.
+
+    Exact-case aliases win. Other casing uses the safe case-insensitive index;
+    an ambiguous fold with no exact uppercase row is returned unchanged.
+    """
+    raw = str(symbol)
+    exact, case_insensitive = _symbol_synonym_indexes()
+    exact_match = exact.get(raw)
+    if exact_match is not None:
+        return exact_match
+    return case_insensitive.get(raw.upper(), raw)
 
 
 def gene_identifier_mapping_coverage() -> pd.DataFrame:

--- a/oncoref/load_dataset.py
+++ b/oncoref/load_dataset.py
@@ -59,6 +59,16 @@ _CATEGORICAL_COLUMNS_BY_DATASET = {
     ),
 }
 
+# NCBI uses literal aliases such as "NA" and "NaN". Preserve every nonempty
+# string in this table while continuing to represent empty CSV cells as missing.
+_CSV_READ_OPTIONS_BY_DATASET = {
+    "ncbi-symbol-synonyms": {
+        "dtype": "string",
+        "keep_default_na": False,
+        "na_values": [""],
+    },
+}
+
 # Back-compat alias.
 _DATA_DIR = _BUNDLED_DATA_DIR
 
@@ -146,11 +156,17 @@ def _optimize_cached_dataframe(dataset_name: str, df: pd.DataFrame) -> pd.DataFr
     return df
 
 
+def _read_csv_for_cache(path: Path, dataset_name: str) -> pd.DataFrame:
+    """Read one CSV with the owning dataset's lossless parsing contract."""
+    options = _CSV_READ_OPTIONS_BY_DATASET.get(dataset_name, {})
+    return pd.read_csv(str(path), low_memory=False, **options)
+
+
 def _read_shards_for_cache(shard_dir: Path, paths: list[Path]) -> list[pd.DataFrame]:
     """Read shards while compacting each one before the next is retained."""
     frames = []
     for path in paths:
-        frame = pd.read_csv(str(path), low_memory=False)
+        frame = _read_csv_for_cache(path, shard_dir.name)
         frames.append(_optimize_cached_dataframe(shard_dir.name, frame))
     return frames
 
@@ -270,7 +286,8 @@ def get_data(name, _dataframes_dict=None, *, copy=True):
             else:
                 cache_key = resolved.name.removesuffix(".gz")
                 if cache_key not in _CACHED_DATAFRAMES:
-                    _CACHED_DATAFRAMES[cache_key] = pd.read_csv(str(resolved), low_memory=False)
+                    dataset_name = cache_key.removesuffix(".csv")
+                    _CACHED_DATAFRAMES[cache_key] = _read_csv_for_cache(resolved, dataset_name)
             cached = _CACHED_DATAFRAMES[cache_key]
             return cached.copy() if copy else cached
     raise ValueError(f"Dataset {name} not found")

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.167"
+__version__ = "1.8.168"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_gene_ids.py
+++ b/tests/test_gene_ids.py
@@ -8,6 +8,7 @@
 
 import oncoref
 from oncoref import gene_ids as g
+from oncoref.load_dataset import get_data
 
 
 def test_unversioned_normalizer():
@@ -194,6 +195,39 @@ def test_symbol_synonym_resolution():
     assert g.resolve_symbol(alias.lower()) == official  # case-insensitive
     # an unknown / already-official symbol passes through
     assert g.resolve_symbol("NOT_A_REAL_GENE") == "NOT_A_REAL_GENE"
+
+
+def test_symbol_synonym_resolution_preserves_exact_case_collisions():
+    assert g.resolve_symbol("NA") == "XK"
+    assert g.resolve_symbol("NaN") == "SCN11A"
+    assert g.resolve_symbol("20-ALPHA-HSD") == "AKR1C1"
+    assert g.resolve_symbol("20-alpha-HSD") == "HSD17B1"
+    assert g.resolve_symbol("5PTASE") == "INPP5A"
+    assert g.resolve_symbol("5PTase") == "INPP5B"
+
+    # Other casing deterministically follows the exact uppercase snapshot row.
+    assert g.resolve_symbol("20-AlPhA-HsD") == "AKR1C1"
+    assert g.resolve_symbol("5PtAsE") == "INPP5A"
+    assert g.canonical_gene_id("20-ALPHA-HSD") == "ENSG00000187134"
+    assert g.canonical_gene_id("20-alpha-HSD") == "ENSG00000108786"
+    assert g.canonical_gene_id("5PTASE") == "ENSG00000068383"
+    assert g.canonical_gene_id("5PTase") == "ENSG00000204084"
+
+
+def test_symbol_synonym_resolution_leaves_unanchored_case_collisions_ambiguous():
+    assert g.resolve_symbol("H-plk") == "ZNF117"
+    assert g.resolve_symbol("h-PLK") == "ERV3-1-ZNF117"
+    assert g.resolve_symbol("H-PLK") == "H-PLK"
+
+
+def test_every_exact_symbol_synonym_row_roundtrips():
+    synonyms = get_data("ncbi-symbol-synonyms", copy=False)
+    failures = [
+        (str(row.alias), str(row.official_symbol), g.resolve_symbol(str(row.alias)))
+        for row in synonyms.itertuples(index=False)
+        if g.resolve_symbol(str(row.alias)) != str(row.official_symbol)
+    ]
+    assert not failures, failures[:5]
 
 
 def test_canonical_gene_space_and_biotype():

--- a/tests/test_load_dataset.py
+++ b/tests/test_load_dataset.py
@@ -78,3 +78,23 @@ def test_reference_expression_csv_shards_are_compacted_before_concatenation(tmp_
     assert loaded == optimized_shards
     assert len(loaded) == 2
     assert all(isinstance(frame["source_cohort"].dtype, pd.CategoricalDtype) for frame in loaded)
+
+
+def test_ncbi_synonym_loader_preserves_na_like_aliases():
+    load_dataset._clear_cache()
+    synonyms = load_dataset.get_data("ncbi-symbol-synonyms")
+
+    expected = {"NA": "XK", "NaN": "SCN11A"}
+    observed = synonyms[synonyms["alias"].isin(expected)].set_index("alias")["official_symbol"]
+    assert observed.to_dict() == expected
+    assert isinstance(synonyms["alias"].dtype, pd.StringDtype)
+
+
+def test_ncbi_synonym_loader_keeps_empty_cells_missing(tmp_path):
+    path = tmp_path / "ncbi-symbol-synonyms.csv"
+    path.write_text("alias,official_symbol\nNA,XK\nNaN,SCN11A\n,EMPTY\n")
+
+    loaded = load_dataset._read_csv_for_cache(path, "ncbi-symbol-synonyms")
+
+    assert loaded["alias"].iloc[:2].tolist() == ["NA", "NaN"]
+    assert pd.isna(loaded["alias"].iloc[2])


### PR DESCRIPTION
## Summary
- load the NCBI synonym table as strings without coercing literal `NA` and `NaN` aliases to missing values
- continue treating genuinely empty CSV fields as missing
- resolve aliases by exact case first, then use only a safe case-insensitive fallback
- use an exact uppercase snapshot row as the deterministic fallback for case-fold collisions; leave unanchored ambiguous folds unchanged
- document the lookup contract and release as 1.8.168

## Regression coverage
- `NA -> XK` and `NaN -> SCN11A` survive the public loader
- synthetic blank alias cells remain `pd.NA`
- reported `20-ALPHA-HSD` / `20-alpha-HSD` and `5PTASE` / `5PTase` collisions resolve to distinct official genes and canonical ENSGs
- an ambiguous collision with no exact uppercase row remains unchanged for the folded query
- all 65,455 exact synonym rows round-trip to their owning official symbol

## Validation
- `./test.sh` (993 passed, 86% coverage)
- focused loader/gene-ID tests (21 passed)
- `mkdocs build --strict`
- Ruff lint and formatting

Closes #462.
Closes #464.

No Salmon process was run.