### PR TITLE
Expose checksum-verified HPA provenance

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1127,7 +1127,13 @@ order.
 ### HPA data
 
 - `oncoref.reference_data` / `oncoref.hpa` — HPA reference-data cache and HPA
-  tissue/cell-type accessors.
+  tissue/cell-type accessors. Use
+  `reference_data.provenance(name, version, verify_content=True)` for a
+  defensive provenance snapshot containing the concrete source URL, local
+  path and size, recorded SHA-256 and download time, existence state, and
+  checksum result. `reference_data.status(verify_content=True)` exposes the
+  same fields for every default-version HPA source; omit `verify_content` to
+  avoid hashing large cached files.
 
 ## Compatibility Modules
 

--- a/oncoref/reference_data.py
+++ b/oncoref/reference_data.py
@@ -233,16 +233,75 @@ def verify(name: str, version: str | None = None) -> bool:
     Raises if there is no manifest record to check against (nothing to verify).
     Unlike the cheap size check on reuse, this re-hashes the file — call it
     deliberately (a cache audit), not on every access."""
-    version = resolve_version(name, version)
-    dest = local_path(name, version)
-    expected = _manifest_record(name, version).get("sha256")
-    if not expected:
+    record = provenance(name, version, verify_content=True)
+    if not record["sha256"]:
         raise ReferenceDataError(
-            f"no manifest sha256 recorded for {name!r} {version}; nothing to verify"
+            f"no manifest sha256 recorded for {name!r} {record['version']}; nothing to verify"
         )
-    if not dest.exists():
-        return False
-    return hashlib.sha256(dest.read_bytes()).hexdigest() == expected
+    return record["checksum_matches"] is True
+
+
+def provenance(
+    name: str,
+    version: str | None = None,
+    *,
+    verify_content: bool = False,
+) -> dict:
+    """Return source and cache provenance for one concrete reference artifact.
+
+    The returned dictionary is a defensive, scalar-only snapshot; changing it
+    cannot mutate the cache manifest. ``verify_content=False`` avoids hashing
+    large HPA TSVs and reports ``verification_state="not_checked"`` when a
+    checksum is available. Opting into content verification reports one of
+    ``"verified"`` or ``"checksum_mismatch"``. The other explicit states are
+    ``"no_manifest"``, ``"missing_checksum"``, and ``"missing_file"``.
+    """
+    version = resolve_version(name, version)
+    spec = _source(name)
+    dest = local_path(name, version)
+    record = dict(_manifest_record(name, version))
+    exists = dest.exists()
+    try:
+        local_bytes = dest.stat().st_size if exists else None
+    except OSError:
+        exists = False
+        local_bytes = None
+
+    recorded_bytes = record.get("bytes")
+    try:
+        recorded_bytes = int(recorded_bytes) if recorded_bytes is not None else None
+    except (TypeError, ValueError):
+        recorded_bytes = None
+
+    expected = record.get("sha256") or None
+    checksum_matches = None
+    if not record:
+        verification_state = "no_manifest"
+    elif not expected:
+        verification_state = "missing_checksum"
+    elif not exists:
+        verification_state = "missing_file"
+        checksum_matches = False
+    elif verify_content:
+        checksum_matches = hashlib.sha256(dest.read_bytes()).hexdigest() == expected
+        verification_state = "verified" if checksum_matches else "checksum_mismatch"
+    else:
+        verification_state = "not_checked"
+
+    return {
+        "name": name,
+        "version": version,
+        "url": record.get("url") or spec["urls"][version],
+        "path": str(dest),
+        "bytes": local_bytes,
+        "recorded_bytes": recorded_bytes,
+        "sha256": expected,
+        "downloaded_at": record.get("downloaded_at") or None,
+        "exists": exists,
+        "manifest_recorded": bool(record),
+        "checksum_matches": checksum_matches,
+        "verification_state": verification_state,
+    }
 
 
 def _zip_member(zf: zipfile.ZipFile, preferred: str) -> str:
@@ -266,21 +325,25 @@ def ensure(name: str, version: str | None = None) -> Path:
     return download(name, version)
 
 
-def status() -> list[dict]:
-    """One row per source: cached?, version, size, description."""
+def status(*, verify_content: bool = False) -> list[dict]:
+    """One row per source with default-version cache and provenance status.
+
+    Set ``verify_content=True`` to hash each present artifact and populate a
+    definitive checksum verification state. The default is deliberately cheap.
+    """
     rows = []
     for name, spec in REFERENCE_SOURCES.items():
-        path = local_path(name)
-        record = _manifest_record(name, DEFAULT_HPA_VERSION)
+        source_provenance = provenance(name, verify_content=verify_content)
         rows.append(
             {
-                "name": name,
-                "cached": path.exists(),
+                **source_provenance,
+                "cached": source_provenance["exists"],
+                "bytes": source_provenance["bytes"] or 0,
                 "default_version": DEFAULT_HPA_VERSION,
                 "available_versions": sorted(spec["urls"]),
-                "cached_version": record.get("version"),
-                "bytes": path.stat().st_size if path.exists() else 0,
-                "path": str(path),
+                "cached_version": (
+                    source_provenance["version"] if source_provenance["manifest_recorded"] else None
+                ),
                 "description": spec["description"],
             }
         )

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -64,6 +64,8 @@ def test_status_shape(monkeypatch, tmp_path):
     names = {r["name"] for r in rows}
     assert names == {"hpa_rna_consensus", "hpa_normal_tissue", "hpa_single_cell"}
     assert all(r["cached"] is False for r in rows)  # nothing downloaded
+    assert all(r["verification_state"] == "no_manifest" for r in rows)
+    assert all(r["sha256"] is None for r in rows)
 
 
 def test_single_cell_registered():
@@ -145,3 +147,99 @@ def test_verify_without_manifest_raises(monkeypatch, tmp_path):
     monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
     with pytest.raises(reference_data.ReferenceDataError, match="nothing to verify"):
         reference_data.verify("hpa_rna_consensus")
+
+
+def test_provenance_selects_exact_cached_version(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    v23 = _seed_cache("hpa_rna_consensus", b"v23-data", version="v23")
+    latest = _seed_cache("hpa_rna_consensus", b"latest-data", version="latest")
+
+    v23_record = reference_data.provenance("hpa_rna_consensus", "v23")
+    latest_record = reference_data.provenance("hpa_rna_consensus", "latest")
+
+    assert v23_record["version"] == "v23"
+    assert v23_record["path"] == str(v23)
+    assert v23_record["sha256"] == hashlib.sha256(b"v23-data").hexdigest()
+    assert latest_record["version"] == "latest"
+    assert latest_record["path"] == str(latest)
+    assert latest_record["sha256"] == hashlib.sha256(b"latest-data").hexdigest()
+
+
+def test_provenance_distinguishes_verification_states(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    dest = _seed_cache("hpa_rna_consensus", b"good")
+
+    unchecked = reference_data.provenance("hpa_rna_consensus")
+    assert unchecked["verification_state"] == "not_checked"
+    assert unchecked["checksum_matches"] is None
+
+    verified = reference_data.provenance("hpa_rna_consensus", verify_content=True)
+    assert verified["verification_state"] == "verified"
+    assert verified["checksum_matches"] is True
+
+    dest.write_bytes(b"bad")
+    mismatched = reference_data.provenance("hpa_rna_consensus", verify_content=True)
+    assert mismatched["verification_state"] == "checksum_mismatch"
+    assert mismatched["checksum_matches"] is False
+
+    dest.unlink()
+    missing = reference_data.provenance("hpa_rna_consensus", verify_content=True)
+    assert missing["verification_state"] == "missing_file"
+    assert missing["checksum_matches"] is False
+
+
+def test_provenance_distinguishes_no_manifest_and_missing_checksum(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    dest = reference_data.local_path("hpa_rna_consensus")
+    dest.parent.mkdir(parents=True)
+    dest.write_bytes(b"unrecorded")
+
+    absent = reference_data.provenance("hpa_rna_consensus", verify_content=True)
+    assert absent["manifest_recorded"] is False
+    assert absent["verification_state"] == "no_manifest"
+    assert absent["checksum_matches"] is None
+
+    manifest_path = reference_data.cache_dir() / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                reference_data._manifest_key("hpa_rna_consensus", "v23"): {
+                    "name": "hpa_rna_consensus",
+                    "version": "v23",
+                    "url": "http://example/test",
+                    "path": str(dest),
+                    "bytes": len(b"unrecorded"),
+                }
+            }
+        )
+    )
+    missing_checksum = reference_data.provenance("hpa_rna_consensus", verify_content=True)
+    assert missing_checksum["manifest_recorded"] is True
+    assert missing_checksum["verification_state"] == "missing_checksum"
+    assert missing_checksum["checksum_matches"] is None
+
+
+def test_provenance_is_a_defensive_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    _seed_cache("hpa_rna_consensus", b"stable")
+
+    first = reference_data.provenance("hpa_rna_consensus")
+    expected_sha256 = first["sha256"]
+    first["sha256"] = "mutated"
+    first["url"] = "http://example/mutated"
+
+    second = reference_data.provenance("hpa_rna_consensus")
+    assert second["sha256"] == expected_sha256
+    assert second["url"] == "http://example/test"
+
+
+def test_status_can_verify_default_version_content(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANCERDATA_DATA_DIR", str(tmp_path))
+    _seed_cache("hpa_rna_consensus", b"stable")
+
+    by_name = {row["name"]: row for row in reference_data.status(verify_content=True)}
+    record = by_name["hpa_rna_consensus"]
+    assert record["verification_state"] == "verified"
+    assert record["checksum_matches"] is True
+    assert record["url"] == "http://example/test"
+    assert record["recorded_bytes"] == len(b"stable")


### PR DESCRIPTION
## Summary

- add a public, defensive `reference_data.provenance()` snapshot for an exact HPA source and version
- expose recorded URL, path, sizes, SHA-256, download time, file presence, and explicit checksum state
- extend `reference_data.status()` with the same provenance fields and opt-in content hashing
- preserve legacy manifest lookup and existing `verify()` behavior

## Validation

- `pytest -q` (1056 passed)
- `./lint.sh`

Closes #491.