### PR TITLE
Complete acquisition source project provenance

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -435,6 +435,12 @@ cancer code. They are related planning surfaces, not interchangeable provenance:
 the selected ACC matrix, for example, currently comes from Treehouse even though
 `tcga-acc` is a registered acquisition source.
 
+An acquisition source with a known physical cohort also carries a nonempty
+`source_project`. This makes `expression_sources()` self-contained for display
+provenance. Its label may be more specific than the cohort registry's shared
+project label, so consumers should preserve the source-owned value instead of
+replacing it with a cohort-level fallback.
+
 Use `oncoref.source_matrices.codes_for_source(source_id)` for the selected code
 list. Use `oncoref.source_matrices.resolution_for_source(source_id)` when
 provenance matters. Its `resolution_method` is `physical_source` only when the

--- a/oncoref/data/expression_sources.yaml
+++ b/oncoref/data/expression_sources.yaml
@@ -160,6 +160,7 @@ sources:
     recount3_route: mds_cd34
     expected_samples_by_code: {MDS: 82}
     source_cohort: GSE114922_SHIOZAWA_2018
+    source_project: GEO
     builder: scripts/build_recount3_source.py
     unit: recount3 Gencode-v26 coverage gene-sums
     expected_size_gb: 0.1
@@ -779,6 +780,7 @@ sources:
     recount3_route: all
     expected_samples_by_code: {NET_PANCREAS: 33}
     source_cohort: GSE118014_ALVAREZ_2018
+    source_project: GEO
     builder: scripts/build_recount3_source.py
     unit: recount3 Gencode-v26 coverage gene-sums
     expected_size_gb: 0.1
@@ -1533,6 +1535,7 @@ sources:
     source_type: github-release
     builder: scripts/build_lnen_drmetrics_reference_expression.py
     source_cohort: DRMETRICS_ALCALA_2019_LNEN
+    source_project: GEO (DR-metrics / Alcala LNEN)
     url: https://github.com/IARCbioinfo/DRMetrics
     expected_size_gb: 0.05
     citation: PMID 31431620 (Alcala 2019) + PMID 33203751 (Gabriel 2020)
@@ -1580,6 +1583,7 @@ sources:
     recount3_route: net_origin
     expected_samples_by_code: {NET_MIDGUT: 81, NET_PANCREAS: 113, NET_RECTAL: 18}
     source_cohort: GSE98894_ALVAREZ_2018_NET
+    source_project: GEO
     builder: scripts/build_recount3_source.py
     unit: recount3 Gencode-v26 coverage gene-sums
     expected_size_gb: 0.1
@@ -1613,6 +1617,7 @@ sources:
     citation: GSE32662 (Pringle 2012 medullary thyroid carcinoma)
     expected_size_gb: 0.05
     source_cohort: GSE32662_PRINGLE_2012_MTC
+    source_project: GEO
     tumor_origin: primary
     unit: TPM proxy
     processing_pipeline: GPL6480 series-matrix log2 intensity to TPM proxy; Ensembl 112
@@ -1677,6 +1682,7 @@ sources:
     citation: PMID 22241786 (Singer 2007 MSKCC 140-sample LPS classifier)
     expected_size_gb: 0.1
     source_cohort: GSE30929_SINGER_2007_LPS
+    source_project: GEO
     tumor_origin: primary
     special_handling: >
       Affymetrix HG-U133A (GPL96) microarray; 140 primary liposarcomas

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.168"
+__version__ = "1.8.169"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/tests/test_expression_sources.py
+++ b/tests/test_expression_sources.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pandas as pd
 
 import oncoref
-from oncoref import expression_builders, samples
+from oncoref import expression_builders, samples, source_matrices
 from oncoref import expression_registry as es
 from oncoref.cancer_types import resolve_cancer_type
 from oncoref.load_dataset import get_data
@@ -172,6 +172,45 @@ def test_expression_sources_df_shape():
         "citation",
     } <= set(df.columns)
     assert len(df) == len(es.expression_sources())
+
+
+def test_selected_physical_sources_preserve_known_availability_projects():
+    availability = get_data("cancer-reference-expression-availability")
+    projects_by_cohort = {
+        str(source_cohort): {
+            str(project)
+            for project in rows["source_project"]
+            if pd.notna(project) and str(project).strip()
+        }
+        for source_cohort, rows in availability.groupby("source_cohort", observed=True)
+    }
+    missing = []
+    for source in es.expression_sources():
+        resolution = source_matrices.resolution_for_source(source.id)
+        if resolution.resolution_method != "physical_source":
+            continue
+        known_projects = set().union(
+            *(projects_by_cohort.get(matrix.source_cohort, set()) for matrix in resolution.matrices)
+        )
+        if known_projects and not source.source_project:
+            missing.append((source.id, sorted(known_projects)))
+
+    assert not missing
+
+
+def test_previously_missing_source_projects_use_canonical_cohort_labels():
+    expected = {
+        "gse114922-mds": "GEO",
+        "gse118014-pannet": "GEO",
+        "drmetrics-lnen-2020": "GEO (DR-metrics / Alcala LNEN)",
+        "gse98894-midnet": "GEO",
+        "gse32662-mtc": "GEO",
+        "gse30929-lps": "GEO",
+    }
+
+    assert {
+        source_id: es.expression_source(source_id).source_project for source_id in expected
+    } == expected
 
 
 def test_expression_source_registry_raw_helpers_are_public():


### PR DESCRIPTION
## Summary
- populate the six remaining owner-known `source_project` fields in the acquisition registry
- enforce parity between physical-source resolution and known project metadata in the availability manifest
- document that source-owned project labels are authoritative and may be more specific than cohort-level fallbacks

## Validation
- `./test.sh` (995 passed, 86% coverage)
- `pytest -q tests/test_expression_sources.py` (18 passed)
- `mkdocs build --strict`

Closes #461