### PR TITLE
Speed up the test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -218,4 +218,7 @@ jobs:
           PY
 
       - name: Run unit tests
-        run: pytest tests/ -v -n 2 --dist load --cov=oncoref --cov-report=xml
+        run: >-
+          pytest tests/ -v -n 2 --dist loadgroup
+          --durations 20 --durations-min 0.5
+          --cov=oncoref --cov-report=xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,7 @@ jobs:
       # Keep real-data test fixtures under the workspace so actions/cache can archive them.
       CANCERDATA_SOURCE_MATRICES: ${{ github.workspace }}/.ci-cache/source-matrices
       CANCERDATA_DATA_DIR: ${{ github.workspace }}/.ci-cache/reference-data
+      CANCERDATA_BUNDLED_DATA: ${{ github.workspace }}/.ci-cache/bundled-data
       # Pin the fixture by content, independently of an unreleased source-version bump.
       CI_LUAD_SOURCE_URL: https://github.com/pirl-unc/oncoref/releases/download/source-v5.22.8/LUAD_per_sample_tpm.parquet
       CI_LUAD_SHA256: 001ebb9ad18aea86599ff5d808851007523f6d8f0927dfdf2a2f39372f83ffc5
@@ -158,7 +159,7 @@ jobs:
           import urllib.request
           from pathlib import Path
 
-          from oncoref import reference_data
+          from oncoref import data_bundle, reference_data
 
           def sha256(path):
               digest = hashlib.sha256()
@@ -183,7 +184,7 @@ jobs:
               temporary_path.replace(acc_reference)
 
           bundle_acc_reference = (
-              Path(os.environ["CANCERDATA_DATA_DIR"])
+              data_bundle.cache_dir()
               / "cancer-reference-expression-percentiles"
               / "ACC.parquet"
           )

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,6 @@ jobs:
           python - <<'PY'
           import hashlib
           import os
-          import shutil
           import urllib.request
 
           from oncoref import source_matrices
@@ -155,6 +154,7 @@ jobs:
           python - <<'PY'
           import hashlib
           import os
+          import shutil
           import urllib.request
           from pathlib import Path
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,6 +116,7 @@ jobs:
           python - <<'PY'
           import hashlib
           import os
+          import shutil
           import urllib.request
 
           from oncoref import source_matrices
@@ -180,6 +181,18 @@ jobs:
                   expected_acc_sha256,
               )
               temporary_path.replace(acc_reference)
