### PR TITLE
Publish compatible oncodata redirect

### DIFF
--- a/pypi-oncodata-redirect/.gitignore
+++ b/pypi-oncodata-redirect/.gitignore
@@ -1,0 +1,5 @@
+/build/
+/dist/
+/*.egg-info/
+__pycache__/
+*.py[cod]

--- a/pypi-oncodata-redirect/DEPLOY.md
+++ b/pypi-oncodata-redirect/DEPLOY.md
@@ -1,0 +1,34 @@
+# Publishing the oncodata → oncoref redirect
+
+This directory builds a final `oncodata` 1.6.1 release that depends on and
+re-exports `oncoref`, plus a README/warning telling users to migrate. It is a
+one-time artifact, separate from the main `oncoref` package.
+
+## Order matters
+
+1. **Publish `oncoref` first** (from the repo root), so the redirect's
+   `oncoref>=1.6.0` dependency resolves:
+
+   ```bash
+   ./deploy.sh          # lint + test + build + twine upload + tag
+   ```
+
+2. **Then publish this redirect:**
+
+   ```bash
+   cd pypi-oncodata-redirect
+   rm -rf dist && python3 -m build
+   python3 -m twine check dist/*
+   python3 -m twine upload dist/*
+   ```
+
+Both uploads need your PyPI credentials (`~/.pypirc` or a token).
+
+## Notes
+- PyPI cannot rename or transfer a project, so `oncoref` is a brand-new
+  project and the old `oncodata` 1.4.0 / 1.5.0 releases remain installable.
+- This is `oncodata` **1.6.1**. It supersedes the incomplete 1.6.0 redirect,
+  which did not preserve legacy submodule imports, base genome support, or the
+  `plots` extra.
+- After upload you can delete this `pypi-oncodata-redirect/` directory; it is
+  not part of the `oncoref` source tree.

--- a/pypi-oncodata-redirect/LICENSE
+++ b/pypi-oncodata-redirect/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pypi-oncodata-redirect/README.md
+++ b/pypi-oncodata-redirect/README.md
@@ -1,0 +1,23 @@
+# oncodata has been renamed to **oncoref**
+
+This package is no longer maintained under the name `oncodata`. It has been
+renamed to [`oncoref`](https://pypi.org/project/oncoref/).
+
+## Migrate
+
+```bash
+pip uninstall oncodata
+pip install oncoref
+```
+
+```python
+import oncoref          # was: import oncodata
+```
+
+The `oncodata` command remains as a deprecated alias for `oncoref`.
+
+This final `oncodata` release depends on `oncoref`, re-exports its public API,
+and preserves the legacy module paths and optional `plots` extra. It will not
+receive feature updates. Please switch to `oncoref`.
+
+Source & issues: <https://github.com/pirl-unc/oncoref>

--- a/pypi-oncodata-redirect/oncodata/__init__.py
+++ b/pypi-oncodata-redirect/oncodata/__init__.py
@@ -1,0 +1,72 @@
+"""Compatibility shim for the package renamed from ``oncodata`` to ``oncoref``.
+
+The redirect preserves the former top-level API and module import paths while
+warning callers to migrate. It contains no data or implementation of its own.
+"""
+
+import importlib
+import sys
+import warnings
+
+import oncoref as _oncoref
+
+warnings.warn(
+    "The 'oncodata' package has been renamed to 'oncoref'. "
+    "Install it with `pip install oncoref` and use `import oncoref`. "
+    "This 'oncodata' package is frozen and will not be updated.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+# Re-export the public API and preserve every Python module shipped by oncodata
+# 1.5.0. Registering the original paths in sys.modules means both
+# ``import oncodata.expression`` and ``from oncodata.expression import ...``
+# resolve to the one corresponding oncoref module object.
+from oncoref import *  # noqa: E402, F403
+from oncoref import __version__  # noqa: E402
+
+__all__ = _oncoref.__all__
+
+_LEGACY_SUBMODULES = (
+    "apd1",
+    "cancer_genes",
+    "cancer_types",
+    "catalog",
+    "cli",
+    "coverage",
+    "cta",
+    "cta_regen",
+    "cta_tissues",
+    "data_bundle",
+    "data_manifest",
+    "expression",
+    "expression_builders",
+    "expression_engine",
+    "expression_registry",
+    "fusions",
+    "gene_families",
+    "gene_ids",
+    "gene_qc",
+    "genome",
+    "hpa",
+    "ici",
+    "incidence",
+    "load_dataset",
+    "normalization",
+    "peptides",
+    "plots",
+    "proteoforms",
+    "reference_data",
+    "response_signatures",
+    "samples",
+    "source_matrices",
+    "tmb",
+    "version",
+)
+
+for _name in _LEGACY_SUBMODULES:
+    _module = importlib.import_module(f"oncoref.{_name}")
+    sys.modules[f"{__name__}.{_name}"] = _module
+    globals()[_name] = _module
+
+del _module, _name

--- a/pypi-oncodata-redirect/pyproject.toml
+++ b/pypi-oncodata-redirect/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=77.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "oncodata"
+version = "1.6.1"
+description = "Renamed to 'oncoref' — install and import oncoref instead"
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [
+    {name = "Alex Rubinsteyn", email = "alex.rubinsteyn@unc.edu"}
+]
+classifiers = [
+    "Development Status :: 7 - Inactive",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+requires-python = ">=3.9"
+# oncodata 1.5.0 included pyensembl in its base installation. Keep that
+# contract for requirements that still name the legacy distribution.
+dependencies = ["oncoref[genome]>=1.6.0"]
+
+[project.optional-dependencies]
+plots = ["oncoref[plots]>=1.6.0"]
+
+[project.scripts]
+oncodata = "oncoref.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/pirl-unc/oncoref"
+Repository = "https://github.com/pirl-unc/oncoref"
+
+[tool.setuptools.packages.find]
+include = ["oncodata*"]

--- a/pypi-oncodata-redirect/tests/test_redirect.py
+++ b/pypi-oncodata-redirect/tests/test_redirect.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+from pathlib import Path
+
+import oncoref
+
+REDIRECT_ROOT = Path(__file__).resolve().parents[1]
+LEGACY_SUBMODULES = (
+    "apd1",
+    "cancer_genes",
+    "cancer_types",
+    "catalog",
+    "cli",
+    "coverage",
+    "cta",
+    "cta_regen",
+    "cta_tissues",
+    "data_bundle",
+    "data_manifest",
+    "expression",
+    "expression_builders",
+    "expression_engine",
+    "expression_registry",
+    "fusions",
+    "gene_families",
+    "gene_ids",
+    "gene_qc",
+    "genome",
+    "hpa",
+    "ici",
+    "incidence",
+    "load_dataset",
+    "normalization",
+    "peptides",
+    "plots",
+    "proteoforms",
+    "reference_data",
+    "response_signatures",
+    "samples",
+    "source_matrices",
+    "tmb",
+    "version",
+)
+
+
+def _import_redirect():
+    sys.path.insert(0, str(REDIRECT_ROOT))
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return importlib.import_module("oncodata")
+    finally:
+        sys.path.remove(str(REDIRECT_ROOT))
+
+
+def test_redirect_reexports_public_api():
+    oncodata = _import_redirect()
+
+    assert oncodata.__version__ == oncoref.__version__
+    assert oncodata.__all__ == oncoref.__all__
+    assert oncodata.cancer_type_codes is oncoref.cancer_type_codes
+
+
+def test_all_legacy_submodules_alias_oncoref_modules():
+    oncodata = _import_redirect()
+
+    for name in LEGACY_SUBMODULES:
+        legacy = importlib.import_module(f"oncodata.{name}")
+        replacement = importlib.import_module(f"oncoref.{name}")
+        assert legacy is replacement
+        assert getattr(oncodata, name) is replacement
+
+
+def test_documented_expression_submodule_import():
+    _import_redirect()
+
+    from oncodata.expression import SHARD_DATASETS
+
+    assert SHARD_DATASETS is oncoref.expression.SHARD_DATASETS

--- a/tests/test_oncodata_redirect.py
+++ b/tests/test_oncodata_redirect.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import oncoref
 
-REDIRECT_ROOT = Path(__file__).resolve().parents[1]
+REDIRECT_ROOT = Path(__file__).resolve().parents[1] / "pypi-oncodata-redirect"
 LEGACY_SUBMODULES = (
     "apd1",
     "cancer_genes",


### PR DESCRIPTION
## Summary

- publish a corrected `oncodata` 1.6.1 redirect after the incomplete 1.6.0 release
- preserve all 34 Python submodule paths shipped by `oncodata` 1.5.0
- retain the legacy base-install genome dependency, `plots` extra, and CLI command
- require a PEP 639-capable setuptools backend

## Why

The 1.6.0 redirect re-exported only top-level names. Existing imports such as `oncodata.expression`, base calls requiring `pyensembl`, and `oncodata[plots]` installations were therefore broken. Its declared setuptools minimum also could not parse its license metadata.

## Validation

- `python -m pytest -q tests/test_oncodata_redirect.py`
- `ruff check pypi-oncodata-redirect/oncodata pypi-oncodata-redirect/tests`
- isolated PEP 517 wheel and sdist build with setuptools 83
- `python -m twine check pypi-oncodata-redirect/dist/*`
- clean installation of `oncodata-1.6.1-py3-none-any.whl[plots]`, resolving Oncoref, pyensembl, and plotting dependencies
- clean-install imports for `oncodata.expression` and `oncodata.plots`, plus `oncodata version`
