### PR TITLE
Prepare oncoref 1.8.174 release

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.173"
+__version__ = "1.8.174"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins


### PR DESCRIPTION
## Summary

- bump the package version to 1.8.174 for the code changes merged in #481
- retain data bundle 5.23.17 because the release changes registry/accessor behavior but not derived bundle artifacts

## Validation

- release workflow tests: 8 passed
- Ruff lint and formatting passed

Release follow-up to #481.