+
+          bundle_acc_reference = (
+              Path(os.environ["CANCERDATA_DATA_DIR"])
+              / "cancer-reference-expression-percentiles"
+              / "ACC.parquet"
+          )
+          if (
+              not bundle_acc_reference.is_file()
+              or sha256(bundle_acc_reference) != expected_acc_sha256
+          ):
+              bundle_acc_reference.parent.mkdir(parents=True, exist_ok=True)
+              shutil.copy2(acc_reference, bundle_acc_reference)
 
           hpa_sources = {
               "hpa_rna_consensus": os.environ["CI_HPA_RNA_SHA256"],

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,7 +22,6 @@ TAG="v${VERSION}"
 PYPI_URL="https://pypi.org/project/oncoref/${VERSION}/"
 PYPI_PUBLISHED_MARKER="<!-- oncoref-deploy-pypi-published -->"
 
-./lint.sh
 ./test.sh
 "$PYTHON_BIN" -m pip install --upgrade build twine
 rm -rf dist

--- a/oncoref/genome.py
+++ b/oncoref/genome.py
@@ -31,6 +31,7 @@ against the newest release first, falling back to older installed releases.
 from __future__ import annotations
 
 import logging
+import re
 from functools import lru_cache
 
 from .gene_ids import resolve_symbol, unversioned
@@ -122,64 +123,30 @@ def gene_for_ensembl_id(genome, gene_id: str):
         return None
 
 
-@lru_cache(maxsize=1)
-def _index_genome():
-    """Newest installed release with a **queryable GTF** (gene/transcript tables
-    built), or ``None``. A release with sequence FASTA but no built GTF database
-    (``gene_ids()`` raises) is skipped — otherwise it would be picked as ``genomes()[0]``
-    yet yield empty indexes, silently forcing every lookup onto the slow per-release
-    fallback."""
-    for g in genomes():
-        try:
-            g.gene_ids()  # GTF probe — raises if the database isn't built
-            return g
-        except Exception:
-            continue
-    return None
+_ENSEMBL_GENE_ID = re.compile(r"ENSG\d+")
+_ENSEMBL_TRANSCRIPT_ID = re.compile(r"ENST\d+")
 
 
-@lru_cache(maxsize=1)
-def _newest_indexes():
-    """``(gene_id->name, transcript_id->gene_name)`` from the newest *usable* release,
-    built once in memory (pyensembl persists its own SQLite cache)."""
-    gid_to_name: dict[str, str] = {}
-    tid_to_gene: dict[str, str] = {}
-    g = _index_genome()
-    if g is not None:
-        for gene in g.genes():
-            gid_to_name[strip_version(gene.id)] = gene.name
-        for t in g.transcripts():
-            tid_to_gene[strip_version(t.id)] = t.gene_name
-    return gid_to_name, tid_to_gene
-
-
-def _fallback_genomes():
-    """Installed releases other than the one already indexed (newest first) — for the
-    per-id fallback when the in-memory index misses."""
-    idx = _index_genome()
-    return [g for g in genomes() if g is not idx]
-
-
+@lru_cache(maxsize=65_536)
 def find_gene_name_from_ensembl_gene_id(gene_id: str) -> str | None:
-    """Gene symbol for an Ensembl gene id — indexed release, then older releases."""
+    """Gene symbol for a human Ensembl gene id, newest installed release first."""
     gid = strip_version(gene_id)
-    name = _newest_indexes()[0].get(gid)
-    if name:
-        return name
-    for genome in _fallback_genomes():
+    if _ENSEMBL_GENE_ID.fullmatch(gid) is None:
+        return None
+    for genome in genomes():
         gene = gene_for_ensembl_id(genome, gid)
-        if gene and gene.gene_name:
-            return gene.gene_name
+        if gene:
+            return getattr(gene, "gene_name", None) or getattr(gene, "name", None)
     return None
 
 
+@lru_cache(maxsize=65_536)
 def find_gene_name_from_ensembl_transcript_id(transcript_id: str) -> str | None:
-    """Gene symbol for an Ensembl transcript id — indexed release, then older."""
+    """Gene symbol for a human Ensembl transcript id, newest installed release first."""
     tid = strip_version(transcript_id)
-    name = _newest_indexes()[1].get(tid)
-    if name:
-        return name
-    for genome in _fallback_genomes():
+    if _ENSEMBL_TRANSCRIPT_ID.fullmatch(tid) is None:
+        return None
+    for genome in genomes():
         try:
             t = genome.transcript_by_id(tid)
         except Exception:

--- a/oncoref/plots.py
+++ b/oncoref/plots.py
@@ -265,8 +265,8 @@ def _family_legend_handles(plt, fam_color):
 def _repel_labels(ax, texts):
     """Nudge point labels apart so they don't overlap, drawing thin leader lines back to
     the points (uses ``adjustText`` when installed; a no-op fallback otherwise). Best-effort
-    and cosmetic — it must never break figure generation, so any failure degrades to
-    un-repelled labels rather than raising."""
+    and cosmetic: work is capped at one second, and any failure degrades to un-repelled
+    labels rather than breaking figure generation."""
     if not texts:
         return
     try:
@@ -276,6 +276,7 @@ def _repel_labels(ax, texts):
             texts,
             ax=ax,
             expand=(1.05, 1.2),
+            time_lim=1.0,
             arrowprops={"arrowstyle": "-", "color": "0.6", "lw": 0.4},
         )
     except Exception:  # cosmetic label placement — never fatal to figure generation

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.171"
+__version__ = "1.8.172"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 set -o errexit
 
 ./lint.sh
-python -m pytest tests/ -n 2 --dist load --cov=oncoref --cov-report=term-missing
+python -m pytest tests/ -n 2 --dist loadgroup --durations 20 --durations-min 0.5 --cov=oncoref --cov-report=term-missing

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -3031,6 +3031,7 @@ def test_released_ifs_cmn_physical_sources_are_individually_loadable():
         ("CMN", "TREEHOUSE_RIBOD_25_01"): 1,
     }
 
+    loaded = {}
     for (code, source_cohort), n_samples in expected_samples.items():
         rows = expression.cancer_reference_expression(
             code,
@@ -3042,14 +3043,9 @@ def test_released_ifs_cmn_physical_sources_are_individually_loadable():
         assert not rows.empty
         assert set(rows["source_cohort"]) == {source_cohort}
         assert set(rows["n_reference_samples"]) == {n_samples}
+        loaded[(code, source_cohort)] = rows
 
-    cmn_array = expression.cancer_reference_expression(
-        "CMN",
-        normalize="tpm_raw",
-        reference_source="summary_rows_all",
-        sample_qc="all",
-        source_cohort="GSE11482_GADD_2010_CMN",
-    )
+    cmn_array = loaded[("CMN", "GSE11482_GADD_2010_CMN")]
     assert set(cmn_array["source_scale_class"]) == {"microarray_tpm_proxy"}
     assert not cmn_array["linear_tpm_comparable"].any()
 

--- a/tests/test_genome_pick.py
+++ b/tests/test_genome_pick.py
@@ -6,6 +6,8 @@
 
 """Unit tests for the pure gene-ranking helpers (no Ensembl release needed)."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from oncoref import genome as gx
@@ -24,6 +26,57 @@ class _Gene:
         self.name = name
         self.transcripts = transcripts
         self.biotype = biotype
+
+
+@pytest.fixture(autouse=True)
+def _clear_id_resolver_caches():
+    resolvers = (
+        gx.find_gene_name_from_ensembl_gene_id,
+        gx.find_gene_name_from_ensembl_transcript_id,
+    )
+    for resolver in resolvers:
+        resolver.cache_clear()
+    yield
+    for resolver in resolvers:
+        resolver.cache_clear()
+
+
+def test_id_resolvers_reject_malformed_ids_without_opening_a_genome(monkeypatch):
+    monkeypatch.setattr(
+        gx, "genomes", lambda: pytest.fail("malformed IDs must not query pyensembl")
+    )
+
+    assert gx.find_gene_name_from_ensembl_gene_id("ENSG_FAKE") is None
+    assert gx.find_gene_name_from_ensembl_transcript_id("ENST_FAKE") is None
+
+
+def test_transcript_resolver_queries_releases_directly_and_caches(monkeypatch):
+    calls = []
+
+    class Genome:
+        def __init__(self, gene_name=None):
+            self.gene_name = gene_name
+
+        def transcript_by_id(self, transcript_id):
+            calls.append((self.gene_name, transcript_id))
+            if self.gene_name is None:
+                raise ValueError(transcript_id)
+            return SimpleNamespace(gene_name=self.gene_name)
+
+    monkeypatch.setattr(gx, "genomes", lambda: [Genome(), Genome("TP53")])
+
+    assert gx.find_gene_name_from_ensembl_transcript_id("ENST00000269305.9") == "TP53"
+    assert gx.find_gene_name_from_ensembl_transcript_id("ENST00000269305.9") == "TP53"
+    assert calls == [(None, "ENST00000269305"), ("TP53", "ENST00000269305")]
+
+
+def test_gene_resolver_queries_exact_ids_without_materializing_release(monkeypatch):
+    genome = SimpleNamespace(
+        gene_by_id=lambda gene_id: SimpleNamespace(gene_name=None, name="TP53")
+    )
+    monkeypatch.setattr(gx, "genomes", lambda: [genome])
+
+    assert gx.find_gene_name_from_ensembl_gene_id("ENSG00000141510") == "TP53"
 
 
 def test_best_transcript_support_prefers_lower_tsl():

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -4,7 +4,9 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import pandas as pd
 import pytest
@@ -12,6 +14,8 @@ import pytest
 pytest.importorskip("matplotlib")
 
 from oncoref import cli, data_bundle, plots
+
+pytestmark = pytest.mark.xdist_group("plots")
 
 
 @pytest.fixture(autouse=True)
@@ -24,9 +28,29 @@ def _close_figures_after_test():
 
 def test_apd1_vs_tmb_renders(tmp_path):
     out = tmp_path / "apd1_vs_tmb.png"
-    fig = plots.apd1_vs_tmb(save=str(out))
+    fig = plots.apd1_vs_tmb(annotate=False, save=str(out))
     assert out.exists() and out.stat().st_size > 0
     assert fig is not None
+
+
+def test_scatter_label_adjustment_has_a_runtime_bound(monkeypatch):
+    observed = {}
+    fake_adjust_text = ModuleType("adjustText")
+
+    def adjust_text(texts, **kwargs):
+        observed["texts"] = texts
+        observed.update(kwargs)
+
+    fake_adjust_text.adjust_text = adjust_text
+    monkeypatch.setitem(sys.modules, "adjustText", fake_adjust_text)
+
+    texts = [object()]
+    axis = object()
+    plots._repel_labels(axis, texts)
+
+    assert observed["texts"] == texts
+    assert observed["ax"] is axis
+    assert observed["time_lim"] == 1.0
 
 
 def test_apd1_vs_tmb_strict_pd1_filters_proxy_targets(tmp_path):

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -262,8 +262,9 @@ def test_cli_plot_threshold_tpm_is_opt_in(monkeypatch, tmp_path):
 
 
 def test_cta_expression_heatmap_renders(tmp_path):
-    if not data_bundle.item_is_local("cancer-reference-expression-percentiles"):
-        pytest.skip("percentile artifacts not present locally")
+    assert data_bundle.item_is_local("cancer-reference-expression-percentiles"), (
+        "tests require a staged percentile artifact"
+    )
 
     out = tmp_path / "cta.png"
     cohorts = __import__("oncoref").available_percentile_cohorts()[:6]

--- a/tests/test_workflow_actions.py
+++ b/tests/test_workflow_actions.py
@@ -88,6 +88,7 @@ def test_test_workflow_stages_required_real_data():
         step for step in test_job["steps"] if step["name"] == "Stage required reference data"
     )
     assert 'os.environ["ONCOREF_CI_ACC_PERCENTILE_REFERENCE"]' in reference_step["run"]
