### PR TITLE
Prepare oncoref 1.8.175 release

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.174"
+__version__ = "1.8.175"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins


### PR DESCRIPTION
## Summary

- bump the package version to 1.8.175
- release the NCI-gap and non-testicular germ-cell source-candidate work merged in #490
- retain data bundle 5.23.17 and source-matrix bundle 5.22.10 because this release changes packaged registry/candidate metadata, not downloadable derived matrices

## Validation

- `pytest -q tests/test_release_workflow.py` (8 passed)
- `./lint.sh`

Follow-up release for #490.