### PR TITLE
Make plotting part of the base package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
           import importlib.util
 
           assert importlib.util.find_spec("pyensembl") is None
+          for dependency in ("matplotlib", "adjustText", "matplotlib_venn"):
+              assert importlib.util.find_spec(dependency) is not None, dependency
 
           import oncoref
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ stay downstream.
 pip install oncoref
 ```
 
-Optional integrations are explicit extras:
+Reference plotting is included in the standard installation. The pyensembl-backed
+genome integration remains optional because it also requires a separately installed
+Ensembl release:
 
 ```bash
 pip install 'oncoref[genome]'  # pyensembl-backed transcript and gene lookup
-pip install 'oncoref[plots]'   # reference plotting
 ```
 
 ## Quick start

--- a/oncoref/cta_curation_plots.py
+++ b/oncoref/cta_curation_plots.py
@@ -17,8 +17,8 @@ only oncoref-owned data. The figures summarize the CTA source overlap, filter
 funnel/outcome, deflated reproductive-fraction distribution, and
 protein-reliability-vs-RNA thresholds from ``cancer-testis-antigens.csv``.
 
-``matplotlib_venn`` is optional. If it is not installed, the source-overlap
-figure degrades to a source-size bar, matching pirlygenes' behavior.
+The standard oncoref installation includes ``matplotlib_venn`` for the
+source-overlap figure.
 """
 
 from __future__ import annotations
@@ -109,29 +109,20 @@ def _save(fig, path, plt):
 
 
 def _fig_source_venn(df, path, plt):
+    from matplotlib_venn import venn3
+
     sets = _tag_sets(df)
     fig, ax = plt.subplots(figsize=(7, 6))
     keys = ("CTpedia", "CTexploreR", "daSilva2017_protein")
     placental = len(sets["placental_antigen"])
-    try:
-        from matplotlib_venn import venn3
-    except ImportError:
-        ax.barh(list(keys), [len(sets[k]) for k in keys], color=KEPT)
-        ax.set_xlabel("genes")
-        ax.set_title(
-            "CTA source sizes - install matplotlib_venn (or oncoref[plots])\n"
-            f"for the overlap venn; +{placental} placental-antigen genes folded in"
-        )
-    else:
-        venn3(
-            [sets[k] for k in keys],
-            set_labels=("CTpedia", "CTexploreR", "da Silva 2017\n(protein)"),
-            ax=ax,
-        )
-        ax.set_title(
-            "CTA source overlap (primary databases)\n"
-            f"+{placental} placental-antigen genes folded in"
-        )
+    venn3(
+        [sets[k] for k in keys],
+        set_labels=("CTpedia", "CTexploreR", "da Silva 2017\n(protein)"),
+        ax=ax,
+    )
+    ax.set_title(
+        f"CTA source overlap (primary databases)\n+{placental} placental-antigen genes folded in"
+    )
     _save(fig, path, plt)
 
 

--- a/oncoref/plots.py
+++ b/oncoref/plots.py
@@ -16,10 +16,9 @@ These need only oncoref-owned data (TMB, anti-PD-1 ORR, incidence/mortality,
 the cancer-type registry for lineage colors) — no CTA or peptide data — so they
 have no dependency on the target-selection libraries.
 
-matplotlib is an optional extra (``pip install oncoref[plots]``); it is
-imported lazily so the data layer stays importable without it. Every function
-returns the matplotlib ``Figure`` and optionally writes a PNG when ``save`` is
-given.
+The standard oncoref installation includes matplotlib. It is imported lazily to
+keep ordinary data access lightweight. Every function returns the matplotlib
+``Figure`` and optionally writes a PNG when ``save`` is given.
 """
 
 from __future__ import annotations
@@ -57,15 +56,11 @@ def _plt():
     global _PLT
     if _PLT is not None:
         return _PLT
-    try:
-        import matplotlib
+    import matplotlib
 
-        matplotlib.use("Agg", force=False)
-        import matplotlib.pyplot as plt
-    except ModuleNotFoundError as e:  # pragma: no cover - exercised via extras
-        raise ModuleNotFoundError(
-            "oncoref plotting requires matplotlib — install with `pip install oncoref[plots]`"
-        ) from e
+    matplotlib.use("Agg", force=False)
+    import matplotlib.pyplot as plt
+
     _PLT = plt
     return _PLT
 

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.172"
+__version__ = "1.8.173"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,25 +31,20 @@ dependencies = [
     "numpy",
     "pyarrow",
     "PyYAML",
+    "matplotlib",
+    "adjustText",
+    "matplotlib_venn>=1.0",
 ]
 
 [project.optional-dependencies]
 genome = [
     "pyensembl",
 ]
-plots = [
-    "matplotlib",
-    "adjustText",
-    "matplotlib_venn>=1.0",
-]
 dev = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
     "ruff",
-    "matplotlib",
-    "adjustText",
-    "matplotlib_venn>=1.0",
     "pyensembl",
 ]
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -8,10 +8,9 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
-
-pytest.importorskip("matplotlib")
 
 from oncoref import cli, data_bundle, plots
 
@@ -21,8 +20,6 @@ pytestmark = pytest.mark.xdist_group("plots")
 @pytest.fixture(autouse=True)
 def _close_figures_after_test():
     yield
-    import matplotlib.pyplot as plt
-
     plt.close("all")
 
 
@@ -931,8 +928,6 @@ def test_regenerate_plots_runner_writes_all_figures_pdf(tmp_path):
     import importlib.util
     from pathlib import Path
 
-    import matplotlib.pyplot as plt
-
     runner = Path(__file__).resolve().parent.parent / "scripts" / "regenerate_plots.py"
     spec = importlib.util.spec_from_file_location("_regen_plots", runner)
     mod = importlib.util.module_from_spec(spec)
@@ -954,8 +949,6 @@ def test_regenerate_plots_runner_writes_all_figures_pdf(tmp_path):
 def test_regenerate_plots_runner_closes_each_returned_figure(tmp_path, monkeypatch):
     import importlib.util
     import sys
-
-    import matplotlib.pyplot as plt
 
     runner = Path(__file__).resolve().parent.parent / "scripts" / "regenerate_plots.py"
     spec = importlib.util.spec_from_file_location("_regen_plots_memory", runner)

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -22,6 +22,18 @@ def test_build_backend_supports_declared_pep_639_license_metadata():
     assert 'license-files = ["LICENSE"]' in pyproject
 
 
+def test_plotting_dependencies_are_part_of_the_base_install():
+    pyproject = Path("pyproject.toml").read_text()
+    project_metadata, optional_dependencies = pyproject.split(
+        "[project.optional-dependencies]", maxsplit=1
+    )
+
+    for requirement in ('"matplotlib"', '"adjustText"', '"matplotlib_venn>=1.0"'):
+        assert requirement in project_metadata
+    assert "\nplots = [" not in optional_dependencies
+    assert "oncoref[plots]" not in Path("README.md").read_text()
+
+
 def test_source_distribution_includes_regeneration_scripts():
     manifest = Path("MANIFEST.in").read_text()
 

--- a/tests/test_workflow_actions.py
+++ b/tests/test_workflow_actions.py
@@ -98,6 +98,19 @@ def test_test_workflow_stages_required_real_data():
     assert '"hpa_normal_tissue": os.environ["CI_HPA_NORMAL_TISSUE_SHA256"]' in reference_step["run"]
 
 
+def test_minimal_install_includes_plotting_but_not_genome_dependencies():
+    workflow = yaml.safe_load(Path(".github/workflows/tests.yml").read_text())
+    minimal_steps = workflow["jobs"]["minimal"]["steps"]
+    verification = next(
+        step["run"]
+        for step in minimal_steps
+        if step["name"] == "Verify minimal base-layer contract"
+    )
+
+    assert 'find_spec("pyensembl") is None' in verification
+    assert '("matplotlib", "adjustText", "matplotlib_venn")' in verification
+
+
 def test_test_commands_use_bounded_parallelism_with_coverage():
     workflow = yaml.safe_load(Path(".github/workflows/tests.yml").read_text())
     test_steps = workflow["jobs"]["test"]["steps"]


### PR DESCRIPTION
## Summary

- make matplotlib, adjustText, and matplotlib-venn standard oncoref dependencies
- remove the `plots` extra and its optional-install documentation
- make plotting tests fail rather than skip when the installation is incomplete
- verify the clean base-install CI environment includes every plotting dependency

## Rationale

Oncoref ships plotting modules and plot CLI commands as supported package features. Requiring a separate extra made a normal installation behaviorally incomplete and allowed missing plotting dependencies to suppress test coverage.

## Validation

- `./test.sh`: 1042 passed, zero skipped
- Ruff check and format checks pass
- wheel build succeeds and declares all three plotting libraries as unconditional `Requires-Dist` entries