+    assert "import shutil" in reference_step["run"]
     assert '"cancer-reference-expression-percentiles"' in reference_step["run"]
     assert "shutil.copy2(acc_reference, bundle_acc_reference)" in reference_step["run"]
     assert '"hpa_rna_consensus": os.environ["CI_HPA_RNA_SHA256"]' in reference_step["run"]

--- a/tests/test_workflow_actions.py
+++ b/tests/test_workflow_actions.py
@@ -103,7 +103,9 @@ def test_test_commands_use_bounded_parallelism_with_coverage():
     for command in (workflow_command, local_command):
         arguments = shlex.split(command)
         assert arguments[arguments.index("-n") + 1] == "2"
-        assert arguments[arguments.index("--dist") + 1] == "load"
+        assert arguments[arguments.index("--dist") + 1] == "loadgroup"
+        assert arguments[arguments.index("--durations") + 1] == "20"
+        assert arguments[arguments.index("--durations-min") + 1] == "0.5"
         assert "--cov=oncoref" in arguments
     assert "--cov-report=xml" in shlex.split(workflow_command)
     assert "--cov-report=term-missing" in shlex.split(local_command)

--- a/tests/test_workflow_actions.py
+++ b/tests/test_workflow_actions.py
@@ -63,6 +63,7 @@ def test_test_workflow_stages_required_real_data():
         "/ci-fixtures-v1/ACC_reference_percentiles_v5.23.2.parquet"
     )
     assert "CANCERDATA_DATA_DIR" in test_job["env"]
