### PR TITLE
Consolidate evidence resolution and silence expected test warnings

### DIFF
--- a/oncoref/_evidence_resolution.py
+++ b/oncoref/_evidence_resolution.py
@@ -46,7 +46,7 @@ def resolve_evidence(
     *,
     direct_lookup: Callable[[str], Payload | None],
     source_code_for: Callable[[str], str],
-    parent_by_code: Mapping[str, object],
+    parent_by_code: Mapping[str, object] | Callable[[], Mapping[str, object]],
     inherit: bool,
     direct_gap_lookup: Callable[[str], Payload | None] | None = None,
 ) -> EvidenceResolution[Payload]:
@@ -82,14 +82,19 @@ def resolve_evidence(
         if source is not None:
             return EvidenceResolution(source_code, "source_scope", source)
 
-    current = parent_code(requested_code, parent_by_code)
+    # Parent metadata is unnecessary for direct hits, audited gaps, source-scope
+    # hits, and lookups with inheritance disabled. Accepting a provider keeps that
+    # comparatively expensive index lazy while preserving support for callers that
+    # already have a mapping.
+    parents = parent_by_code() if callable(parent_by_code) else parent_by_code
+    current = parent_code(requested_code, parents)
     seen = {requested_code}
     while current and current not in seen:
         seen.add(current)
         ancestor = direct_lookup(current)
         if ancestor is not None:
             return EvidenceResolution(current, "ancestor", ancestor)
-        current = parent_code(current, parent_by_code)
+        current = parent_code(current, parents)
 
     return EvidenceResolution(requested_code, "missing", None)
 

--- a/oncoref/_evidence_resolution.py
+++ b/oncoref/_evidence_resolution.py
@@ -1,0 +1,122 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared evidence-source resolution for cancer-code keyed reference tables."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+import pandas as pd
+
+Payload = TypeVar("Payload")
+
+
+@dataclass(frozen=True)
+class EvidenceResolution(Generic[Payload]):
+    """One completed direct/source-scope/ancestor evidence lookup."""
+
+    resolved_code: str
+    inheritance_kind: str
+    payload: Payload | None
+
+
+def parent_code(code: str, parent_by_code: Mapping[str, object]) -> str | None:
+    """Return a clean parent code from a registry mapping, including nullable data."""
+    parent = parent_by_code.get(code)
+    if parent is None or pd.isna(parent):
+        return None
+    parent = str(parent).strip()
+    return parent or None
+
+
+def resolve_evidence(
+    requested_code: str,
+    *,
+    direct_lookup: Callable[[str], Payload | None],
+    source_code_for: Callable[[str], str],
+    parent_by_code: Mapping[str, object],
+    inherit: bool,
+    direct_gap_lookup: Callable[[str], Payload | None] | None = None,
+) -> EvidenceResolution[Payload]:
+    """Resolve one evidence payload with a single, ordered inheritance contract.
+
+    Resolution order is deliberately uniform across ICI, anti-PD-1, and TMB:
+
+    1. a value curated directly for the requested code;
+    2. an audited gap curated directly for that code;
+    3. the registry's evidence-source code;
+    4. the nearest ancestor with a value;
+    5. missing.
+
+    A direct audited gap is checked before ``inherit`` and therefore always blocks
+    proxy or ancestor evidence. Disabling inheritance still permits direct values and
+    direct gaps, but skips both source-scope and ancestor resolution.
+    """
+    direct = direct_lookup(requested_code)
+    if direct is not None:
+        return EvidenceResolution(requested_code, "direct", direct)
+
+    if direct_gap_lookup is not None:
+        gap = direct_gap_lookup(requested_code)
+        if gap is not None:
+            return EvidenceResolution(requested_code, "direct_missing", gap)
+
+    if not inherit:
+        return EvidenceResolution(requested_code, "missing", None)
+
+    source_code = source_code_for(requested_code)
+    if source_code != requested_code:
+        source = direct_lookup(source_code)
+        if source is not None:
+            return EvidenceResolution(source_code, "source_scope", source)
+
+    current = parent_code(requested_code, parent_by_code)
+    seen = {requested_code}
+    while current and current not in seen:
+        seen.add(current)
+        ancestor = direct_lookup(current)
+        if ancestor is not None:
+            return EvidenceResolution(current, "ancestor", ancestor)
+        current = parent_code(current, parent_by_code)
+
+    return EvidenceResolution(requested_code, "missing", None)
+
+
+def public_value(value):
+    """Convert pandas/numpy missing values and scalars for a public record."""
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if hasattr(value, "item"):
+        return value.item()
+    return value
+
+
+def evidence_record(
+    row,
+    *,
+    requested_code: str,
+    resolved_code: str,
+    inheritance_kind: str,
+) -> dict[str, object]:
+    """Convert a resolved pandas row to the common public record contract."""
+    record = {key: public_value(row[key]) for key in row.index}
+    record["requested_cancer_code"] = requested_code
+    record["resolved_cancer_code"] = resolved_code
+    record["inheritance_kind"] = inheritance_kind
+    record["is_inherited_evidence"] = requested_code != resolved_code
+    return record

--- a/oncoref/apd1.py
+++ b/oncoref/apd1.py
@@ -18,6 +18,7 @@ from functools import lru_cache
 
 import pandas as pd
 
+from ._evidence_resolution import evidence_record, resolve_evidence
 from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
 from .ici import response_anchor_evidence_df
 from .load_dataset import _register_derived_cache, get_data
@@ -92,52 +93,19 @@ def cancer_apd1_response(cancer_type=None, *, inherit=True, include_inherited=Fa
             return out
         return mapping
     code = resolve_cancer_type(cancer_type)
-    if code in mapping or not inherit:
-        return mapping.get(code)
-    source_code = cancer_evidence_source_code(code)
-    if source_code != code and source_code in mapping:
-        return mapping[source_code]
-    reg = cancer_type_registry().set_index("code")
-    cur, seen = code, set()
-    while cur and cur not in seen:
-        seen.add(cur)
-        if cur in mapping:
-            return mapping[cur]
-        if cur not in reg.index:
-            break
-        cur = str(reg.loc[cur].get("parent_code", "") or "").strip() or None
-    return None
-
-
-def _parent_code(code: str, registry) -> str | None:
-    if code not in registry.index:
-        return None
-    parent = registry.loc[code].get("parent_code", "")
-    if pd.isna(parent):
-        return None
-    parent = str(parent).strip()
-    return parent or None
-
-
-def _public_value(value):
-    try:
-        if pd.isna(value):
-            return None
-    except (TypeError, ValueError):
-        pass
-    if hasattr(value, "item"):
-        return value.item()
-    return value
+    _, _, row = _resolve_apd1_response_row(code, inherit=inherit)
+    return None if row is None else float(row["apd1_orr_pct"])
 
 
 def _record_from_row(row, *, requested_code: str, resolved_code: str, inheritance_kind: str):
-    record = {key: _public_value(row[key]) for key in row.index}
-    record["requested_cancer_code"] = requested_code
-    record["resolved_cancer_code"] = resolved_code
+    record = evidence_record(
+        row,
+        requested_code=requested_code,
+        resolved_code=resolved_code,
+        inheritance_kind=inheritance_kind,
+    )
     record["selected_regimen"] = record.get("drug_target")
     record["selected_drug_target"] = record.get("drug_target")
-    record["inheritance_kind"] = inheritance_kind
-    record["is_inherited_evidence"] = requested_code != resolved_code
     return record
 
 
@@ -148,26 +116,14 @@ def _matching_row(df: pd.DataFrame, code: str):
 
 def _resolve_apd1_response_row(requested_code: str, *, inherit: bool):
     df = _apd1_valued_rows()
-    direct = _matching_row(df, requested_code)
-    if direct is not None or not inherit:
-        return requested_code, "direct" if direct is not None else "missing", direct
-
-    source_code = cancer_evidence_source_code(requested_code)
-    if source_code != requested_code:
-        source = _matching_row(df, source_code)
-        if source is not None:
-            return source_code, "source_scope", source
-
-    registry = cancer_type_registry().set_index("code")
-    cur = _parent_code(requested_code, registry)
-    seen = {requested_code}
-    while cur and cur not in seen:
-        seen.add(cur)
-        inherited = _matching_row(df, cur)
-        if inherited is not None:
-            return cur, "ancestor", inherited
-        cur = _parent_code(cur, registry)
-    return requested_code, "missing", None
+    resolution = resolve_evidence(
+        requested_code,
+        direct_lookup=lambda code: _matching_row(df, code),
+        source_code_for=cancer_evidence_source_code,
+        parent_by_code=cancer_type_registry().set_index("code")["parent_code"],
+        inherit=inherit,
+    )
+    return resolution.resolved_code, resolution.inheritance_kind, resolution.payload
 
 
 def resolve_apd1_response_source(cancer_type, *, inherit=True) -> dict:

--- a/oncoref/apd1.py
+++ b/oncoref/apd1.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-import pandas as pd
-
 from ._evidence_resolution import evidence_record, resolve_evidence
-from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
+from .cancer_types import (
+    _registry_parent_by_code,
+    cancer_evidence_source_code,
+    cancer_type_registry,  # noqa: F401 - retained as an existing module attribute
+    resolve_cancer_type,
+)
 from .ici import response_anchor_evidence_df
 from .load_dataset import _register_derived_cache, get_data
 
@@ -44,10 +47,8 @@ def cancer_apd1_response_df():
 def _apd1_response_evidence_frame():
     """The joined aPD-1 anchor+evidence frame, built once.
 
-    Same shared join as :func:`oncoref.ici.cancer_ici_response_df`, and the same
-    rebuild-per-lookup cost: ``_resolve_apd1_response_row`` runs one lookup per
-    requested code, and the ``include_inherited`` bulk maps run one per registry code.
-    Public callers still receive a defensive copy."""
+    Same shared join as :func:`oncoref.ici.cancer_ici_response_df`. Public callers
+    still receive a defensive copy."""
     return response_anchor_evidence_df(
         get_data("cancer-apd1-response"),
         value_col="apd1_orr_pct",
@@ -67,6 +68,24 @@ def _apd1_valued_rows():
 _register_derived_cache(_apd1_valued_rows.cache_clear)
 
 
+@lru_cache(maxsize=1)
+def _apd1_rows_by_code() -> dict[str, object]:
+    """Cached direct-row index. Callers must treat rows as read-only."""
+    return {str(row["cancer_code"]): row for _, row in _apd1_valued_rows().iterrows()}
+
+
+_register_derived_cache(_apd1_rows_by_code.cache_clear)
+
+
+@lru_cache(maxsize=1)
+def _apd1_value_map() -> dict[str, float]:
+    """Cached direct numeric map. Callers must treat it as read-only."""
+    return {code: float(row["apd1_orr_pct"]) for code, row in _apd1_rows_by_code().items()}
+
+
+_register_derived_cache(_apd1_value_map.cache_clear)
+
+
 def cancer_apd1_response(cancer_type=None, *, inherit=True, include_inherited=False):
     """Anti-PD-1 monotherapy ORR (%) for one cancer type, or the whole
     ``{code: orr_pct}`` map. ``cancer_type`` is resolved through
@@ -80,18 +99,17 @@ def cancer_apd1_response(cancer_type=None, *, inherit=True, include_inherited=Fa
     used for individual lookups, so source-scoped children such as ``COAD_MSI`` and
     ``READ_MSI`` are included with inherited values.
     """
-    vals = _apd1_valued_rows()
-    mapping = dict(zip(vals["cancer_code"].astype(str), vals["apd1_orr_pct"].astype(float)))
+    mapping = _apd1_value_map()
     if cancer_type is None:
         if include_inherited:
             out = {}
-            codes = sorted(set(cancer_type_registry()["code"].astype(str)) | set(mapping))
+            codes = sorted(set(_registry_parent_by_code()) | set(mapping))
             for code in codes:
                 value = cancer_apd1_response(code, inherit=inherit)
                 if value is not None:
                     out[code] = value
             return out
-        return mapping
+        return dict(mapping)
     code = resolve_cancer_type(cancer_type)
     _, _, row = _resolve_apd1_response_row(code, inherit=inherit)
     return None if row is None else float(row["apd1_orr_pct"])
@@ -109,18 +127,13 @@ def _record_from_row(row, *, requested_code: str, resolved_code: str, inheritanc
     return record
 
 
-def _matching_row(df: pd.DataFrame, code: str):
-    hit = df[df["cancer_code"].astype(str) == code]
-    return None if hit.empty else hit.iloc[0]
-
-
 def _resolve_apd1_response_row(requested_code: str, *, inherit: bool):
-    df = _apd1_valued_rows()
+    rows = _apd1_rows_by_code()
     resolution = resolve_evidence(
         requested_code,
-        direct_lookup=lambda code: _matching_row(df, code),
+        direct_lookup=rows.get,
         source_code_for=cancer_evidence_source_code,
-        parent_by_code=cancer_type_registry().set_index("code")["parent_code"],
+        parent_by_code=_registry_parent_by_code,
         inherit=inherit,
     )
     return resolution.resolved_code, resolution.inheritance_kind, resolution.payload
@@ -171,10 +184,9 @@ def cancer_apd1_response_record(cancer_type=None, *, inherit=True, include_inher
     source metadata.
     """
     if cancer_type is None:
-        df = _apd1_valued_rows()
-        direct_codes = set(df["cancer_code"].astype(str).unique())
+        direct_codes = set(_apd1_rows_by_code())
         codes = (
-            sorted(set(cancer_type_registry()["code"].astype(str)) | direct_codes)
+            sorted(set(_registry_parent_by_code()) | direct_codes)
             if include_inherited
             else sorted(direct_codes)
         )

--- a/oncoref/cancer_types.py
+++ b/oncoref/cancer_types.py
@@ -281,6 +281,7 @@ def _clear_caches():
     from .load_dataset import _clear_cache
 
     CANCER_TYPE_NAMES.clear_cache()
+    _registry_parent_by_code.cache_clear()
     _registry_frame.cache_clear()
     _who_audit_frame.cache_clear()
     _who_registry_metadata.cache_clear()
@@ -680,6 +681,18 @@ def _registry_frame():
     """Cached registry frame (shared, read-only). Internal hot-path callers use
     this; the public :func:`cancer_type_registry` returns a defensive copy."""
     return get_data("cancer-type-registry", copy=False)
+
+
+@lru_cache(maxsize=1)
+def _registry_parent_by_code() -> dict[str, object]:
+    """Cached ``code -> parent_code`` index for internal resolution hot paths.
+
+    This uses the raw registry frame because evidence resolution needs neither the
+    public registry's defensive copy nor its computed WHO/reference metadata.
+    Callers must treat the returned mapping as read-only.
+    """
+    registry = _registry_frame()
+    return dict(zip(registry["code"].astype(str), registry["parent_code"]))
 
 
 WHO_AUDIT_STATUS_VALUES = ("represented", "alias", "axis", "missing", "out_of_scope")

--- a/oncoref/ici.py
+++ b/oncoref/ici.py
@@ -83,7 +83,12 @@ from functools import lru_cache
 import pandas as pd
 
 from ._evidence_resolution import evidence_record, resolve_evidence
-from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
+from .cancer_types import (
+    _registry_parent_by_code,
+    cancer_evidence_source_code,
+    cancer_type_registry,
+    resolve_cancer_type,
+)
 from .load_dataset import _register_derived_cache, get_data
 
 #: Response-proportion endpoints that can be responder-weighted-pooled (each needs a
@@ -514,6 +519,22 @@ def _valued_rows():
 _register_derived_cache(_valued_rows.cache_clear)
 
 
+@lru_cache(maxsize=1)
+def _rows_by_code_and_regimen() -> dict[str, dict[str, object]]:
+    """Cached row index used by scalar and inherited-bulk resolution.
+
+    The source frame has at most one row per cancer-code/regimen pair. Callers must
+    treat the nested mappings and pandas rows as read-only.
+    """
+    rows: dict[str, dict[str, object]] = {}
+    for _, row in _valued_rows().iterrows():
+        rows.setdefault(str(row["cancer_code"]), {})[str(row["regimen"])] = row
+    return rows
+
+
+_register_derived_cache(_rows_by_code_and_regimen.cache_clear)
+
+
 def _gap_record(requested_code: str, *, resolver: bool) -> dict:
     """The public record for an audited gap: the curated row plus lookup metadata.
 
@@ -541,21 +562,20 @@ def _resolve_with_fallback(code: str, maps: dict[str, dict[str, float]], order):
 
 
 def _bulk_lookup_codes(*, include_inherited: bool = False) -> list[str]:
-    df = _valued_rows()
-    direct_codes = {str(code) for code in df["cancer_code"]}
+    direct_codes = set(_rows_by_code_and_regimen())
     if not include_inherited:
         return sorted(direct_codes)
-    registry_codes = set(cancer_type_registry()["code"].astype(str))
+    registry_codes = set(_registry_parent_by_code())
     return sorted(registry_codes | direct_codes)
 
 
-def _matching_rows(df, code: str, order) -> dict[str, object]:
-    rows: dict[str, object] = {}
-    sub = df[df["cancer_code"] == code]
+def _matching_rows(code: str, order) -> dict[str, object]:
+    indexed = _rows_by_code_and_regimen().get(code, {})
+    rows = {}
     for regimen in order:
-        hit = sub[sub["regimen"] == regimen]
-        if not hit.empty:
-            rows[str(regimen)] = hit.iloc[0]
+        key = str(regimen)
+        if key in indexed:
+            rows[key] = indexed[key]
     return rows
 
 
@@ -571,14 +591,13 @@ def _record_from_row(row, *, requested_code: str, resolved_code: str, inheritanc
 
 
 def _resolve_ici_response_source(requested_code: str, order, *, inherit: bool):
-    df = _valued_rows()
     gaps = _gap_rows()
     resolution = resolve_evidence(
         requested_code,
-        direct_lookup=lambda code: _matching_rows(df, code, order) or None,
+        direct_lookup=lambda code: _matching_rows(code, order) or None,
         direct_gap_lookup=gaps.get,
         source_code_for=cancer_evidence_source_code,
-        parent_by_code=cancer_type_registry().set_index("code")["parent_code"],
+        parent_by_code=_registry_parent_by_code,
         inherit=inherit,
     )
     rows = (
@@ -680,10 +699,10 @@ def cancer_ici_response(
     duplicated in default bulk maps. Pass ``include_inherited=True`` to expand across
     registry codes with the same resolver used for individual lookups.
     """
-    maps = _regimen_maps()
     order = (regimen,) if regimen is not None else REGIMEN_FALLBACK
 
     if cancer_type is None:
+        maps = _regimen_maps()
         if include_inherited:
             out = {}
             for code in _bulk_lookup_codes(include_inherited=True):

--- a/oncoref/ici.py
+++ b/oncoref/ici.py
@@ -82,6 +82,7 @@ from functools import lru_cache
 
 import pandas as pd
 
+from ._evidence_resolution import evidence_record, resolve_evidence
 from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
 from .load_dataset import _register_derived_cache, get_data
 
@@ -539,16 +540,6 @@ def _resolve_with_fallback(code: str, maps: dict[str, dict[str, float]], order):
     return None, None
 
 
-def _parent_code(code: str, registry) -> str | None:
-    if code not in registry.index:
-        return None
-    parent = registry.loc[code].get("parent_code", "")
-    if pd.isna(parent):
-        return None
-    parent = str(parent).strip()
-    return parent or None
-
-
 def _bulk_lookup_codes(*, include_inherited: bool = False) -> list[str]:
     df = _valued_rows()
     direct_codes = {str(code) for code in df["cancer_code"]}
@@ -568,64 +559,34 @@ def _matching_rows(df, code: str, order) -> dict[str, object]:
     return rows
 
 
-def _public_value(value):
-    try:
-        if pd.isna(value):
-            return None
-    except (TypeError, ValueError):
-        pass
-    if hasattr(value, "item"):
-        return value.item()
-    return value
-
-
 def _record_from_row(row, *, requested_code: str, resolved_code: str, inheritance_kind: str):
-    record = {key: _public_value(row[key]) for key in row.index}
-    record["requested_cancer_code"] = requested_code
-    record["resolved_cancer_code"] = resolved_code
+    record = evidence_record(
+        row,
+        requested_code=requested_code,
+        resolved_code=resolved_code,
+        inheritance_kind=inheritance_kind,
+    )
     record["selected_regimen"] = record.get("regimen")
-    record["inheritance_kind"] = inheritance_kind
-    record["is_inherited_evidence"] = requested_code != resolved_code
     return record
 
 
 def _resolve_ici_response_source(requested_code: str, order, *, inherit: bool):
     df = _valued_rows()
-    direct = _matching_rows(df, requested_code, order)
-    if direct:
-        return requested_code, "direct", direct
-
-    # A curated gap row is a reviewed decision about *this* code, so it outranks any
-    # inherited evidence — exactly as a blank-value TMB row stops the ancestor walk.
-    # It is reported whether or not inheritance is enabled, because the review applies
-    # to the requested code itself; ``tmb._resolve_tmb_row`` makes the same ordering.
-    if requested_code in _gap_rows():
-        return requested_code, "direct_missing", {}
-    if not inherit:
-        # No rows and nothing to inherit from: the code is unreviewed, not a direct
-        # hit. ``apd1._resolve_apd1_response_row`` reports "missing" here too.
-        return requested_code, "missing", {}
-
-    source_code = cancer_evidence_source_code(requested_code)
-    if source_code != requested_code:
-        source = _matching_rows(df, source_code, order)
-        if source:
-            return source_code, "source_scope", source
-
-    registry = cancer_type_registry().set_index("code")
-    cur = _parent_code(requested_code, registry)
-    seen = {requested_code}
-    while cur and cur not in seen:
-        seen.add(cur)
-        inherited = _matching_rows(df, cur, order)
-        if inherited:
-            return cur, "ancestor", inherited
-        cur = _parent_code(cur, registry)
-    return requested_code, "missing", {}
-
-
-def _resolve_ici_response_rows(requested_code: str, order, *, inherit: bool):
-    return _resolve_ici_response_source(requested_code, order, inherit=inherit)
+    gaps = _gap_rows()
+    resolution = resolve_evidence(
+        requested_code,
+        direct_lookup=lambda code: _matching_rows(df, code, order) or None,
+        direct_gap_lookup=gaps.get,
+        source_code_for=cancer_evidence_source_code,
+        parent_by_code=cancer_type_registry().set_index("code")["parent_code"],
+        inherit=inherit,
+    )
+    rows = (
+        resolution.payload
+        if resolution.payload is not None and resolution.inheritance_kind != "direct_missing"
+        else {}
+    )
+    return resolution.resolved_code, resolution.inheritance_kind, rows
 
 
 def resolve_ici_response_source(cancer_type, *, regimen=None, fallback=True, inherit=True) -> dict:
@@ -762,54 +723,15 @@ def cancer_ici_response(
         return out
 
     code = resolve_cancer_type(cancer_type)
+    _, _, rows = _resolve_ici_response_source(code, order, inherit=inherit)
 
     if regimen is None and not fallback:
-        per = {r: maps[r][code] for r in REGIMEN_FALLBACK if code in maps.get(r, {})}
-        if per or not inherit:
-            return per
-        # Same audited-gap guard as the scalar path below: a reviewed gap must not
-        # inherit an ancestor's per-regimen map either, or the two lookup paths would
-        # disagree about whether the code has a value.
-        if code in _gap_rows():
-            return {}
-        source_code = cancer_evidence_source_code(code)
-        if source_code != code:
-            hit = {
-                r: maps[r][source_code] for r in REGIMEN_FALLBACK if source_code in maps.get(r, {})
-            }
-            if hit:
-                return hit
-        # walk ancestors for a per-regimen mapping
-        reg = cancer_type_registry().set_index("code")
-        cur, seen = code, set()
-        while cur and cur not in seen:
-            seen.add(cur)
-            hit = {r: maps[r][cur] for r in REGIMEN_FALLBACK if cur in maps.get(r, {})}
-            if hit:
-                return hit
-            cur = _parent_code(cur, reg)
-        return {}
+        return {key: float(row["orr_pct"]) for key, row in rows.items()}
 
-    val, _ = _resolve_with_fallback(code, maps, order)
-    if val is not None or not inherit:
-        return val
-    # Keep the value path and the resolver in agreement: a curated gap row means this
-    # code has been reviewed and has no representative ORR, so it must not inherit one.
-    if code in _gap_rows():
-        return None
-    source_code = cancer_evidence_source_code(code)
-    if source_code != code:
-        val, _ = _resolve_with_fallback(source_code, maps, order)
-        if val is not None:
-            return val
-    reg = cancer_type_registry().set_index("code")
-    cur, seen = code, set()
-    while cur and cur not in seen:
-        seen.add(cur)
-        val, _ = _resolve_with_fallback(cur, maps, order)
-        if val is not None:
-            return val
-        cur = _parent_code(cur, reg)
+    for key in order:
+        row = rows.get(str(key))
+        if row is not None:
+            return float(row["orr_pct"])
     return None
 
 
@@ -882,7 +804,7 @@ def cancer_ici_response_record(
         }
 
     requested_code = resolve_cancer_type(cancer_type)
-    resolved_code, inheritance_kind, rows = _resolve_ici_response_rows(
+    resolved_code, inheritance_kind, rows = _resolve_ici_response_source(
         requested_code, order, inherit=inherit
     )
 

--- a/oncoref/tmb.py
+++ b/oncoref/tmb.py
@@ -19,7 +19,12 @@ from functools import lru_cache
 import pandas as pd
 
 from ._evidence_resolution import evidence_record, resolve_evidence
-from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
+from .cancer_types import (
+    _registry_parent_by_code,
+    cancer_evidence_source_code,
+    cancer_type_registry,
+    resolve_cancer_type,
+)
 from .load_dataset import _register_derived_cache, get_data
 
 _TMB_EVIDENCE_OVERRIDES = {
@@ -135,6 +140,12 @@ def cancer_tmb_df():
     (Lawrence 2013) with panel-based medians (Chalmers 2017) and disease-specific
     studies; see the ``source``/``notes`` columns — panel and WES TMB are not
     strictly comparable in the low-TMB range."""
+    return _tmb_evidence_frame().copy()
+
+
+@lru_cache(maxsize=1)
+def _tmb_evidence_frame():
+    """Cached annotated TMB frame. Internal callers treat it as read-only."""
     df = get_data("cancer-tmb").copy()
     evidence = [
         tmb_evidence_fields(row["cancer_code"], row["median_tmb_mut_mb"])
@@ -143,6 +154,9 @@ def cancer_tmb_df():
     for col in ("estimate_type", "source_scope", "missing_reason"):
         df[col] = [record[col] for record in evidence]
     return df
+
+
+_register_derived_cache(_tmb_evidence_frame.cache_clear)
 
 
 def tmb_evidence_fields(
@@ -180,10 +194,23 @@ def tmb_evidence_fields(
     }
 
 
-def _tmb_value_map(df=None) -> dict[str, float]:
-    df = cancer_tmb_df() if df is None else df
-    vals = df.dropna(subset=["median_tmb_mut_mb"])
+@lru_cache(maxsize=1)
+def _tmb_value_map() -> dict[str, float]:
+    """Cached direct numeric map. Callers must treat it as read-only."""
+    vals = _tmb_evidence_frame().dropna(subset=["median_tmb_mut_mb"])
     return dict(zip(vals["cancer_code"].astype(str), vals["median_tmb_mut_mb"].astype(float)))
+
+
+_register_derived_cache(_tmb_value_map.cache_clear)
+
+
+@lru_cache(maxsize=1)
+def _tmb_rows_by_code() -> dict[str, object]:
+    """Cached direct-row index, including audited gaps. Treat rows as read-only."""
+    return {str(row["cancer_code"]): row for _, row in _tmb_evidence_frame().iterrows()}
+
+
+_register_derived_cache(_tmb_rows_by_code.cache_clear)
 
 
 def _record_from_row(row, *, requested_code: str, resolved_code: str, inheritance_kind: str):
@@ -198,15 +225,14 @@ def _record_from_row(row, *, requested_code: str, resolved_code: str, inheritanc
 
 
 def _resolve_tmb_row(requested_code: str, *, inherit: bool):
-    df = cancer_tmb_df()
-    values = _tmb_value_map(df)
-    rows = df.set_index("cancer_code", drop=False)
+    values = _tmb_value_map()
+    rows = _tmb_rows_by_code()
     resolution = resolve_evidence(
         requested_code,
-        direct_lookup=lambda code: rows.loc[code] if code in values else None,
-        direct_gap_lookup=lambda code: rows.loc[code] if code in rows.index else None,
+        direct_lookup=lambda code: rows.get(code) if code in values else None,
+        direct_gap_lookup=rows.get,
         source_code_for=cancer_evidence_source_code,
-        parent_by_code=cancer_type_registry().set_index("code")["parent_code"],
+        parent_by_code=_registry_parent_by_code,
         inherit=inherit,
     )
     return resolution.resolved_code, resolution.inheritance_kind, resolution.payload
@@ -257,10 +283,9 @@ def cancer_tmb(cancer_type=None, *, inherit=True):
     ``LUAD``, ``SCLC_ASCL1`` -> ``SCLC``, rare ``SARC_*`` -> ``SARC``) resolve
     without a curated row each. Returns ``None`` if neither the code nor any
     ancestor has a value."""
-    df = cancer_tmb_df()
-    mapping = _tmb_value_map(df)
+    mapping = _tmb_value_map()
     if cancer_type is None:
-        return mapping
+        return dict(mapping)
     code = resolve_cancer_type(cancer_type)
     resolved_code, _, row = _resolve_tmb_row(code, inherit=inherit)
     return mapping.get(resolved_code) if row is not None else None

--- a/oncoref/tmb.py
+++ b/oncoref/tmb.py
@@ -18,6 +18,7 @@ from functools import lru_cache
 
 import pandas as pd
 
+from ._evidence_resolution import evidence_record, resolve_evidence
 from .cancer_types import cancer_evidence_source_code, cancer_type_registry, resolve_cancer_type
 from .load_dataset import _register_derived_cache, get_data
 
@@ -185,33 +186,13 @@ def _tmb_value_map(df=None) -> dict[str, float]:
     return dict(zip(vals["cancer_code"].astype(str), vals["median_tmb_mut_mb"].astype(float)))
 
 
-def _parent_code(code: str, registry) -> str | None:
-    if code not in registry.index:
-        return None
-    parent = registry.loc[code].get("parent_code", "")
-    if pd.isna(parent):
-        return None
-    parent = str(parent).strip()
-    return parent or None
-
-
-def _public_value(value):
-    try:
-        if pd.isna(value):
-            return None
-    except (TypeError, ValueError):
-        pass
-    if hasattr(value, "item"):
-        return value.item()
-    return value
-
-
 def _record_from_row(row, *, requested_code: str, resolved_code: str, inheritance_kind: str):
-    record = {key: _public_value(row[key]) for key in row.index}
-    record["requested_cancer_code"] = requested_code
-    record["resolved_cancer_code"] = resolved_code
-    record["inheritance_kind"] = inheritance_kind
-    record["is_inherited_evidence"] = requested_code != resolved_code
+    record = evidence_record(
+        row,
+        requested_code=requested_code,
+        resolved_code=resolved_code,
+        inheritance_kind=inheritance_kind,
+    )
     record["has_tmb_source"] = True
     return record
 
@@ -220,27 +201,15 @@ def _resolve_tmb_row(requested_code: str, *, inherit: bool):
     df = cancer_tmb_df()
     values = _tmb_value_map(df)
     rows = df.set_index("cancer_code", drop=False)
-
-    if requested_code in values:
-        return requested_code, "direct", rows.loc[requested_code]
-    if requested_code in rows.index:
-        return requested_code, "direct_missing", rows.loc[requested_code]
-    if not inherit:
-        return requested_code, "missing", None
-
-    source_code = cancer_evidence_source_code(requested_code)
-    if source_code != requested_code and source_code in values:
-        return source_code, "source_scope", rows.loc[source_code]
-
-    registry = cancer_type_registry().set_index("code")
-    cur = _parent_code(requested_code, registry)
-    seen = {requested_code}
-    while cur and cur not in seen:
-        seen.add(cur)
-        if cur in values:
-            return cur, "ancestor", rows.loc[cur]
-        cur = _parent_code(cur, registry)
-    return requested_code, "missing", None
+    resolution = resolve_evidence(
+        requested_code,
+        direct_lookup=lambda code: rows.loc[code] if code in values else None,
+        direct_gap_lookup=lambda code: rows.loc[code] if code in rows.index else None,
+        source_code_for=cancer_evidence_source_code,
+        parent_by_code=cancer_type_registry().set_index("code")["parent_code"],
+        inherit=inherit,
+    )
+    return resolution.resolved_code, resolution.inheritance_kind, resolution.payload
 
 
 def resolve_tmb_source(cancer_type, *, inherit=True) -> dict:

--- a/oncoref/version.py
+++ b/oncoref/version.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.192"
+__version__ = "1.8.193"
 
 # Version of the downloadable data bundle (the heavy per-cohort percentile +
 # representative shards). Bump when the DERIVED reference artifacts change — it pins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,12 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_functions = "test_*"
 addopts = "-v --tb=short"
+filterwarnings = [
+    # Frozen compatibility accessors intentionally warn in user code. Their dedicated
+    # contract test forces and verifies every warning; ordinary feature tests need not
+    # repeat the same process-global warn-once messages in the suite summary.
+    "ignore:'.*' is a frozen compatibility snapshot .*:DeprecationWarning",
+]
 
 [tool.coverage.run]
 source = ["oncoref"]

--- a/tests/test_evidence_resolution.py
+++ b/tests/test_evidence_resolution.py
@@ -13,6 +13,7 @@
 import numpy as np
 import pandas as pd
 
+from oncoref import apd1, cancer_types, ici, tmb
 from oncoref._evidence_resolution import evidence_record, parent_code, resolve_evidence
 
 
@@ -84,6 +85,44 @@ def test_source_scope_precedes_nearest_ancestor_and_inheritance_can_be_disabled(
     assert missing.payload is None
 
 
+def test_parent_index_provider_is_lazy_until_an_ancestor_walk_is_needed():
+    calls = []
+
+    def parents():
+        calls.append(True)
+        return {"CHILD": "PARENT"}
+
+    direct = resolve_evidence(
+        "CHILD",
+        direct_lookup={"CHILD": "direct"}.get,
+        source_code_for=lambda code: code,
+        parent_by_code=parents,
+        inherit=True,
+    )
+    assert direct.payload == "direct"
+    assert calls == []
+
+    missing_without_inheritance = resolve_evidence(
+        "CHILD",
+        direct_lookup={}.get,
+        source_code_for=lambda code: code,
+        parent_by_code=parents,
+        inherit=False,
+    )
+    assert missing_without_inheritance.payload is None
+    assert calls == []
+
+    inherited = resolve_evidence(
+        "CHILD",
+        direct_lookup={"PARENT": "ancestor"}.get,
+        source_code_for=lambda code: code,
+        parent_by_code=parents,
+        inherit=True,
+    )
+    assert inherited.payload == "ancestor"
+    assert calls == [True]
+
+
 def test_nearest_ancestor_wins_and_cycles_terminate_as_missing():
     nearest = _resolve(
         "CHILD",
@@ -125,3 +164,30 @@ def test_nullable_parent_and_public_record_conversion_are_shared():
         "inheritance_kind": "ancestor",
         "is_inherited_evidence": True,
     }
+
+
+def test_evidence_row_and_parent_indexes_are_cached_and_invalidated():
+    cache_functions = (
+        cancer_types._registry_parent_by_code,
+        ici._rows_by_code_and_regimen,
+        apd1._apd1_rows_by_code,
+        apd1._apd1_value_map,
+        tmb._tmb_evidence_frame,
+        tmb._tmb_rows_by_code,
+        tmb._tmb_value_map,
+    )
+    cancer_types._clear_caches()
+    try:
+        assert all(fn.cache_info().currsize == 0 for fn in cache_functions)
+
+        assert cancer_types._registry_parent_by_code() is cancer_types._registry_parent_by_code()
+        assert ici._rows_by_code_and_regimen() is ici._rows_by_code_and_regimen()
+        assert apd1._apd1_rows_by_code() is apd1._apd1_rows_by_code()
+        assert apd1._apd1_value_map() is apd1._apd1_value_map()
+        assert tmb._tmb_evidence_frame() is tmb._tmb_evidence_frame()
+        assert tmb._tmb_rows_by_code() is tmb._tmb_rows_by_code()
+        assert tmb._tmb_value_map() is tmb._tmb_value_map()
+    finally:
+        cancer_types._clear_caches()
+
+    assert all(fn.cache_info().currsize == 0 for fn in cache_functions)

--- a/tests/test_evidence_resolution.py
+++ b/tests/test_evidence_resolution.py
@@ -1,0 +1,127 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+
+from oncoref._evidence_resolution import evidence_record, parent_code, resolve_evidence
+
+
+def _resolve(
+    requested_code,
+    *,
+    values,
+    gaps=None,
+    sources=None,
+    parents=None,
+    inherit=True,
+):
+    gaps = gaps or {}
+    sources = sources or {}
+    return resolve_evidence(
+        requested_code,
+        direct_lookup=values.get,
+        direct_gap_lookup=gaps.get,
+        source_code_for=lambda code: sources.get(code, code),
+        parent_by_code=parents or {},
+        inherit=inherit,
+    )
+
+
+def test_direct_value_precedes_gap_and_all_inheritance_routes():
+    resolution = _resolve(
+        "CHILD",
+        values={"CHILD": "direct", "SOURCE": "source", "PARENT": "ancestor"},
+        gaps={"CHILD": "gap"},
+        sources={"CHILD": "SOURCE"},
+        parents={"CHILD": "PARENT"},
+    )
+
+    assert resolution.resolved_code == "CHILD"
+    assert resolution.inheritance_kind == "direct"
+    assert resolution.payload == "direct"
+
+
+def test_direct_gap_blocks_source_and_ancestor_even_without_inheritance():
+    kwargs = {
+        "values": {"SOURCE": "source", "PARENT": "ancestor"},
+        "gaps": {"CHILD": "reviewed gap"},
+        "sources": {"CHILD": "SOURCE"},
+        "parents": {"CHILD": "PARENT"},
+    }
+
+    for inherit in (True, False):
+        resolution = _resolve("CHILD", inherit=inherit, **kwargs)
+        assert resolution.resolved_code == "CHILD"
+        assert resolution.inheritance_kind == "direct_missing"
+        assert resolution.payload == "reviewed gap"
+
+
+def test_source_scope_precedes_nearest_ancestor_and_inheritance_can_be_disabled():
+    kwargs = {
+        "values": {"SOURCE": "source", "PARENT": "ancestor"},
+        "sources": {"CHILD": "SOURCE"},
+        "parents": {"CHILD": "PARENT"},
+    }
+
+    inherited = _resolve("CHILD", **kwargs)
+    assert inherited.resolved_code == "SOURCE"
+    assert inherited.inheritance_kind == "source_scope"
+    assert inherited.payload == "source"
+
+    missing = _resolve("CHILD", inherit=False, **kwargs)
+    assert missing.resolved_code == "CHILD"
+    assert missing.inheritance_kind == "missing"
+    assert missing.payload is None
+
+
+def test_nearest_ancestor_wins_and_cycles_terminate_as_missing():
+    nearest = _resolve(
+        "CHILD",
+        values={"PARENT": "nearest", "ROOT": "root"},
+        parents={"CHILD": "PARENT", "PARENT": "ROOT"},
+    )
+    assert (nearest.resolved_code, nearest.inheritance_kind, nearest.payload) == (
+        "PARENT",
+        "ancestor",
+        "nearest",
+    )
+
+    cycle = _resolve(
+        "CHILD",
+        values={},
+        parents={"CHILD": "PARENT", "PARENT": "CHILD"},
+    )
+    assert cycle.inheritance_kind == "missing"
+    assert cycle.payload is None
+
+
+def test_nullable_parent_and_public_record_conversion_are_shared():
+    assert parent_code("ROOT", {"ROOT": np.nan}) is None
+    assert parent_code("CHILD", {"CHILD": " PARENT "}) == "PARENT"
+
+    row = pd.Series({"missing": pd.NA, "count": np.int64(3), "label": "value"})
+    record = evidence_record(
+        row,
+        requested_code="CHILD",
+        resolved_code="PARENT",
+        inheritance_kind="ancestor",
+    )
+    assert record == {
+        "missing": None,
+        "count": 3,
+        "label": "value",
+        "requested_cancer_code": "CHILD",
+        "resolved_cancer_code": "PARENT",
+        "inheritance_kind": "ancestor",
+        "is_inherited_evidence": True,
+    }

--- a/tests/test_ici.py
+++ b/tests/test_ici.py
@@ -730,11 +730,6 @@ def test_ici_response_record_whole_table_matches_value_maps():
     assert {code: record["orr_pct"] for code, record in pdl1_records.items()} == pdl1_values
 
 
-def test_parent_code_helper_treats_nan_parent_as_missing():
-    registry = ici.cancer_type_registry().set_index("code")
-    assert ici._parent_code("CRC", registry) is None
-
-
 def test_regimen_maps_cached():
     # _regimen_maps is memoized (same object back from the cache).
     assert ici._regimen_maps() is ici._regimen_maps()
@@ -934,7 +929,7 @@ def test_only_declared_codes_may_carry_a_blank_orr():
 
 
 def test_audited_gap_agrees_across_every_lookup_surface():
-    """The gap guard lives in four resolution paths; they must not drift apart."""
+    """Every public lookup surface must preserve the shared gap resolution."""
     for code in ici._ICI_EVIDENCE_OVERRIDES:
         assert ici.cancer_ici_response(code) is None, code
         assert ici.cancer_ici_response(code, inherit=False) is None, code

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -264,7 +264,11 @@ def test_cta_expression_heatmap_renders(tmp_path):
     )
 
     out = tmp_path / "cta.png"
-    cohorts = __import__("oncoref").available_percentile_cohorts()[:6]
+    oncoref = __import__("oncoref")
+    local = oncoref.locally_available_percentile_cohorts(include_recomputable=False)
+    availability = oncoref.cancer_reference_expression_availability(local)
+    cohorts = availability.loc[availability["available"], "cancer_code"].astype(str).tolist()[:6]
+    assert cohorts
     fig = plots.cta_expression_heatmap(
         cohorts=cohorts, n_cohorts=4, n_ctas=8, proteoform=False, save=str(out)
     )


### PR DESCRIPTION
Summary

- centralize the direct, audited-gap, source-scope, ancestor, and missing resolution order in one private helper
- route ICI scalar and per-regimen values, ICI records/resolvers, anti-PD-1 values/records, and TMB values/records through that contract
- cache code/regimen rows, numeric maps, and the raw registry parent index, while loading parent metadata only when an ancestor walk is required
- centralize pandas-to-public-record normalization and remove duplicated implementation
- silence only the known frozen-compatibility deprecation pattern during ordinary tests while retaining the dedicated warning-contract test
- make the CTA heatmap render test select local percentile artifacts compatible with strict QC, eliminating the incidental BCC availability warning
- prepare package version 1.8.193

Validation

- ./test.sh: 1,204 passed, zero warnings, ruff clean, format clean
- 3,192 cross-surface assertions across all 228 registry codes, both inheritance modes, every ICI regimen, per-regimen mappings, anti-PD-1, and TMB
- focused resolver, lookup, registry, and cache-invalidation tests: 140 passed
- warm benchmark on the same checkout: ICI direct 5.6 ms -> 1.9 us; ICI inherited bulk 1.18 s -> 0.63 ms; aPD-1 direct 3.5 ms -> 1.5 us; TMB direct 10.8 ms -> 0.9 us