### PR TITLE
Release oncoref 1.8.176

### DIFF
--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.175"
+__version__ = "1.8.176"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins


### PR DESCRIPTION
## Summary

- publish the checksum-verified HPA provenance API from #493
- publish complete cancer burden provenance from #494
- bump the package version to 1.8.176

## Validation

- ./lint.sh
- python -m pytest tests/test_release_workflow.py

Release follows after CI is green and the PR is review-clean.