+    assert "CANCERDATA_BUNDLED_DATA" in test_job["env"]
     assert test_job["env"]["CI_HPA_RNA_SHA256"] == (
         "c49b5b33a076e3b9c1eb4f7d15d063ee936e07045e192ceccfeb9edcf1d90ddb"
     )
@@ -89,6 +90,8 @@ def test_test_workflow_stages_required_real_data():
     )
     assert 'os.environ["ONCOREF_CI_ACC_PERCENTILE_REFERENCE"]' in reference_step["run"]
     assert "import shutil" in reference_step["run"]
+    assert "from oncoref import data_bundle, reference_data" in reference_step["run"]
+    assert "data_bundle.cache_dir()" in reference_step["run"]
     assert '"cancer-reference-expression-percentiles"' in reference_step["run"]
     assert "shutil.copy2(acc_reference, bundle_acc_reference)" in reference_step["run"]
     assert '"hpa_rna_consensus": os.environ["CI_HPA_RNA_SHA256"]' in reference_step["run"]

--- a/tests/test_workflow_actions.py
+++ b/tests/test_workflow_actions.py
@@ -88,6 +88,8 @@ def test_test_workflow_stages_required_real_data():
         step for step in test_job["steps"] if step["name"] == "Stage required reference data"
     )
     assert 'os.environ["ONCOREF_CI_ACC_PERCENTILE_REFERENCE"]' in reference_step["run"]
+    assert '"cancer-reference-expression-percentiles"' in reference_step["run"]
+    assert "shutil.copy2(acc_reference, bundle_acc_reference)" in reference_step["run"]
     assert '"hpa_rna_consensus": os.environ["CI_HPA_RNA_SHA256"]' in reference_step["run"]
     assert '"hpa_normal_tissue": os.environ["CI_HPA_NORMAL_TISSUE_SHA256"]' in reference_step["run"]
 


### PR DESCRIPTION
## Summary
- replace whole-release pyensembl materialization with bounded, cached exact-ID lookups
- cap cosmetic scatter-label adjustment and keep plot tests on one xdist worker to reuse Matplotlib state
- avoid a duplicate released CMN shard parse, report slow tests in local/CI runs, and remove duplicate deploy linting
- bump the code-only package version to 1.8.172; data versions are unchanged

## Measured result
- comparable no-coverage suite: 69.3s before, 44.0s after (36% lower wall time)
- coverage suite: 1,037 passed, 0 skipped in 62.8s before adding the three dependency-free resolver regressions
- transcript resolver test: 16.8s before, 0.01s after

## Verification
- ./test.sh
- focused resolver/workflow tests: 18 passed
- ./lint.sh
- bash -n test.sh deploy.sh